### PR TITLE
APIMF-1427 - file parameters must have formData binding

### DIFF
--- a/amf-client/shared/src/test/resources/validations/file-parameter/file-parameter-correct-properties.json
+++ b/amf-client/shared/src/test/resources/validations/file-parameter/file-parameter-correct-properties.json
@@ -1,0 +1,26 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "0.0.1",
+    "title": "some title"
+  },
+  "paths": {
+    "/somepath": {
+      "post": {
+        "consumes": ["multipart/form-data"],
+        "parameters": [
+          {
+            "name" : "file-parameter",
+            "in" : "formData",
+            "type" : "file"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successfully got github user"
+          }
+        }
+      }
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/validations/file-parameter/file-parameter-incorrect-binding.json
+++ b/amf-client/shared/src/test/resources/validations/file-parameter/file-parameter-incorrect-binding.json
@@ -1,0 +1,26 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "0.0.1",
+    "title": "some title"
+  },
+  "paths": {
+    "/somepath": {
+      "post": {
+        "consumes": ["multipart/form-data"],
+        "parameters": [
+          {
+            "name" : "file-parameter",
+            "in" : "query",
+            "type" : "file"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "a description"
+          }
+        }
+      }
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/validations/file-parameter/invalid.jsonld
+++ b/amf-client/shared/src/test/resources/validations/file-parameter/invalid.jsonld
@@ -1,0 +1,195 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#1",
+        "@type": [
+          "schema-org:WebAPI",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "schema-org:name": [
+          {
+            "@value": "some title"
+          }
+        ],
+        "schema-org:version": [
+          {
+            "@value": "0.0.1"
+          }
+        ],
+        "raml-http:endpoint": [
+          {
+            "@id": "#2",
+            "@type": [
+              "raml-http:EndPoint",
+              "doc:DomainElement"
+            ],
+            "raml-http:path": [
+              {
+                "@value": "/somepath"
+              }
+            ],
+            "hydra:supportedOperation": [
+              {
+                "@id": "#3",
+                "@type": [
+                  "hydra:Operation",
+                  "doc:DomainElement"
+                ],
+                "hydra:method": [
+                  {
+                    "@value": "post"
+                  }
+                ],
+                "hydra:expects": [
+                  {
+                    "@id": "#4",
+                    "@type": [
+                      "raml-http:Request",
+                      "doc:DomainElement"
+                    ],
+                    "raml-http:parameter": [
+                      {
+                        "@id": "#5",
+                        "@type": [
+                          "raml-http:Parameter",
+                          "doc:DomainElement"
+                        ],
+                        "schema-org:name": [
+                          {
+                            "@value": "file-parameter"
+                          }
+                        ],
+                        "raml-http:paramName": [
+                          {
+                            "@value": "file-parameter"
+                          }
+                        ],
+                        "hydra:required": [
+                          {
+                            "@value": false
+                          }
+                        ],
+                        "raml-http:binding": [
+                          {
+                            "@value": "query"
+                          }
+                        ],
+                        "raml-http:schema": [
+                          {
+                            "@id": "#6",
+                            "@type": [
+                              "raml-shapes:FileShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape"
+                            ],
+                            "shacl:name": [
+                              {
+                                "@value": "schema"
+                              }
+                            ],
+                            "smaps": {
+                              "type-property-lexical-info": {
+                                "#6": "[(15,12)-(15,18)]"
+                              },
+                              "lexical": {
+                                "#6": "[(12,10)-(16,11)]"
+                              }
+                            }
+                          }
+                        ],
+                        "smaps": {
+                          "lexical": {
+                            "raml-http:binding": "[(14,12)-(14,19)]",
+                            "schema-org:name": "[(13,12)-(13,21)]",
+                            "#5": "[(12,10)-(16,11)]",
+                            "raml-http:paramName": "[(13,12)-(13,21)]"
+                          }
+                        }
+                      }
+                    ],
+                    "raml-http:payload": [],
+                    "smaps": {
+                      "lexical": {
+                        "raml-http:parameter": "[(11,8)-(11,22)]"
+                      }
+                    }
+                  }
+                ],
+                "hydra:returns": [
+                  {
+                    "@id": "#7",
+                    "@type": [
+                      "raml-http:Response",
+                      "doc:DomainElement"
+                    ],
+                    "schema-org:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "schema-org:description": [
+                      {
+                        "@value": "a description"
+                      }
+                    ],
+                    "hydra:statusCode": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "smaps": {
+                      "lexical": {
+                        "schema-org:description": "[(20,12)-(20,27)]",
+                        "#7": "[(19,10)-(19,21)]"
+                      }
+                    }
+                  }
+                ],
+                "smaps": {
+                  "lexical": {
+                    "hydra:returns": "[(18,8)-(18,21)]",
+                    "#3": "[(9,6)-(9,14)]"
+                  }
+                }
+              }
+            ],
+            "smaps": {
+              "lexical": {
+                "#2": "[(8,4)-(8,17)]"
+              }
+            }
+          }
+        ],
+        "smaps": {
+          "source-vendor": {
+            "#1": "OAS 2.0"
+          },
+          "lexical": {
+            "raml-http:endpoint": "[(7,11)-(25,3)]",
+            "schema-org:name": "[(5,4)-(5,13)]",
+            "#1": "[(1,0)-(26,1)]",
+            "schema-org:version": "[(4,4)-(4,15)]"
+          }
+        }
+      }
+    ],
+    "@context": {
+      "@base": "amf://id",
+      "raml-http": "http://a.ml/vocabularies/http#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "schema-org": "http://schema.org/",
+      "hydra": "http://www.w3.org/ns/hydra/core#"
+    }
+  }
+]

