### PR TITLE
Using futures in cache computing dependency graph

### DIFF
--- a/amf-client/shared/src/test/scala/amf/compiler/AMFCompilerTest.scala
+++ b/amf-client/shared/src/test/scala/amf/compiler/AMFCompilerTest.scala
@@ -225,7 +225,7 @@ class AMFCompilerTest extends AsyncFunSuite with CompilerTestBuilder {
       if (size != expectedSize) {
         cache.foreach {
           case (a, b) =>
-            println(s"${a} -> ${b.id}")
+            println(s"${a} -> ${System.identityHashCode(b)}")
         }
       }
       size should be(expectedSize)

--- a/amf-core/shared/src/main/scala/amf/core/AMFCompiler.scala
+++ b/amf-core/shared/src/main/scala/amf/core/AMFCompiler.scala
@@ -81,7 +81,7 @@ class AMFCompiler(val rawUrl: String,
     ExecutionLog.log(s"AMFCompiler#build: Building $rawUrl")
     if (context.hasCycles) failed(new CyclicReferenceException(context.history))
     else
-      cache.getOrUpdate(location) { () =>
+      cache.getOrUpdate(location, context) { () =>
         ExecutionLog.log(s"AMFCompiler#build: compiling $rawUrl")
         compile()
       }

--- a/amf-core/shared/src/main/scala/amf/core/remote/Cache.scala
+++ b/amf-core/shared/src/main/scala/amf/core/remote/Cache.scala
@@ -7,29 +7,69 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 object GlobalCounter {
-  var v = 0;
+  var v = 0
 }
 
 class Cache {
 
-  protected val cache: mutable.Map[String, BaseUnit] = mutable.Map()
+  protected val cache: mutable.Map[String, Future[BaseUnit]] = mutable.Map()
+  protected val dependencyGraph: mutable.Map[String, Set[String]] = mutable.Map()
 
-  def getOrUpdate(url: String)(supplier: () => Future[BaseUnit]): Future[BaseUnit] = {
-    //println(s"SIZE ${cache.size} :: ${System.identityHashCode(this)}")
-    cache.get(url) match {
-      case Some(value) =>
-        //println(s"- ${url} HIT ${System.identityHashCode(this)}")
-        Future(value)
-      case None =>
-        //println(s"- ${url} MISS ${System.identityHashCode(this)}")
-        supplier() map { value =>
-          update(url, value)
-          value
+  protected def addFromToEdge(from: String, to: String): Unit = {
+    val fromNodes = dependencyGraph.getOrElse(to, Set())
+    dependencyGraph.update(to, fromNodes.+(from))
+  }
+
+  protected def findCycles(node: String, acc: List[String] = List()): Option[List[String]] = {
+    val fullPath: List[String] = acc ++ List(node)
+    if (fullPath.size != fullPath.toSet.size) {
+      Some(fullPath)
+    } else {
+      val sources = dependencyGraph.getOrElse(node, Set())
+      val maybeCycles: Set[Option[List[String]]] = sources.map { source =>
+        findCycles(source, fullPath)
+      }
+      maybeCycles.find(_.isDefined).flatten
+    }
+  }
+
+  protected def beforeLast(elms: List[String]):Option[String] = {
+    val lastTwo = elms.takeRight(2)
+    if (lastTwo.size == 2) {
+      lastTwo.headOption
+    } else {
+      None
+    }
+  }
+
+  def getOrUpdate(url: String, context: Context)(supplier: () => Future[BaseUnit]): Future[BaseUnit] = synchronized {
+    beforeLast(context.history) foreach { from =>
+      addFromToEdge(from, url)
+    }
+    findCycles(url) match {
+      case Some(_) =>
+        if (cache(url).isCompleted) {
+          cache(url)
+        } else {
+          cache.remove(url)
+          supplier() map { res =>
+            update(url, Future(res))
+            res
+          }
+        }
+      case _           =>
+        cache.get(url) match {
+          case Some(value) =>
+            value
+          case None =>
+            val futureUnit = supplier()
+            update(url, futureUnit)
+            futureUnit
         }
     }
   }
 
-  private def update(url: String, value: BaseUnit): Unit = synchronized {
+  private def update(url: String, value: Future[BaseUnit]): Unit = synchronized {
     cache.update(url, value)
   }
 


### PR DESCRIPTION
Prevents cycles building a graph of dependencies in the cache