### PR TITLE
Cache fixes

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/DialectsRegistry.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/DialectsRegistry.scala
@@ -6,7 +6,7 @@ import amf.core.model.document.BaseUnit
 import amf.core.model.domain.{AmfObject, DomainElement}
 import amf.core.parser.Annotations
 import amf.core.registries.AMFDomainEntityResolver
-import amf.core.remote.{Aml, Context}
+import amf.core.remote.{Aml, Cache, Context}
 import amf.core.services.{RuntimeCompiler, RuntimeValidator}
 import amf.core.unsafe.PlatformSecrets
 import amf.core.vocabulary.ValueType
@@ -118,7 +118,7 @@ class DialectsRegistry extends AMFDomainEntityResolver with PlatformSecrets {
       case Some(dialect) => Future { dialect }
       case _ =>
         RuntimeValidator.disableValidationsAsync() { reenable =>
-          RuntimeCompiler(uri, Some("application/yaml"), Some(Aml.name), Context(platform), env = environment)
+          RuntimeCompiler(uri, Some("application/yaml"), Some(Aml.name), Context(platform), env = environment, cache = Cache())
             .map {
               case dialect: Dialect =>
                 reenable()

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/instances/DialectInstanceParser.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/instances/DialectInstanceParser.scala
@@ -91,6 +91,7 @@ class DialectInstanceContext(var dialect: Dialect,
   val rootDeclarationsNodeMappings: Map[String, NodeMapping]    = parseDeclaredNodeMappings("root")
 
   globalSpace = wrapped.globalSpace
+  reportDisambiguation = wrapped.reportDisambiguation
 
   def forPatch(): DialectInstanceContext = {
     isPatch = true

--- a/amf-client/shared/src/main/scala/amf/client/commands/CommandHelper.scala
+++ b/amf-client/shared/src/main/scala/amf/client/commands/CommandHelper.scala
@@ -46,7 +46,8 @@ trait CommandHelper {
       inputFile,
       Option(effectiveMediaType(config.inputMediaType, config.inputFormat)),
       config.inputFormat,
-      Context(platform)
+      Context(platform),
+      cache = Cache()
     )
     val vendor = effectiveVendor(config.inputFormat)
     if (config.resolve)
@@ -63,7 +64,8 @@ trait CommandHelper {
         inputFile,
         Option(effectiveMediaType(config.inputMediaType, config.inputFormat)),
         config.inputFormat,
-        Context(platform)
+        Context(platform),
+        cache = Cache()
       )
       parsed map { parsed =>
         RuntimeResolver.resolve(vendor, parsed, ResolutionPipeline.DEFAULT_PIPELINE, UnhandledErrorHandler)

--- a/amf-client/shared/src/test/scala/amf/compiler/AMFCompilerTest.scala
+++ b/amf-client/shared/src/test/scala/amf/compiler/AMFCompilerTest.scala
@@ -172,7 +172,7 @@ class AMFCompilerTest extends AsyncFunSuite with CompilerTestBuilder {
     }
     amf.core.AMF.registerPlugin(featurePlugin)
     featurePlugin.init() flatMap { _ =>
-      RuntimeCompiler(url, Some("application/yaml"), Some(Raml10.name), Context(platform)) map { _ =>
+      RuntimeCompiler(url, Some("application/yaml"), Some(Raml10.name), Context(platform), cache = Cache()) map { _ =>
         val allPhases = Seq("begin_parsing_invocation",
                             "begin_document_parsing",
                             "syntax_parsed",

--- a/amf-client/shared/src/test/scala/amf/compiler/AMFCompilerTest.scala
+++ b/amf-client/shared/src/test/scala/amf/compiler/AMFCompilerTest.scala
@@ -225,7 +225,7 @@ class AMFCompilerTest extends AsyncFunSuite with CompilerTestBuilder {
       if (size != expectedSize) {
         cache.foreach {
           case (a, b) =>
-            println(s"${a} -> ${b.id}")
+            println(s"${a} -> ${System.identityHashCode(b)}")
         }
       }
       size should be(expectedSize)

--- a/amf-client/shared/src/test/scala/amf/dialects/DialectDefinitionValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/dialects/DialectDefinitionValidationTest.scala
@@ -1,6 +1,7 @@
 package amf.dialects
 import amf.ProfileName
 import amf.core.AMFCompiler
+import amf.core.remote.Cache
 import amf.core.services.RuntimeValidator
 import amf.core.unsafe.PlatformSecrets
 import amf.facades.Validation
@@ -34,7 +35,8 @@ class DialectDefinitionValidationTest extends AsyncFunSuite with Matchers with F
           platform,
           None,
           Some("application/yaml"),
-          Some(AMLPlugin.ID)
+          Some(AMLPlugin.ID),
+          cache = Cache()
         ).build()
       }
       i <- {
@@ -45,7 +47,8 @@ class DialectDefinitionValidationTest extends AsyncFunSuite with Matchers with F
               platform,
               None,
               Some("application/yaml"),
-              Some(AMLPlugin.ID)
+              Some(AMLPlugin.ID),
+              cache = Cache()
             ).build()
           case _ => Future.successful(DialectInstance())
         }

--- a/amf-client/shared/src/test/scala/amf/dialects/DialectInstancesValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/dialects/DialectInstancesValidationTest.scala
@@ -2,6 +2,7 @@ package amf.dialects
 
 import amf.ProfileName
 import amf.core.AMFCompiler
+import amf.core.remote.Cache
 import amf.core.services.RuntimeValidator
 import amf.core.unsafe.PlatformSecrets
 import amf.plugins.document.vocabularies.AMLPlugin
@@ -179,7 +180,8 @@ class DialectInstancesValidationTest extends AsyncFunSuite with PlatformSecrets 
           platform,
           None,
           Some("application/yaml"),
-          Some(AMLPlugin.ID)
+          Some(AMLPlugin.ID),
+          cache = Cache()
         ).build()
       }
       instance <- {
@@ -189,7 +191,8 @@ class DialectInstancesValidationTest extends AsyncFunSuite with PlatformSecrets 
           platform,
           None,
           Some("application/yaml"),
-          Some(AMLPlugin.ID)
+          Some(AMLPlugin.ID),
+          cache = Cache()
         ).build()
       }
       report <- {
@@ -223,7 +226,8 @@ class DialectInstancesValidationTest extends AsyncFunSuite with PlatformSecrets 
           platform,
           None,
           Some("application/yaml"),
-          Some(AMLPlugin.ID)
+          Some(AMLPlugin.ID),
+          cache = Cache()
         ).build()
       }
       profile <- {
@@ -237,7 +241,8 @@ class DialectInstancesValidationTest extends AsyncFunSuite with PlatformSecrets 
           platform,
           None,
           Some("application/yaml"),
-          Some(AMLPlugin.ID)
+          Some(AMLPlugin.ID),
+          cache = Cache()
         ).build()
       }
       report <- {

--- a/amf-client/shared/src/test/scala/amf/emit/CompatibilityTest.scala
+++ b/amf-client/shared/src/test/scala/amf/emit/CompatibilityTest.scala
@@ -50,7 +50,8 @@ class CompatibilityTest extends AsyncFunSuite with FileAssertionTest {
                               Some(mediaType),
                               Some(hint.vendor.name),
                               Context(platform),
-                              env = Environment(StringResourceLoader("amf://id#", content)))
+                              env = Environment(StringResourceLoader("amf://id#", content)),
+                              cache = Cache())
       _ <- RuntimeValidator(unit, ProfileName(hint.vendor.name))
     } yield unit
   }

--- a/amf-client/shared/src/test/scala/amf/error/RamlParserErrorTest.scala
+++ b/amf-client/shared/src/test/scala/amf/error/RamlParserErrorTest.scala
@@ -100,10 +100,6 @@ class RamlParserErrorTest extends ParserErrorTest {
         badInclude2.level should be("Violation")
         badInclude2.message should startWith("Fragments must be imported by using '!include'")
       },
-      badInclude3 => {
-        badInclude3.level should be("Violation")
-        badInclude3.message should startWith("Fragments must be imported by using '!include'")
-      },
       invalidRef => {
         invalidRef.level should be("Violation")
         invalidRef.message should be("Cannot inline a fragment in a not mutable node")

--- a/amf-client/shared/src/test/scala/amf/validation/ValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/ValidationTest.scala
@@ -41,17 +41,6 @@ class ValidationTest extends AsyncFunSuite with PlatformSecrets {
   // todo serialize json of validation report?
   // Example validations test and Example model validation test were the same, because the resolution runs always for validation
 
-  ignore("HERE_HERE PROD") {
-    for {
-      validation <- Validation(platform)
-      library    <- AMFCompiler(productionPath + "bdm/0-main.raml", platform, RamlYamlHint, validation).build()
-      report     <- validation.validate(library, RamlProfile)
-    } yield {
-      println(report)
-      assert(report.conforms)
-    }
-  }
-
   //what is speciy testing?? should be partitioned in a some new of tests? extract to tckUtor?
   ignore("Trailing spaces validation") {
     for {

--- a/amf-client/shared/src/test/scala/amf/validation/ValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/ValidationTest.scala
@@ -41,6 +41,17 @@ class ValidationTest extends AsyncFunSuite with PlatformSecrets {
   // todo serialize json of validation report?
   // Example validations test and Example model validation test were the same, because the resolution runs always for validation
 
+  ignore("HERE_HERE PROD") {
+    for {
+      validation <- Validation(platform)
+      library    <- AMFCompiler(productionPath + "bdm/0-main.raml", platform, RamlYamlHint, validation).build()
+      report     <- validation.validate(library, RamlProfile)
+    } yield {
+      println(report)
+      assert(report.conforms)
+    }
+  }
+
   //what is speciy testing?? should be partitioned in a some new of tests? extract to tckUtor?
   ignore("Trailing spaces validation") {
     for {

--- a/amf-core/shared/src/main/scala/amf/client/parse/Parser.scala
+++ b/amf-core/shared/src/main/scala/amf/client/parse/Parser.scala
@@ -6,7 +6,7 @@ import amf.client.model.document.BaseUnit
 import amf.client.validate.ValidationReport
 import amf.core.client.ParsingOptions
 import amf.core.model.document.{BaseUnit => InternalBaseUnit}
-import amf.core.remote.Context
+import amf.core.remote.{Cache, Context}
 import amf.core.services.{RuntimeCompiler, RuntimeValidator}
 import amf.internal.resource.{ResourceLoader, StringResourceLoader}
 import amf.{MessageStyle, ProfileName, RAMLStyle}
@@ -105,6 +105,7 @@ class Parser(vendor: String, mediaType: String, private val env: Option[Environm
                     Some(vendor),
                     Context(platform),
                     env = environment,
+                    cache = Cache(),
                     parsingOptions = parsingOptions) map { model =>
       parsedModel = Some(model)
       model

--- a/amf-core/shared/src/main/scala/amf/core/AMFCompiler.scala
+++ b/amf-core/shared/src/main/scala/amf/core/AMFCompiler.scala
@@ -51,7 +51,7 @@ class AMFCompiler(val rawUrl: String,
                   val mediaType: Option[String],
                   val vendor: Option[String],
                   val referenceKind: ReferenceKind = UnspecifiedReference,
-                  private val cache: Cache = Cache(),
+                  private val cache: Cache,
                   private val baseContext: Option[ParserContext] = None,
                   val env: Environment = Environment(),
                   val parsingOptions: ParsingOptions = ParsingOptions()) {
@@ -246,7 +246,7 @@ class AMFCompiler(val rawUrl: String,
             verifyMatchingVendor(unit.sourceVendor, nodes)
             verifyValidFragment(unit.sourceVendor, link.refs)
             val reference = ParsedReference(unit, link)
-            handler.update(reference, ctx, context, env).map(Some(_))
+            handler.update(reference, ctx, context, env, cache).map(Some(_))
           case ReferenceResolutionResult(Some(e), _) =>
             e match {
               case e: CyclicReferenceException if !domainPlugin.allowRecursiveReferences =>

--- a/amf-core/shared/src/main/scala/amf/core/parser/ReferenceHandler.scala
+++ b/amf-core/shared/src/main/scala/amf/core/parser/ReferenceHandler.scala
@@ -1,6 +1,6 @@
 package amf.core.parser
 
-import amf.core.remote.Context
+import amf.core.remote.{Cache, Context}
 import amf.internal.environment.Environment
 
 import scala.concurrent.Future
@@ -14,7 +14,8 @@ trait ReferenceHandler {
   def update(reference: ParsedReference,
              ctx: ParserContext,
              context: Context,
-             environment: Environment): Future[ParsedReference] =
+             environment: Environment,
+             cache: Cache): Future[ParsedReference] =
     Future.successful(reference)
 }
 

--- a/amf-core/shared/src/main/scala/amf/core/remote/Cache.scala
+++ b/amf-core/shared/src/main/scala/amf/core/remote/Cache.scala
@@ -12,24 +12,20 @@ object GlobalCounter {
 
 class Cache {
 
-  protected val cache: mutable.Map[String, BaseUnit] = mutable.Map()
+  protected val cache: mutable.Map[String, Future[BaseUnit]] = mutable.Map()
 
   def getOrUpdate(url: String)(supplier: () => Future[BaseUnit]): Future[BaseUnit] = {
-    //println(s"SIZE ${cache.size} :: ${System.identityHashCode(this)}")
     cache.get(url) match {
       case Some(value) =>
-        //println(s"- ${url} HIT ${System.identityHashCode(this)}")
-        Future(value)
+        value
       case None =>
-        //println(s"- ${url} MISS ${System.identityHashCode(this)}")
-        supplier() map { value =>
-          update(url, value)
-          value
-        }
+        val futureUnit = supplier()
+        update(url, futureUnit)
+        futureUnit
     }
   }
 
-  private def update(url: String, value: BaseUnit): Unit = synchronized {
+  private def update(url: String, value: Future[BaseUnit]): Unit = synchronized {
     cache.update(url, value)
   }
 

--- a/amf-core/shared/src/main/scala/amf/core/remote/Cache.scala
+++ b/amf-core/shared/src/main/scala/amf/core/remote/Cache.scala
@@ -6,18 +6,27 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+object GlobalCounter {
+  var v = 0;
+}
+
 class Cache {
 
   protected val cache: mutable.Map[String, BaseUnit] = mutable.Map()
 
-  def getOrUpdate(url: String)(supplier: () => Future[BaseUnit]): Future[BaseUnit] = cache.get(url) match {
-    case Some(value) =>
-      Future(value)
-    case None =>
-      supplier() map { value =>
-        update(url, value)
-        value
-      }
+  def getOrUpdate(url: String)(supplier: () => Future[BaseUnit]): Future[BaseUnit] = {
+    //println(s"SIZE ${cache.size} :: ${System.identityHashCode(this)}")
+    cache.get(url) match {
+      case Some(value) =>
+        //println(s"- ${url} HIT ${System.identityHashCode(this)}")
+        Future(value)
+      case None =>
+        //println(s"- ${url} MISS ${System.identityHashCode(this)}")
+        supplier() map { value =>
+          update(url, value)
+          value
+        }
+    }
   }
 
   private def update(url: String, value: BaseUnit): Unit = synchronized {
@@ -28,5 +37,7 @@ class Cache {
 }
 
 object Cache {
-  def apply(): Cache = new Cache()
+  def apply(): Cache = {
+    new Cache()
+  }
 }

--- a/amf-core/shared/src/main/scala/amf/core/services/RuntimeCompiler.scala
+++ b/amf-core/shared/src/main/scala/amf/core/services/RuntimeCompiler.scala
@@ -33,7 +33,7 @@ object RuntimeCompiler {
             vendor: Option[String],
             base: Context,
             referenceKind: ReferenceKind = UnspecifiedReference,
-            cache: Cache = Cache(),
+            cache: Cache,
             ctx: Option[ParserContext] = None,
             env: Environment = Environment(),
             parsingOptions: ParsingOptions = ParsingOptions()): Future[BaseUnit] = {

--- a/amf-validation/shared/src/main/scala/amf/plugins/features/validation/AMFValidatorPlugin.scala
+++ b/amf-validation/shared/src/main/scala/amf/plugins/features/validation/AMFValidatorPlugin.scala
@@ -7,7 +7,7 @@ import amf.core.benchmark.ExecutionLog
 import amf.core.model.document.{BaseUnit, Document, Fragment, Module}
 import amf.core.rdf.RdfModel
 import amf.core.registries.AMFPluginsRegistry
-import amf.core.remote.{Context, Oas30, Raml08, Vendor}
+import amf.core.remote._
 import amf.core.services.{RuntimeCompiler, RuntimeValidator, ValidationOptions}
 import amf.core.unsafe.PlatformSecrets
 import amf.core.validation.core.{ValidationProfile, ValidationReport, ValidationSpecification}
@@ -73,7 +73,8 @@ object AMFValidatorPlugin extends ParserSideValidationPlugin with PlatformSecret
       validationProfilePath,
       Some("application/yaml"),
       Some(AMLPlugin.ID),
-      Context(platform)
+      Context(platform),
+      cache = Cache()
     ).map {
         case parsed: DialectInstance if parsed.definedBy().is(url) =>
           parsed.encodes

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/JsonSchemaPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/JsonSchemaPlugin.scala
@@ -151,6 +151,7 @@ class JsonSchemaPlugin extends AMFDocumentPlugin with PlatformSecrets {
     val cleanNested =
       ParserContext(url, document.references, EmptyFutureDeclarations(), parserCount = parentContext.parserCount)
     cleanNested.globalSpace = parentContext.globalSpace
+    cleanNested.reportDisambiguation = parentContext.reportDisambiguation
 
     // Apparently, in a RAML 0.8 API spec the JSON Schema has a closure over the schemas declared in the spec...
     val inheritedDeclarations =

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/RamlPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/RamlPlugin.scala
@@ -40,6 +40,7 @@ sealed trait RamlPlugin extends BaseWebApiPlugin {
       ParserContext(root.location, root.references, EmptyFutureDeclarations(), parserCount = wrapped.parserCount)
     val clean = context(cleanNested, root)
     clean.globalSpace = wrapped.globalSpace
+    clean.reportDisambiguation = wrapped.reportDisambiguation
     clean
   }
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/contexts/WebApiContext.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/contexts/WebApiContext.scala
@@ -308,6 +308,7 @@ abstract class WebApiContext(val loc: String,
   }
 
   globalSpace = wrapped.globalSpace
+  reportDisambiguation = wrapped.reportDisambiguation
 
   // JSON Schema has a global namespace
 


### PR DESCRIPTION
- Fixed problem where the cache was not passed to a nested parser
- Disambiguating duplicated reports
- Caching future units, not the parsed unit. Avoids re-parsing