--- a/amf-client/shared/src/test/resources/validations/file-parameter/valid.jsonld
+++ b/amf-client/shared/src/test/resources/validations/file-parameter/valid.jsonld
@@ -1,0 +1,213 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#1",
+        "@type": [
+          "schema-org:WebAPI",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "schema-org:name": [
+          {
+            "@value": "some title"
+          }
+        ],
+        "schema-org:version": [
+          {
+            "@value": "0.0.1"
+          }
+        ],
+        "raml-http:endpoint": [
+          {
+            "@id": "#2",
+            "@type": [
+              "raml-http:EndPoint",
+              "doc:DomainElement"
+            ],
+            "raml-http:path": [
+              {
+                "@value": "/somepath"
+              }
+            ],
+            "hydra:supportedOperation": [
+              {
+                "@id": "#3",
+                "@type": [
+                  "hydra:Operation",
+                  "doc:DomainElement"
+                ],
+                "hydra:method": [
+                  {
+                    "@value": "post"
+                  }
+                ],
+                "hydra:expects": [
+                  {
+                    "@id": "#4",
+                    "@type": [
+                      "raml-http:Request",
+                      "doc:DomainElement"
+                    ],
+                    "raml-http:payload": [
+                      {
+                        "@id": "#5",
+                        "@type": [
+                          "raml-http:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-http:mediaType": [
+                          {
+                            "@value": "multipart/form-data"
+                          }
+                        ],
+                        "raml-http:schema": [
+                          {
+                            "@id": "#6",
+                            "@type": [
+                              "shacl:NodeShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "shacl:closed": [
+                              {
+                                "@value": false
+                              }
+                            ],
+                            "shacl:property": [
+                              {
+                                "@id": "#7",
+                                "@type": [
+                                  "shacl:PropertyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape"
+                                ],
+                                "raml-shapes:range": [
+                                  {
+                                    "@id": "#8",
+                                    "@type": [
+                                      "raml-shapes:FileShape",
+                                      "shacl:Shape",
+                                      "raml-shapes:Shape"
+                                    ],
+                                    "shacl:name": [
+                                      {
+                                        "@value": "file-parameter"
+                                      }
+                                    ],
+                                    "smaps": {
+                                      "type-property-lexical-info": {
+                                        "#8": "[(15,12)-(15,18)]"
+                                      },
+                                      "lexical": {
+                                        "shacl:name": "[(13,12)-(13,21)]",
+                                        "#8": "[(12,10)-(16,11)]"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "shacl:minCount": [
+                                  {
+                                    "@value": 0
+                                  }
+                                ],
+                                "shacl:name": [
+                                  {
+                                    "@value": "file-parameter"
+                                  }
+                                ]
+                              }
+                            ],
+                            "shacl:name": [
+                              {
+                                "@value": "formData"
+                              }
+                            ]
+                          }
+                        ],
+                        "smaps": {
+                          "form-body-parameter": {
+                            "#5": "true"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "hydra:returns": [
+                  {
+                    "@id": "#9",
+                    "@type": [
+                      "raml-http:Response",
+                      "doc:DomainElement"
+                    ],
+                    "schema-org:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "schema-org:description": [
+                      {
+                        "@value": "Successfully got github user"
+                      }
+                    ],
+                    "hydra:statusCode": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "smaps": {
+                      "lexical": {
+                        "schema-org:description": "[(20,12)-(20,27)]",
+                        "#9": "[(19,10)-(19,21)]"
+                      }
+                    }
+                  }
+                ],
+                "smaps": {
+                  "lexical": {
+                    "hydra:returns": "[(18,8)-(18,21)]",
+                    "#3": "[(9,6)-(9,14)]"
+                  }
+                }
+              }
+            ],
+            "smaps": {
+              "lexical": {
+                "#2": "[(8,4)-(8,17)]"
+              }
+            }
+          }
+        ],
+        "smaps": {
+          "source-vendor": {
+            "#1": "OAS 2.0"
+          },
+          "lexical": {
+            "raml-http:endpoint": "[(7,11)-(25,3)]",
+            "schema-org:name": "[(5,4)-(5,13)]",
+            "#1": "[(1,0)-(26,1)]",
+            "schema-org:version": "[(4,4)-(4,15)]"
+          }
+        }
+      }
+    ],
+    "@context": {
+      "@base": "amf://id",
+      "raml-http": "http://a.ml/vocabularies/http#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "schema-org": "http://schema.org/",
+      "hydra": "http://www.w3.org/ns/hydra/core#"
+    }
+  }
+]

--- a/amf-client/shared/src/test/resources/validations/reports/model/file-parameter-incorrect-binding.report
+++ b/amf-client/shared/src/test/resources/validations/reports/model/file-parameter-incorrect-binding.report
@@ -1,0 +1,14 @@
+Model: file://amf-client/shared/src/test/resources/validations/file-parameter/file-parameter-incorrect-binding.json
+Profile: OAS 2.0
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/parser#file-parameter-in-form-data
+  Message: Parameter of type file must set property 'in' to formData
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/file-parameter/file-parameter-incorrect-binding.json#/web-api/end-points/%2Fsomepath/post/request/parameter/file-parameter
+  Property: 
+  Position: Some(LexicalInformation([(12,10)-(16,11)]))
+  Location: file://amf-client/shared/src/test/resources/validations/file-parameter/file-parameter-incorrect-binding.json

--- a/amf-client/shared/src/test/scala/amf/validation/FromJsonLDPayloadValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/FromJsonLDPayloadValidationTest.scala
@@ -43,7 +43,9 @@ class FromJsonLDPayloadValidationTest extends AsyncFunSuite with PlatformSecrets
     "annotationTypes/invalid.jsonld"                         -> ExpectedReport(conforms = false, 1, RamlProfile),
     "annotationTypes/valid.jsonld"                           -> ExpectedReport(conforms = true, 0, RamlProfile),
     "path-parameter-required/required-is-not-present.jsonld" -> ExpectedReport(conforms = false, 1, OasProfile),
-    "path-parameter-required/required-set-to-true.jsonld"    -> ExpectedReport(conforms = true, 0, OasProfile)
+    "path-parameter-required/required-set-to-true.jsonld"    -> ExpectedReport(conforms = true, 0, OasProfile),
+    "file-parameter/invalid.jsonld"                          -> ExpectedReport(conforms = false, 1, OasProfile),
+//  "file-parameter/valid.jsonld"                            -> ExpectedReport(conforms = true, 0, OasProfile) fails in clientJVM with unkown error
   )
 
   for {

--- a/amf-client/shared/src/test/scala/amf/validation/OasJsonModelUniquePlatformReportTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/OasJsonModelUniquePlatformReportTest.scala
@@ -73,5 +73,9 @@ class OasJsonModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
     validate("file-parameter-consumes/no-consumes-defined.json", Some("file-parameter-no-consumes.report"))
   }
 
+  test("file parameter with incorrect binding") {
+    validate("file-parameter/file-parameter-incorrect-binding.json", Some("file-parameter-incorrect-binding.report"))
+  }
+
   override val hint: Hint = OasJsonHint
 }

--- a/amf-client/shared/src/test/scala/amf/validation/ValidOasModelParserTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/ValidOasModelParserTest.scala
@@ -57,6 +57,10 @@ class ValidOasModelParserTest extends ValidModelTest {
     checkValid("/file-parameter-consumes/valid-consumes-for-file-parameter.json", OasProfile)
   }
 
+  test("file parameter with correct binding and consumes") {
+    checkValid("file-parameter/file-parameter-correct-properties.json", OasProfile)
+  }
+
   // Check http inner reference.
   ignore("Http with # reference") {
     checkValid("/http-with-hashtag/http-with-hashtag.json", OasProfile)

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
@@ -2011,6 +2011,21 @@ object AMFRawValidations {
       "Path parameters must have the required property set to true",
       "Path parameters must have the required property set to true",
       "Violation"
+    ),
+    AMFValidation(
+      "amf-parser:file-parameter-in-form-data",
+      "Parameter of type file must set property 'in' to formData",
+      Oas.name,
+      "Domain",
+      "raml-http:Parameter",
+      "raml-http:schema",
+      "PropertyShape",
+      "sh:path",
+      "raml-shapes:fileParameterMustBeInFormData",
+      "0",
+      "Parameter of type file must set property 'in' to formData",
+      "Parameter of type file must set property 'in' to formData",
+      "Violation"
     )
   )
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/DefaultWebApiValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/DefaultWebApiValidations.scala
@@ -244,6 +244,18 @@ object JsCustomValidations {
          |  }
          |}
       """.stripMargin,
+    "fileParameterMustBeInFormData" ->
+      """|function(parameter) {
+         |  var binding = parameter["http:binding"];
+         |  var schema = parameter["http:schema"];
+         |  var typeList = schema[0]["@type"];
+         |  if(Array.isArray(typeList) && typeList.indexOf("raml-shapes:FileShape") != -1){
+         |    return binding == 'formData';
+         |  } else {
+         |    return true;
+         |  }
+         |}
+      """.stripMargin,
     "minMaxItemsValidation" ->
       """|function(shape) {
          |  //console.log(JSON.stringify(shape));


### PR DESCRIPTION
One test is currently failing in 'FromJsonLDPayloadValidationTest'. More specifically, the valid case is failing due to an unrelated violation from shacl with the following message: "Less than 1^^http://www.w3.org/2001/XMLSchema#integer values".