### PR TITLE
Export shapes generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ usage/site/build/
 amf-client/js/amf.js
 amf-client/amf.js
 buildbrowser.sh
+
+# For local development when using "npm link"
+amf-client/js/node_modules/
+!amf-client/js/node_modules/@mulesoft/
+amf-client/js/package-lock.json

--- a/amf-client/js/typings/amf-client-js.d.ts
+++ b/amf-client/js/typings/amf-client-js.d.ts
@@ -35,6 +35,10 @@ declare module 'amf-client-js' {
 
     static loadValidationProfile(url: string): Promise<string>
 
+    static loadValidationProfile(url: string, env: client.environment.Environment): Promise<string>
+
+    static emitShapesGraph(profileName: ProfileName): string
+
     static registerNamespace(alias: string, prefix: string): boolean
 
     // static registerDialect(url: string): Promise<Dialect>
@@ -105,6 +109,10 @@ declare module 'amf-client-js' {
     static validate(model: model.document.BaseUnit, profileName: ProfileName, messageStyle: MessageStyle, env: client.environment.Environment): Promise<client.validate.ValidationReport>
 
     static loadValidationProfile(url: string): Promise<string>
+
+    static loadValidationProfile(url: string, env: client.environment.Environment): Promise<string>
+
+    static emitShapesGraph(profileName: ProfileName): string
 
     static registerNamespace(alias: string, prefix: string): boolean
 

--- a/amf-client/shared/src/main/scala/amf/client/AMF.scala
+++ b/amf-client/shared/src/main/scala/amf/client/AMF.scala
@@ -62,6 +62,9 @@ object AMF {
                             env: Environment): ClientFuture[ProfileName] =
     Core.loadValidationProfile(url, env)
 
+  def emitShapesGraph(profileName: ProfileName): String =
+    Core.emitShapesGraph(profileName)
+
   def registerNamespace(alias: String, prefix: String): Boolean = Core.registerNamespace(alias, prefix)
 
   def registerDialect(url: String): ClientFuture[Dialect] = Vocabularies.registerDialect(url)

--- a/amf-client/shared/src/main/scala/amf/client/AMF.scala
+++ b/amf-client/shared/src/main/scala/amf/client/AMF.scala
@@ -14,7 +14,6 @@ import amf.plugins.document.{Vocabularies, WebApi}
 import amf.plugins.features.AMFValidation
 import amf.plugins.{document, features}
 import amf.{AMFStyle, Core, MessageStyle, ProfileName}
-import amf.core.validation.{EffectiveValidations}
 
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 

--- a/amf-client/shared/src/main/scala/amf/client/AMF.scala
+++ b/amf-client/shared/src/main/scala/amf/client/AMF.scala
@@ -14,6 +14,7 @@ import amf.plugins.document.{Vocabularies, WebApi}
 import amf.plugins.features.AMFValidation
 import amf.plugins.{document, features}
 import amf.{AMFStyle, Core, MessageStyle, ProfileName}
+import amf.core.validation.{EffectiveValidations}
 
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 
@@ -106,6 +107,9 @@ object CoreWrapper {
   def loadValidationProfile(url: String,
                             env: Environment): ClientFuture[ProfileName] =
     Core.loadValidationProfile(url, env)
+
+  def emitShapesGraph(profileName: ProfileName): String =
+    Core.emitShapesGraph(profileName)
 
   def registerNamespace(alias: String, prefix: String): Boolean = Core.registerNamespace(alias, prefix)
 

--- a/amf-client/shared/src/main/scala/amf/facades/Validation.scala
+++ b/amf-client/shared/src/main/scala/amf/facades/Validation.scala
@@ -1,6 +1,6 @@
 package amf.facades
 
-import amf.{MessageStyle, ProfileName, RAMLStyle}
+import amf.{MessageStyle, ProfileName, RAMLStyle, RamlProfile}
 import amf.core.model.document.BaseUnit
 import amf.core.remote.Platform
 import amf.core.services.RuntimeValidator
@@ -110,8 +110,8 @@ class Validation(platform: Platform) {
 
   def computeValidations(profileName: ProfileName): EffectiveValidations = validator.computeValidations(profileName)
 
-  def shapesGraph(validations: EffectiveValidations, messageStyle: MessageStyle = RAMLStyle): String =
-    validator.shapesGraph(validations, messageStyle)
+  def shapesGraph(validations: EffectiveValidations, profileName: ProfileName = RamlProfile): String =
+    validator.shapesGraph(validations, profileName)
 }
 
 object Validation {

--- a/amf-core/shared/src/main/scala/amf/Core.scala
+++ b/amf-core/shared/src/main/scala/amf/Core.scala
@@ -9,7 +9,6 @@ import amf.client.plugins.AMFPlugin
 import amf.client.render.Renderer
 import amf.client.resolve.Resolver
 import amf.client.validate.{ValidationReport, Validator}
-import amf.core.validation.{EffectiveValidations}
 import amf.core.AMF
 import amf.core.unsafe.PlatformSecrets
 
@@ -54,4 +53,5 @@ object Core extends PlatformSecrets {
   def registerNamespace(alias: String, prefix: String): Boolean = platform.registerNamespace(alias, prefix).isDefined
 
   def registerPlugin(plugin: AMFPlugin): Unit = AMF.registerPlugin(plugin)
+
 }

--- a/amf-core/shared/src/main/scala/amf/Core.scala
+++ b/amf-core/shared/src/main/scala/amf/Core.scala
@@ -9,6 +9,7 @@ import amf.client.plugins.AMFPlugin
 import amf.client.render.Renderer
 import amf.client.resolve.Resolver
 import amf.client.validate.{ValidationReport, Validator}
+import amf.core.validation.{EffectiveValidations}
 import amf.core.AMF
 import amf.core.unsafe.PlatformSecrets
 
@@ -47,8 +48,10 @@ object Core extends PlatformSecrets {
   def loadValidationProfile(url: String): ClientFuture[ProfileName] =
     loadValidationProfile(url, DefaultEnvironment())
 
+  def emitShapesGraph(profileName: ProfileName): String =
+    Validator.emitShapesGraph(profileName)
+
   def registerNamespace(alias: String, prefix: String): Boolean = platform.registerNamespace(alias, prefix).isDefined
 
   def registerPlugin(plugin: AMFPlugin): Unit = AMF.registerPlugin(plugin)
-
 }

--- a/amf-core/shared/src/main/scala/amf/client/validate/Validator.scala
+++ b/amf-core/shared/src/main/scala/amf/client/validate/Validator.scala
@@ -26,4 +26,9 @@ object Validator {
   def loadValidationProfile(url: String,
                             env: Environment = DefaultEnvironment()): ClientFuture[ProfileName] =
     RuntimeValidator.loadValidationProfile(url, env._internal).asClient
+
+  def emitShapesGraph(profileName: ProfileName): String = {
+    val effectiveValidations = RuntimeValidator.computeValidations(profileName)
+    RuntimeValidator.shapesGraph(effectiveValidations, profileName)
+  }
 }

--- a/amf-core/shared/src/main/scala/amf/client/validate/Validator.scala
+++ b/amf-core/shared/src/main/scala/amf/client/validate/Validator.scala
@@ -27,8 +27,6 @@ object Validator {
                             env: Environment = DefaultEnvironment()): ClientFuture[ProfileName] =
     RuntimeValidator.loadValidationProfile(url, env._internal).asClient
 
-  def emitShapesGraph(profileName: ProfileName): String = {
-    val effectiveValidations = RuntimeValidator.computeValidations(profileName)
-    RuntimeValidator.shapesGraph(effectiveValidations, profileName)
-  }
+  def emitShapesGraph(profileName: ProfileName): String =
+    RuntimeValidator.emitShapesGraph(profileName)
 }

--- a/amf-core/shared/src/main/scala/amf/core/services/RuntimeValidator.scala
+++ b/amf-core/shared/src/main/scala/amf/core/services/RuntimeValidator.scala
@@ -40,16 +40,10 @@ trait RuntimeValidator {
                       options: ValidationOptions): Future[ValidationReport]
 
   /**
-    * Computes EffectiveValidations for validation profile
-    */
-  def computeValidations(profileName: ProfileName,
-                         computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations
-
-  /**
     * Generates a JSON-LD graph with the SHACL shapes for the requested profile validations
     * @return JSON-LD graph
     */
-  def shapesGraph(validations: EffectiveValidations, profileName: ProfileName): String
+  def emitShapesGraph(profileName: ProfileName): String
 
   /**
     * Returns a native RDF model with the SHACL shapes graph
@@ -120,12 +114,8 @@ object RuntimeValidator {
                       options: ValidationOptions): Future[ValidationReport] =
     validator.shaclValidation(model, validations, options)
 
-  def computeValidations(profileName: ProfileName,
-                         computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations =
-    validator.computeValidations(profileName)
-
-  def shapesGraph(validations: EffectiveValidations, profileName: ProfileName): String =
-    validator.shapesGraph(validations, profileName)
+  def emitShapesGraph(profileName: ProfileName): String =
+    validator.emitShapesGraph(profileName)
 
   def shaclModel(validations: Seq[ValidationSpecification],
                  validationFunctionUrl: String,

--- a/amf-core/shared/src/main/scala/amf/core/services/RuntimeValidator.scala
+++ b/amf-core/shared/src/main/scala/amf/core/services/RuntimeValidator.scala
@@ -40,7 +40,7 @@ trait RuntimeValidator {
                       options: ValidationOptions): Future[ValidationReport]
 
   /**
-    * Generates a JSON-LD graph with the SHACL shapes for the requested profile validations
+    * Generates a JSON-LD graph with the SHACL shapes for the requested profile name
     * @return JSON-LD graph
     */
   def emitShapesGraph(profileName: ProfileName): String

--- a/amf-core/shared/src/main/scala/amf/core/services/RuntimeValidator.scala
+++ b/amf-core/shared/src/main/scala/amf/core/services/RuntimeValidator.scala
@@ -40,6 +40,18 @@ trait RuntimeValidator {
                       options: ValidationOptions): Future[ValidationReport]
 
   /**
+    * Computes EffectiveValidations for validation profile
+    */
+  def computeValidations(profileName: ProfileName,
+                         computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations
+
+  /**
+    * Generates a JSON-LD graph with the SHACL shapes for the requested profile validations
+    * @return JSON-LD graph
+    */
+  def shapesGraph(validations: EffectiveValidations, profileName: ProfileName): String
+
+  /**
     * Returns a native RDF model with the SHACL shapes graph
     */
   def shaclModel(validations: Seq[ValidationSpecification],
@@ -107,6 +119,13 @@ object RuntimeValidator {
                       validations: EffectiveValidations,
                       options: ValidationOptions): Future[ValidationReport] =
     validator.shaclValidation(model, validations, options)
+
+  def computeValidations(profileName: ProfileName,
+                         computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations =
+    validator.computeValidations(profileName)
+
+  def shapesGraph(validations: EffectiveValidations, profileName: ProfileName): String =
+    validator.shapesGraph(validations, profileName)
 
   def shaclModel(validations: Seq[ValidationSpecification],
                  validationFunctionUrl: String,

--- a/amf-core/shared/src/main/scala/amf/plugins/features/validation/ParserSideValidationPlugin.scala
+++ b/amf-core/shared/src/main/scala/amf/plugins/features/validation/ParserSideValidationPlugin.scala
@@ -206,4 +206,12 @@ class ParserSideValidationPlugin extends AMFFeaturePlugin with RuntimeValidator 
                           functionUrls: String,
                           messgeStyle: MessageStyle): RdfModel =
     throw new Exception("SHACL Support not available")
+
+  override def computeValidations(profileName: ProfileName,
+                                  computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations =
+    throw new Exception("SHACL Support not available")
+
+  override def shapesGraph(validations: EffectiveValidations,
+                           profileName: ProfileName): String =
+    throw new Exception("SHACL Support not available")
 }

--- a/amf-core/shared/src/main/scala/amf/plugins/features/validation/ParserSideValidationPlugin.scala
+++ b/amf-core/shared/src/main/scala/amf/plugins/features/validation/ParserSideValidationPlugin.scala
@@ -207,11 +207,6 @@ class ParserSideValidationPlugin extends AMFFeaturePlugin with RuntimeValidator 
                           messgeStyle: MessageStyle): RdfModel =
     throw new Exception("SHACL Support not available")
 
-  override def computeValidations(profileName: ProfileName,
-                                  computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations =
-    throw new Exception("SHACL Support not available")
-
-  override def shapesGraph(validations: EffectiveValidations,
-                           profileName: ProfileName): String =
+  override def emitShapesGraph(profileName: ProfileName): String =
     throw new Exception("SHACL Support not available")
 }

--- a/amf-validation/shared/src/main/scala/amf/plugins/features/validation/AMFValidatorPlugin.scala
+++ b/amf-validation/shared/src/main/scala/amf/plugins/features/validation/AMFValidatorPlugin.scala
@@ -109,7 +109,7 @@ object AMFValidatorPlugin extends ParserSideValidationPlugin with PlatformSecret
       }
   }
 
-  override def computeValidations(profileName: ProfileName,
+  def computeValidations(profileName: ProfileName,
                                   computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations = {
     val maybeProfile = profiles.get(profileName.profile) match {
       case Some(profileGenerator) => Some(profileGenerator())
@@ -233,7 +233,7 @@ object AMFValidatorPlugin extends ParserSideValidationPlugin with PlatformSecret
     * Generates a JSON-LD graph with the SHACL shapes for the requested profile validations
     * @return JSON-LD graph
     */
-  override def shapesGraph(validations: EffectiveValidations, profileName: ProfileName = RamlProfile): String = {
+  def shapesGraph(validations: EffectiveValidations, profileName: ProfileName = RamlProfile): String = {
     new ValidationJSONLDEmitter(profileName).emitJSON(customValidations(validations))
   }
 
@@ -248,6 +248,10 @@ object AMFValidatorPlugin extends ParserSideValidationPlugin with PlatformSecret
                           messageStyle: MessageStyle): RdfModel =
     PlatformValidator.instance.shapes(validations, functionUrls)
 
+  override def emitShapesGraph(profileName: ProfileName): String = {
+    val effectiveValidations = computeValidations(profileName)
+    shapesGraph(effectiveValidations, profileName)
+  }
 }
 
 object ValidationMutex {}

--- a/amf-validation/shared/src/main/scala/amf/plugins/features/validation/AMFValidatorPlugin.scala
+++ b/amf-validation/shared/src/main/scala/amf/plugins/features/validation/AMFValidatorPlugin.scala
@@ -109,8 +109,8 @@ object AMFValidatorPlugin extends ParserSideValidationPlugin with PlatformSecret
       }
   }
 
-  def computeValidations(profileName: ProfileName,
-                         computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations = {
+  override def computeValidations(profileName: ProfileName,
+                                  computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations = {
     val maybeProfile = profiles.get(profileName.profile) match {
       case Some(profileGenerator) => Some(profileGenerator())
       case _                      => None
@@ -233,8 +233,8 @@ object AMFValidatorPlugin extends ParserSideValidationPlugin with PlatformSecret
     * Generates a JSON-LD graph with the SHACL shapes for the requested profile validations
     * @return JSON-LD graph
     */
-  def shapesGraph(validations: EffectiveValidations, messageStyle: MessageStyle = RAMLStyle): String = {
-    new ValidationJSONLDEmitter(messageStyle.profileName).emitJSON(customValidations(validations))
+  override def shapesGraph(validations: EffectiveValidations, profileName: ProfileName = RamlProfile): String = {
+    new ValidationJSONLDEmitter(profileName).emitJSON(customValidations(validations))
   }
 
   def customValidations(validations: EffectiveValidations): Seq[ValidationSpecification] =

--- a/amf-validation/shared/src/main/scala/amf/plugins/features/validation/AMFValidatorPlugin.scala
+++ b/amf-validation/shared/src/main/scala/amf/plugins/features/validation/AMFValidatorPlugin.scala
@@ -248,6 +248,10 @@ object AMFValidatorPlugin extends ParserSideValidationPlugin with PlatformSecret
                           messageStyle: MessageStyle): RdfModel =
     PlatformValidator.instance.shapes(validations, functionUrls)
 
+  /**
+    * Generates a JSON-LD graph with the SHACL shapes for the requested profile name
+    * @return JSON-LD graph
+    */
   override def emitShapesGraph(profileName: ProfileName): String = {
     val effectiveValidations = computeValidations(profileName)
     shapesGraph(effectiveValidations, profileName)

--- a/amf-validation/shared/src/main/scala/amf/plugins/features/validation/AMFValidatorPlugin.scala
+++ b/amf-validation/shared/src/main/scala/amf/plugins/features/validation/AMFValidatorPlugin.scala
@@ -110,7 +110,7 @@ object AMFValidatorPlugin extends ParserSideValidationPlugin with PlatformSecret
   }
 
   def computeValidations(profileName: ProfileName,
-                                  computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations = {
+                         computed: EffectiveValidations = new EffectiveValidations()): EffectiveValidations = {
     val maybeProfile = profiles.get(profileName.profile) match {
       case Some(profileGenerator) => Some(profileGenerator())
       case _                      => None


### PR DESCRIPTION
Things changed:
* Added and exported to JS utility functions `emitShapesGraph` to emit SHACL Shapes Graph string;
* Added `amf-client/js/node_modules/` to gitignore because when linking amf locally from another libs, deps are installed in that folder and then git complains;
* Added missing TS definitions for recently implemented `loadValidationProfile` (https://github.com/aml-org/amf/pull/448);
* Changed `shapesGraph` methods' definitions to accept `ProfileName` instead of `MessageStyle` because it looks to me that `MessageStyle` is unnecessary there and it won't allow to pass custom validation profile `ProfileName`.