### PR TITLE
standardize owl class & property

### DIFF
--- a/amf-client/jvm/src/main/scala/amf/ValidationsExporter.scala
+++ b/amf-client/jvm/src/main/scala/amf/ValidationsExporter.scala
@@ -49,9 +49,8 @@ object ValidationsExporter extends ImportUtils {
           .map(severity)
           .mkString("\t")
 
-        println(
-          s"${uri(validation)}\t${uriModel(validation.owlClass)}\t${uriModel(validation.owlProperty)}\t${validation.message
-            .getOrElse("")}\t${validation.ramlErrorMessage}\t${validation.openApiErrorMessage}\t$levelsString")
+        println(s"${uri(validation)}\t${validation.owlClass}\t${validation.owlProperty}\t${validation.message
+          .getOrElse("")}\t${validation.ramlErrorMessage}\t${validation.openApiErrorMessage}\t$levelsString")
     }
 
   }

--- a/amf-client/jvm/src/main/scala/amf/tasks/tsvimport/ValidationsFile.scala
+++ b/amf-client/jvm/src/main/scala/amf/tasks/tsvimport/ValidationsFile.scala
@@ -29,7 +29,7 @@ class ValidationsFile(validationsFile: File) {
                  ramlErrorMessage,
                  openAPIErrorMessage) =>
         Some(
-          AMFValidation(
+          AMFValidation.fromStrings(
             uri.trim,
             message.trim,
             owlClass.trim,

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
@@ -2,26 +2,28 @@ package amf.plugins.document.webapi.validation
 
 import amf._
 import amf.core.validation.{SeverityLevels => Severity}
+import amf.core.vocabulary.Namespace.XsdTypes
 import amf.core.vocabulary.{Namespace, ValueType}
+import amf.plugins.domain.webapi.metamodel._
 
 object AMFRawValidations {
 
   /**
-    * @param uri URI of the validation, null to auto-generate
-    * @param message Optional message for the validation, propagates to all spec-specific messages if they're all empty
-    * @param owlClass Optional OWL class target of the validation
-    * @param owlProperty Optional OWL property target of the validation
-    * @param target Default is "sh:path"
-    * @param constraint URI of the constraint component
-    * @param value Value for the constraint component. Default is "0"
-    * @param ramlErrorMessage (optional) specify the validation message thrown in raml
+    * @param uri                 URI of the validation, null to auto-generate
+    * @param message             Optional message for the validation, propagates to all spec-specific messages if they're all empty
+    * @param owlClass            Optional OWL class target of the validation
+    * @param owlProperty         Optional OWL property target of the validation
+    * @param target              Default is "sh(path)"
+    * @param constraint          URI of the constraint component
+    * @param value               Value for the constraint component. Default is "0"
+    * @param ramlErrorMessage    (optional) specify the validation message thrown in raml
     * @param openApiErrorMessage (optional) specify the validation message thrown in Oas
-    * @param severity The severity of the validation: VIOLATION | WARNING | INFO. Default is VIOLATION
+    * @param severity            The severity of the validation: VIOLATION | WARNING | INFO. Default is VIOLATION
     */
   class AMFValidation(val uri: Option[String],
                       val message: Option[String],
-                      val owlClass: Option[String],
-                      val owlProperty: Option[String],
+                      val owlClass: String,
+                      val owlProperty: String,
                       val target: String,
                       val constraint: String,
                       val value: String,
@@ -29,30 +31,29 @@ object AMFRawValidations {
                       val openApiErrorMessage: String,
                       val severity: String)
   object AMFValidation {
-    def apply(
+    def fromStrings(
         uri: String = "",
         message: String = "",
-        owlClass: String = "",
-        owlProperty: String = "",
+        owlClass: String,
+        owlProperty: String,
         target: String = "sh:path",
-        constraint: String = "",
+        constraint: String,
         value: String = "0",
         ramlErrorMessage: String = "",
         openApiErrorMessage: String = "",
         severity: String = Severity.VIOLATION,
     ): AMFValidation = {
 
-      def optional(s: String): Option[String] = if (s.isEmpty) None else Some(s.trim)
-
-      val sameMessage = !message.isEmpty && ramlErrorMessage.isEmpty && openApiErrorMessage.isEmpty
+      def iri(s: String) = Namespace.uri(s).iri()
+      val sameMessage    = !message.isEmpty && ramlErrorMessage.isEmpty && openApiErrorMessage.isEmpty
 
       new AMFValidation(
         uri = optional(uri).map(Namespace.uri(_).iri()),
         message = optional(message),
-        owlClass = optional(owlClass).map(Namespace.uri(_).iri()),
-        owlProperty = optional(owlProperty).map(Namespace.uri(_).iri()),
-        target = Namespace.uri(target).iri(),
-        constraint = Namespace.uri(constraint).iri(),
+        owlClass = iri(owlClass),
+        owlProperty = iri(owlProperty),
+        target = iri(target),
+        constraint = iri(constraint),
         value = adaptValue(constraint, value),
         ramlErrorMessage = if (sameMessage) message else ramlErrorMessage,
         openApiErrorMessage = if (sameMessage) message else openApiErrorMessage,
@@ -60,39 +61,72 @@ object AMFRawValidations {
       )
     }
 
-    // todo: (2018) change Validations instances for use this with types, Use ValueType instead of string uri.
-    def fromFields(uri: Option[ValueType],
-                   message: Option[String],
-                   owlClass: Option[ValueType],
-                   owlProperty: Option[ValueType],
-                   target: ValueType,
-                   constraint: ValueType,
-                   value: String,
-                   ramlErrorMessage: String,
-                   openApiErrorMessage: String,
-                   severity: String): AMFValidation =
-      new AMFValidation(
-        uri.map(_.iri()),
-        message,
-        owlClass.map(_.iri()),
-        owlProperty.map(_.iri()),
-        target.iri(),
-        constraint.iri(),
-        adaptValue(constraint.iri(), value),
-        ramlErrorMessage,
-        openApiErrorMessage,
-        severity
-      )
+    def apply(
+        uri: Option[ValueType] = None,
+        message: String = "",
+        owlClass: ValueType,
+        owlProperty: ValueType,
+        target: ValueType = sh("path"),
+        constraint: ValueType,
+        value: String = "0",
+        ramlErrorMessage: String = "",
+        openApiErrorMessage: String = "",
+        severity: String = Severity.VIOLATION
+    ): AMFValidation = {
 
-    private def adaptValue(constraint: String, value: String) =
+      val sameMessage = !message.isEmpty && ramlErrorMessage.isEmpty && openApiErrorMessage.isEmpty
+
+      new AMFValidation(
+        uri = uri.map(_.iri()),
+        message = optional(message),
+        owlClass = owlClass.iri(),
+        owlProperty = owlProperty.iri(),
+        target = target.iri(),
+        constraint = constraint.iri(),
+        value = adaptValue(constraint.iri(), value),
+        ramlErrorMessage = if (sameMessage) message else ramlErrorMessage,
+        openApiErrorMessage = if (sameMessage) message else openApiErrorMessage,
+        severity = severity
+      )
+    }
+
+    def adaptValue(constraint: String, value: String): String =
       if (constraint.endsWith("pattern")) value
       else Namespace.uri(value).iri() // this might not be a URI, but trying to expand it is still safe
+
+    def optional(s: String): Option[String] = if (s.isEmpty) None else Some(s.trim)
   }
 
+  // owl
+  def apiContract(name: String): ValueType = ValueType(Namespace.ApiContract, name)
+
+  def doc(name: String): ValueType = ValueType(Namespace.Document, name)
+
+  def core(name: String): ValueType = ValueType(Namespace.Core, name)
+
+  def shape(name: String): ValueType = ValueType(Namespace.Shapes, name)
+
+  def security(name: String): ValueType = ValueType(Namespace.Security, name)
+
+  def amfParser(name: String): Option[ValueType] = Some(ValueType(Namespace.AmfParser, name))
+
+  def apiBinding(name: String): ValueType = ValueType(Namespace.ApiBinding, name)
+
+  // constraints
+  def sh(name: String): ValueType = ValueType(Namespace.Shacl, name)
+
+  val dataType: ValueType = sh("datatype")
+  val minCount: ValueType = sh("minCount")
+
+  // values
+  val string: String  = XsdTypes.xsdString.iri()
+  val boolean: String = XsdTypes.xsdBoolean.iri()
+  val integer: String = XsdTypes.xsdInteger.iri()
+
   val schemaRequiredInParameter: AMFValidation = AMFValidation(
-    owlClass = "apiContract:Parameter",
-    owlProperty = "raml-shapes:schema",
-    constraint = "sh:minCount",
+    owlClass = apiContract(ParameterModel.doc.displayName),
+    owlProperty = shape("schema"),
+    constraint = minCount,
     value = "1",
     ramlErrorMessage = "RAML Type information is mandatory for parameters",
     openApiErrorMessage = "Schema/type information required for Parameter objects",
@@ -105,519 +139,518 @@ object AMFRawValidations {
   trait AmfProfileValidations extends ProfileValidations {
     private lazy val result = Seq(
       AMFValidation(
-        owlClass = "doc:DomainElement",
-        owlProperty = "core:name",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = doc("DomainElement"),
+        owlProperty = core("name"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "Title and names must be string",
         openApiErrorMessage = "Names must be string"
       ),
       AMFValidation(
-        owlClass = "doc:DomainElement",
-        owlProperty = "core:description",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = doc("DomainElement"),
+        owlProperty = core("description"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "Descriptions must be strings",
         openApiErrorMessage = "Description must be strings"
       ),
       AMFValidation(
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "core:name",
-        constraint = "sh:minCount",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = core("name"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "API title is mandatory",
         openApiErrorMessage = "Info object 'title' must be a single value"
       ),
       AMFValidation(
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "apiContract:scheme",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = apiContract("scheme"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "API BaseUri scheme information must be a string",
         openApiErrorMessage = "Swagger object 'schemes' must be a string"
       ),
       AMFValidation(
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "apiContract:scheme",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = apiContract("scheme"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "API BaseUri scheme information must be a string",
         openApiErrorMessage = "Swagger object 'schemes' must be a string"
       ),
       AMFValidation(
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "apiContract:accepts",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = apiContract("accepts"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "Default media types must contain strings",
         openApiErrorMessage = "Field 'consumes' must contain strings"
       ),
       AMFValidation(
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "apiContract:accepts",
-        constraint = "sh:pattern",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = apiContract("accepts"),
+        constraint = sh("pattern"),
         value = "^(([-\\w]+|[*]{1})\\/([-+.\\w]+|[*]{1}))(\\s*;\\s*\\w+=[-+\\w.]+)*$",
         ramlErrorMessage = "Default media types must be valid",
         openApiErrorMessage = "Field 'produces' must be valid"
       ),
       AMFValidation(
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "core:mediaType",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = core("mediaType"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "Default media types must be string",
         openApiErrorMessage = "Field 'produces' must contain strings"
       ),
       AMFValidation(
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "core:version",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = core("version"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "API version must be a string",
         openApiErrorMessage = "Info object 'version' must be string"
       ),
       AMFValidation(
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "core:termsOfService",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = core("termsOfService"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "API terms of service must be a string",
         openApiErrorMessage = "Info object 'termsOfService' must be string"
       ),
       AMFValidation(
-        owlClass = "core:Organization",
-        owlProperty = "core:email",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = core("Organization"),
+        owlProperty = core("email"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "API provider email must be a string",
         openApiErrorMessage = "Contact object 'email' must be a string"
       ),
       AMFValidation(
-        owlClass = "apiContract:EndPoint",
-        owlProperty = "apiContract:path",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("EndPoint"),
+        owlProperty = apiContract("path"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "Resource path must be a string",
         openApiErrorMessage = "PathItem object path must be a string"
       ),
       AMFValidation(
         message = "Methods' summary information must be a string",
-        owlClass = "apiContract:Operation",
-        owlProperty = "apiContract:guiSummary",
-        constraint = "sh:datatype",
-        value = "xsd:string"
+        owlClass = apiContract("Operation"),
+        owlProperty = apiContract("guiSummary"),
+        constraint = dataType,
+        value = string
       ),
       AMFValidation(
         message = "Methods' deprecated must be a boolean",
-        owlClass = "apiContract:Operation",
-        owlProperty = "doc:deprecated",
-        constraint = "sh:datatype",
-        value = "xsd:boolean"
+        owlClass = apiContract("Operation"),
+        owlProperty = doc("deprecated"),
+        constraint = dataType,
+        value = boolean
       ),
       AMFValidation(
-        owlClass = "apiContract:Operation",
-        owlProperty = "apiContract:scheme",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("Operation"),
+        owlProperty = apiContract("scheme"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "Protocols must contain strings",
         openApiErrorMessage = "Schemes must contain strings"
       ),
       AMFValidation(
-        owlClass = "apiContract:Operation",
-        owlProperty = "apiContract:accepts",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("Operation"),
+        owlProperty = apiContract("accepts"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "Method default media types consumed must be strings",
         openApiErrorMessage = "Operation object 'consumes' must be strings"
       ),
       AMFValidation(
-        owlClass = "apiContract:Response",
-        owlProperty = "apiContract:statusCode",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("Response"),
+        owlProperty = apiContract("statusCode"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "Status code for a Response must be a string",
         openApiErrorMessage = "Status code for a Response object must be a string"
       ),
       AMFValidation(
-        owlClass = "apiContract:Parameter",
-        owlProperty = "core:name",
-        constraint = "sh:minCount",
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = core("name"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "Parameter information must have a name",
         openApiErrorMessage = "Parameter object must have a name property"
       ),
       AMFValidation(
-        owlClass = "apiContract:Parameter",
-        owlProperty = "apiContract:required",
-        constraint = "sh:datatype",
-        value = "xsd:boolean",
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = apiContract("required"),
+        constraint = dataType,
+        value = boolean,
         ramlErrorMessage = "Information about required parameters must be a boolean value",
         openApiErrorMessage = "Required property of a Parameter object must be boolean"
       ),
       AMFValidation(
-        owlClass = "apiContract:Parameter",
-        owlProperty = "apiContract:binding",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = apiContract("binding"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "Information about the binding of the parameter is mandatory",
         openApiErrorMessage = "'in' property of a Parameter object must be a string"
       ),
       AMFValidation(
-        owlClass = "apiContract:Parameter",
-        owlProperty = "apiContract:binding",
-        constraint = "sh:minCount",
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = apiContract("binding"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "Binding information for a parameter is mandatory",
         openApiErrorMessage = "'in' property of a Parameter object is mandatory"
       ),
       AMFValidation(
-        owlClass = "apiContract:Payload",
-        owlProperty = "core:mediaType",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("Payload"),
+        owlProperty = core("mediaType"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "Method default media types must be strings",
         openApiErrorMessage = "Operation object 'produces' must be strings"
       ),
       AMFValidation(
-        uri = "amf-parser:xml-wrapped-scalar",
+        uri = amfParser("xml-wrapped-scalar"),
         message = "XML property 'wrapped' must be false for scalar types",
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:xmlSerialization",
-        // Not useful
-        constraint = "raml-shapes:xmlWrappedScalar",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("xmlSerialization"),
+        constraint = shape("xmlWrappedScalar")
       ),
       AMFValidation(
-        uri = "amf-parser:xml-non-scalar-attribute",
+        uri = amfParser("xml-non-scalar-attribute"),
         message = "XML property 'attribute' must be false for non-scalar types",
-        owlClass = "raml-shapes:Shape",
-        owlProperty = "sh:xmlSerialization",
-        // Not useful
-        constraint = "raml-shapes:xmlNonScalarAttribute",
+        owlClass = shape("Shape"),
+        owlProperty = sh("xmlSerialization"),
+        constraint = shape("xmlNonScalarAttribute")
       ),
       AMFValidation(
         message = "XML attribute serialisation info must be boolean",
-        owlClass = "raml-shapes:XMLSerializer",
-        owlProperty = "raml-shapes:xmlAtribute",
-        constraint = "sh:datatype",
-        value = "xsd:boolean",
+        owlClass = shape("XMLSerializer"),
+        owlProperty = shape("xmlAtribute"),
+        constraint = dataType,
+        value = boolean
       ),
       AMFValidation(
         message = "XML wrapping serialisation info must be boolean",
-        owlClass = "raml-shapes:XMLSerializer",
-        owlProperty = "raml-shapes:xmlWrapped",
-        constraint = "sh:datatype",
-        value = "xsd:boolean",
+        owlClass = shape("XMLSerializer"),
+        owlProperty = shape("xmlWrapped"),
+        constraint = dataType,
+        value = boolean
       ),
       AMFValidation(
         message = "XML name serialisation info must be string",
-        owlClass = "raml-shapes:XMLSerializer",
-        owlProperty = "raml-shapes:xmlName",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = shape("XMLSerializer"),
+        owlProperty = shape("xmlName"),
+        constraint = dataType,
+        value = string
       ),
       AMFValidation(
         message = "XML namespace serialisation info must be string",
-        owlClass = "raml-shapes:XMLSerializer",
-        owlProperty = "raml-shapes:xmlNamespace",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = shape("XMLSerializer"),
+        owlProperty = shape("xmlNamespace"),
+        constraint = dataType,
+        value = string
       ),
       AMFValidation(
         message = "XML prefix serialisation info must be string",
-        owlClass = "raml-shapes:XMLSerializer",
-        owlProperty = "raml-shapes:xmlPrefix",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = shape("XMLSerializer"),
+        owlProperty = shape("xmlPrefix"),
+        constraint = dataType,
+        value = string
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ObjectShape",
-        owlProperty = "raml-shapes:minProperties",
-        constraint = "sh:minInclusive",
+        owlClass = shape("ObjectShape"),
+        owlProperty = shape("minProperties"),
+        constraint = sh("minInclusive"),
         ramlErrorMessage = "minProperties for a RAML Object type cannot be negative",
         openApiErrorMessage = "minProperties for a Schema object cannot be negative"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ObjectShape",
-        owlProperty = "raml-shapes:minProperties",
-        constraint = "sh:datatype",
-        value = "xsd:integer",
+        owlClass = shape("ObjectShape"),
+        owlProperty = shape("minProperties"),
+        constraint = dataType,
+        value = integer,
         ramlErrorMessage = "minProperties for a RAML Object type must be an integer",
         openApiErrorMessage = "minProperties for a Schema object must be an integer"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ObjectShape",
-        owlProperty = "raml-shapes:maxProperties",
-        constraint = "sh:minInclusive",
+        owlClass = shape("ObjectShape"),
+        owlProperty = shape("maxProperties"),
+        constraint = sh("minInclusive"),
         ramlErrorMessage = "maxProperties for a RAML Object type cannot be negative",
         openApiErrorMessage = "maxProperties for a Schema object cannot be negative"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ObjectShape",
-        owlProperty = "raml-shapes:maxProperties",
-        constraint = "sh:datatype",
-        value = "xsd:integer",
+        owlClass = shape("ObjectShape"),
+        owlProperty = shape("maxProperties"),
+        constraint = dataType,
+        value = integer,
         ramlErrorMessage = "maxProperties for a RAML Object type must be an integer",
         openApiErrorMessage = "maxProperties for a Schema object must be an integer"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ObjectShape",
-        owlProperty = "sh:closed",
-        constraint = "sh:datatype",
-        value = "xsd:boolean",
+        owlClass = shape("ObjectShape"),
+        owlProperty = sh("closed"),
+        constraint = dataType,
+        value = boolean,
         ramlErrorMessage = "additionalProperties for a RAML Object type must be a boolean",
         openApiErrorMessage = "additionalProperties for a Schema object must be a boolean"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ObjectShape",
-        owlProperty = "raml-shapes:discriminator",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = shape("ObjectShape"),
+        owlProperty = shape("discriminator"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "discriminator for RAML Object type must be a string value",
         openApiErrorMessage = "discriminator for a Schema object must be a string value"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ObjectShape",
-        owlProperty = "raml-shapes:discriminatorValue",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = shape("ObjectShape"),
+        owlProperty = shape("discriminatorValue"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "x-discriminatorValue for RAML Object type must be a string value",
         openApiErrorMessage = "discriminatorValue for a Schema object must be a string value"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ObjectShape",
-        owlProperty = "raml-shapes:readOnly ",
-        constraint = "sh:datatype",
-        value = "xsd:boolean",
+        owlClass = shape("ObjectShape"),
+        owlProperty = shape("readOnly"),
+        constraint = dataType,
+        value = boolean,
         ramlErrorMessage = "(readOnly) for a RAML Object type must be a boolean",
         openApiErrorMessage = "readOnly for a Schema object must be a boolean"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ArrayShape",
-        owlProperty = "sh:minCount",
-        constraint = "sh:datatype",
-        value = "xsd:integer",
+        owlClass = shape("ArrayShape"),
+        owlProperty = minCount,
+        constraint = dataType,
+        value = integer,
         ramlErrorMessage = "minItems for a RAML Array type must be an integer",
         openApiErrorMessage = "minItems of a Schema object of type 'array' must be an integer"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ArrayShape",
-        owlProperty = "sh:minCount",
-        constraint = "sh:minInclusive ",
+        owlClass = shape("ArrayShape"),
+        owlProperty = minCount,
+        constraint = sh("minInclusive"),
         ramlErrorMessage = "maxItems for a RAML Array type must be greater than 0",
         openApiErrorMessage = "maxItems of a Schema object of type 'array' must be greater than 0"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ArrayShape",
-        owlProperty = "sh:maxCount",
-        constraint = "sh:datatype",
-        value = "xsd:integer",
+        owlClass = shape("ArrayShape"),
+        owlProperty = sh("maxCount"),
+        constraint = dataType,
+        value = integer,
         ramlErrorMessage = "maxItems for a RAML Array type must be an integer",
         openApiErrorMessage = "maxItems of a Schema object of type 'array' must be an integer"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ArrayShape",
-        owlProperty = "sh:minCount",
-        constraint = "sh:minInclusive",
+        owlClass = shape("ArrayShape"),
+        owlProperty = minCount,
+        constraint = sh("minInclusive"),
         ramlErrorMessage = "minItems for a RAML Array type must be greater than 0",
         openApiErrorMessage = "minItems of a Schema object of type 'array' must be greater than 0"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ArrayShape",
-        owlProperty = "sh:maxCount",
-        constraint = "sh:minInclusive",
+        owlClass = shape("ArrayShape"),
+        owlProperty = sh("maxCount"),
+        constraint = sh("minInclusive"),
         ramlErrorMessage = "maxItems for a RAML Array type must be greater than 0",
         openApiErrorMessage = "maxItems of a Schema object of type 'array' must be greater than 0"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ArrayShape",
-        owlProperty = "raml-shapes:uniqueItems",
-        constraint = "sh:datatype",
-        value = "xsd:boolean",
+        owlClass = shape("ArrayShape"),
+        owlProperty = shape("uniqueItems"),
+        constraint = dataType,
+        value = boolean,
         ramlErrorMessage = "uniqueItems for a RAML Array type must be a boolean",
         openApiErrorMessage = "uniqueItems of a Schema object of type 'array' must be a boolean"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:pattern",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("pattern"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "pattern facet for a RAML scalar type must be a string",
         openApiErrorMessage = "pattern for scalar Schema object of scalar type must be a string"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:minLength",
-        constraint = "sh:datatype",
-        value = "xsd:integer",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("minLength"),
+        constraint = dataType,
+        value = integer,
         ramlErrorMessage = "minLength facet for a RAML scalar type must be a integer",
         openApiErrorMessage = "minLength for scalar Schema object of scalar type must be a integer"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:maxLength",
-        constraint = "sh:datatype",
-        value = "xsd:integer",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("maxLength"),
+        constraint = dataType,
+        value = integer,
         ramlErrorMessage = "maxLength facet for a RAML scalar type must be a integer",
         openApiErrorMessage = "maxLength for scalar Schema object of scalar type must be a integer"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:minInclusive",
-        constraint = "sh:datatype",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("minInclusive"),
+        constraint = dataType,
         value = "xsd:double",
         ramlErrorMessage = "minimum facet for a RAML scalar type must be a number",
         openApiErrorMessage = "minimum for scalar Schema object of scalar type must be a integer"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:maxInclusive",
-        constraint = "sh:datatype",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("maxInclusive"),
+        constraint = dataType,
         value = "xsd:double",
         ramlErrorMessage = "maximum facet for a RAML scalar type must be a number",
         openApiErrorMessage = "maximum for scalar Schema object of scalar type must be a integer"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:minExclusive",
-        constraint = "sh:datatype",
-        value = "xsd:boolean",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("minExclusive"),
+        constraint = dataType,
+        value = boolean,
         ramlErrorMessage = "x-exclusiveMinimum facet for a RAML scalar type must be a boolean",
         openApiErrorMessage = "exclusiveMinimum for scalar Schema object of scalar type must be a boolean"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:maxExclusive",
-        constraint = "sh:datatype",
-        value = "xsd:boolean",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("maxExclusive"),
+        constraint = dataType,
+        value = boolean,
         ramlErrorMessage = "x-exclusiveMaximum facet for a RAML scalar type must be a boolean",
         openApiErrorMessage = "exclusiveMaximum for scalar Schema object of scalar type must be a boolean"
       ),
       AMFValidation(
         message = "Min length facet should be greater or equal than 0",
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:minLength",
-        constraint = "sh:minInclusive",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("minLength"),
+        constraint = sh("minInclusive")
       ),
       AMFValidation(
         message = "Max length facet should be greater or equal than 0",
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:maxLength",
-        constraint = "sh:minInclusive",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("maxLength"),
+        constraint = sh("minInclusive")
       ),
       AMFValidation(
         message = "Min length facet should be greater or equal than 0",
-        owlClass = "raml-shapes:FileShape",
-        owlProperty = "sh:minLength",
-        constraint = "sh:minInclusive",
+        owlClass = shape("FileShape"),
+        owlProperty = sh("minLength"),
+        constraint = sh("minInclusive")
       ),
       AMFValidation(
         message = "Max length facet should be greater or equal than 0",
-        owlClass = "raml-shapes:FileShape",
-        owlProperty = "sh:maxLength",
-        constraint = "sh:minInclusive",
+        owlClass = shape("FileShape"),
+        owlProperty = sh("maxLength"),
+        constraint = sh("minInclusive")
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "raml-shapes:format",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = shape("ScalarShape"),
+        owlProperty = shape("format"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "format facet for a RAML scalar type must be a string",
         openApiErrorMessage = "format for scalar Schema object of scalar type must be a string"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "raml-shapes:multipleOf",
-        constraint = "sh:datatype",
+        owlClass = shape("ScalarShape"),
+        owlProperty = shape("multipleOf"),
+        constraint = dataType,
         value = "xsd:double",
         ramlErrorMessage = "multipleOf facet for a RAML scalar type must be a number",
         openApiErrorMessage = "multipleOf for scalar Schema object of scalar type must be a number"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "raml-shapes:multipleOf",
-        constraint = "sh:minExclusive",
+        owlClass = shape("ScalarShape"),
+        owlProperty = shape("multipleOf"),
+        constraint = sh("minExclusive"),
         ramlErrorMessage = "multipleOf facet for a RAML scalar type must be greater than 0",
         openApiErrorMessage = "multipleOf for scalar Schema object of scalar type must be greater than 0"
       ),
       AMFValidation(
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:datatype",
-        constraint = "sh:minCount",
+        owlClass = shape("ScalarShape"),
+        owlProperty = dataType,
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "type information for a RAML scalar is required",
         openApiErrorMessage = "type information fo a Schema object of scalar type is required"
       ),
       AMFValidation(
-        owlClass = "apiContract:Tag",
-        owlProperty = "core:name",
-        constraint = "sh:minCount",
+        owlClass = apiContract("Tag"),
+        owlProperty = core("name"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "Tag must have a name",
         openApiErrorMessage = "Tag object must have a name property"
       ),
       AMFValidation(
-        owlClass = "apiContract:Server",
-        owlProperty = "core:urlTemplate",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("Server"),
+        owlProperty = core("urlTemplate"),
+        constraint = dataType,
+        value = string,
         ramlErrorMessage = "API baseUri host information must be a string",
         openApiErrorMessage = "Swagger object 'host' and 'basePath' must be a string"
       ),
       AMFValidation(
         message = "Server 'description' property must be a string",
-        owlClass = "apiContract:Server",
-        owlProperty = "core:description",
-        constraint = "sh:datatype",
-        value = "xsd:string",
+        owlClass = apiContract("Server"),
+        owlProperty = core("description"),
+        constraint = dataType,
+        value = string
       ),
       AMFValidation(
         message = "Server must have an 'url' property",
-        owlClass = "apiContract:Server",
-        owlProperty = "core:urlTemplate",
-        constraint = "sh:minCount",
-        value = "1",
+        owlClass = apiContract("Server"),
+        owlProperty = core("urlTemplate"),
+        constraint = minCount,
+        value = "1"
       ),
       AMFValidation(
         message = "Security scheme type is mandatory",
-        owlClass = "security:SecurityScheme",
-        owlProperty = "security:type",
-        constraint = "sh:minCount",
-        value = "1",
+        owlClass = security("SecurityScheme"),
+        owlProperty = security("type"),
+        constraint = minCount,
+        value = "1"
       ),
       AMFValidation(
         message = "Security scheme type should be one of the supported ones",
-        owlClass = "security:SecurityScheme",
-        owlProperty = "security:type",
-        constraint = "sh:pattern",
+        owlClass = security("SecurityScheme"),
+        owlProperty = security("type"),
+        constraint = sh("pattern"),
         value =
-          "^OAuth\\s1.0|OAuth\\s2.0|Basic\\sAuthentication|Digest\\sAuthentication|Pass\\sThrough|Api\\sKey|http|openIdConnect|userPassword|X509|symmetricEncryption|asymmetricEncryption|x-.+$",
+          "^OAuth\\s1.0|OAuth\\s2.0|Basic\\sAuthentication|Digest\\sAuthentication|Pass\\sThrough|Api\\sKey|http|openIdConnect|userPassword|X509|symmetricEncryption|asymmetricEncryption|x-.+$"
       ),
       AMFValidation(
         message = "Type is mandatory in a Security Scheme Object",
-        owlClass = "security:SecurityScheme",
-        owlProperty = "security:type",
-        constraint = "sh:minCount",
-        value = "1",
+        owlClass = security("SecurityScheme"),
+        owlProperty = security("type"),
+        constraint = minCount,
+        value = "1"
       ),
       AMFValidation(
-        uri = "amf-parser:strict-url-strinzgs",
+        uri = amfParser("strict-url-strinzgs"),
         message = "URLs in values mapped to core:url must be valid",
-        owlClass = "doc:DomainElement",
-        owlProperty = "core:url",
-        target = "sh:targetObjectsOf",
-        constraint = "sh:nodeKind",
-        value = "sh:IRI",
+        owlClass = doc("DomainElement"),
+        owlProperty = core("url"),
+        target = sh("targetObjectsOf"),
+        constraint = sh("nodeKind"),
+        value = sh("IRI").iri(),
         ramlErrorMessage = "URLs must be valid",
         openApiErrorMessage = "URLs must be valid"
       ),
       AMFValidation(
-        uri = "amf-parser:pattern-validation",
+        uri = amfParser("pattern-validation"),
         message = "Pattern is not valid",
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:pattern",
-        constraint = "raml-shapes:patternValidation",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("pattern"),
+        constraint = shape("patternValidation"),
       )
     )
+
     override def validations(): Seq[AMFValidation] = result
   }
 
@@ -626,70 +659,71 @@ object AMFRawValidations {
   trait RamlAndOasValidations extends AmfProfileValidations {
     private lazy val result = super.validations() ++ Seq(
       AMFValidation(
-        owlClass = "apiContract:Parameter",
-        owlProperty = "apiContract:binding",
-        constraint = "sh:in",
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = apiContract("binding"),
+        constraint = sh("in"),
         value = "query,path,header,uri,cookie",
         ramlErrorMessage = "Binding information for a parameter with an invalid value",
         openApiErrorMessage = "'in' property of a parameter with an invalid value"
       ),
       AMFValidation(
-        owlClass = "apiContract:EndPoint",
-        owlProperty = "apiContract:path",
-        constraint = "sh:pattern",
+        owlClass = apiContract("EndPoint"),
+        owlProperty = apiContract("path"),
+        constraint = sh("pattern"),
         value = "^/",
         ramlErrorMessage = "Resource path must start with a '/'",
         openApiErrorMessage = "PathItem path must start with a '/'"
       ),
       AMFValidation(
-        owlClass = "apiContract:Operation",
-        owlProperty = "apiContract:method",
-        constraint = "sh:in",
+        owlClass = apiContract("Operation"),
+        owlProperty = apiContract("method"),
+        constraint = sh("in"),
         value = "get,put,post,delete,options,head,patch,connect,trace",
         ramlErrorMessage = "Unknown method type",
         openApiErrorMessage = "Unknown Operation method"
       ),
       AMFValidation(
         message = "Header parameter name is invalid according to HTTP spec",
-        owlClass = "apiContract:Parameter",
-        owlProperty = "apiContract:Name",
-        constraint = "raml-shapes:headerParamNameMustBeAscii",
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = apiContract("Name"),
+        constraint = shape("headerParamNameMustBeAscii"),
         severity = Severity.WARNING
       )
     )
+
     override def validations(): Seq[AMFValidation] = result
   }
 
   trait RamlValidations extends RamlAndOasValidations {
     private lazy val result = super.validations() ++ Seq(
       AMFValidation(
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "core:name",
-        constraint = "sh:minLength",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = core("name"),
+        constraint = sh("minLength"),
         value = "1",
         ramlErrorMessage = "Info object 'title' must not be empty",
         openApiErrorMessage = "API name must not be an empty string"
       ),
       AMFValidation(
-        owlClass = "core:CreativeWork",
-        owlProperty = "core:title",
-        constraint = "sh:minCount",
+        owlClass = core("CreativeWork"),
+        owlProperty = core("title"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "API documentation title is mandatory",
         openApiErrorMessage = "Documentation object 'x-title' is mandatory"
       ),
       AMFValidation(
-        owlClass = "core:CreativeWork",
-        owlProperty = "core:description",
-        constraint = "sh:minCount",
+        owlClass = core("CreativeWork"),
+        owlProperty = core("description"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "API documentation content is mandatory",
         openApiErrorMessage = "Documentation object 'description' is mandatory"
       ),
       AMFValidation(
-        owlClass = "doc:DomainProperty",
-        owlProperty = "raml-shapes:schema",
-        constraint = "sh:minCount",
+        owlClass = doc("DomainProperty"),
+        owlProperty = shape("schema"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "type is mandatory for a RAML annotationType",
         openApiErrorMessage = "schema is mandatory for an extension type"
@@ -697,112 +731,114 @@ object AMFRawValidations {
       AMFValidation(
         message =
           "Invalid authorization grant. The options are: authorization_code, password, client_credentials, implicit or any valid absolute URI",
-        owlClass = "security:Settings",
-        owlProperty = "security:authorizationGrant",
-        constraint = "sh:pattern",
-        value = "^authorization_code|password|client_credentials|implicit|(\\w+:(\\/?\\/?)[^\\s]+)$",
+        owlClass = security("Settings"),
+        owlProperty = security("authorizationGrant"),
+        constraint = sh("pattern"),
+        value = "^authorization_code|password|client_credentials|implicit|(\\w+:(\\/?\\/?)[^\\s]+)$"
       ),
       AMFValidation(
-        uri = "amf-parser:raml-root-schemes-values",
+        uri = amfParser("raml-root-schemes-values"),
         message = "Protocols property must be http or https",
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "apiContract:scheme",
-        constraint = "sh:pattern",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = apiContract("scheme"),
+        constraint = sh("pattern"),
         value = "^(H|h)(T|t)(T|t)(P|p)(S|s)?$",
         ramlErrorMessage = "Protocols must have a case insensitive value matching http or https",
         openApiErrorMessage =
           "Swagger object 'schemes' property must have a case insensitive value matching http or https"
       ),
       AMFValidation(
-        uri = "amf-parser:raml-operation-schemes-values",
+        uri = amfParser("raml-operation-schemes-values"),
         message = "Protocols property must be http or https",
-        owlClass = "apiContract:Operation",
-        owlProperty = "apiContract:scheme",
-        constraint = "sh:pattern",
+        owlClass = apiContract("Operation"),
+        owlProperty = apiContract("scheme"),
+        constraint = sh("pattern"),
         value = "^(H|h)(T|t)(T|t)(P|p)(S|s)?$",
         ramlErrorMessage = "Protocols must have a case insensitive value matching http or https",
         openApiErrorMessage =
           "Swagger object 'schemes' property must have a case insensitive value matching http or https"
       ),
       AMFValidation(
-        uri = "amf-parser:raml-root-schemes-non-empty-array",
+        uri = amfParser("raml-root-schemes-non-empty-array"),
         message = "Protocols must be a non-empty array of case-insensitive strings with values 'http' and/or 'https'",
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "apiContract:scheme",
-        constraint = "raml-shapes:nonEmptyListOfProtocols",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = apiContract("scheme"),
+        constraint = shape("nonEmptyListOfProtocols")
       ),
       AMFValidation(
-        uri = "amf-parser:raml-operation-schemes-non-empty-array",
+        uri = amfParser("raml-operation-schemes-non-empty-array"),
         message = "Protocols must be a non-empty array of case-insensitive strings with values 'http' and/or 'https'",
-        owlClass = "apiContract:Operation",
-        owlProperty = "apiContract:scheme",
-        constraint = "raml-shapes:nonEmptyListOfProtocols",
+        owlClass = apiContract("Operation"),
+        owlProperty = apiContract("scheme"),
+        constraint = shape("nonEmptyListOfProtocols")
       ),
       AMFValidation(
-        uri = "amf-parser:min-max-inclusive",
+        uri = amfParser("min-max-inclusive"),
         message = "Maximum must be greater than or equal to minimum",
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:minInclusive",
-        constraint = "raml-shapes:minimumMaximumValidation",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("minInclusive"),
+        constraint = shape("minimumMaximumValidation")
       ),
       AMFValidation(
-        uri = "amf-parser:min-max-items",
+        uri = amfParser("min-max-items"),
         message = "MaxItems must be greater than or equal to minItems",
-        owlClass = "raml-shapes:ArrayShape",
-        owlProperty = "sh:minCount",
-        constraint = "raml-shapes:minMaxItemsValidation",
+        owlClass = shape("ArrayShape"),
+        owlProperty = minCount,
+        constraint = shape("minMaxItemsValidation")
       ),
       AMFValidation(
-        uri = "amf-parser:min-max-length",
+        uri = amfParser("min-max-length"),
         message = "MaxLength must be greater than or equal to minLength",
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:minLength",
-        constraint = "raml-shapes:minMaxLengthValidation",
+        owlClass = shape("ScalarShape"),
+        owlProperty = sh("minLength"),
+        constraint = shape("minMaxLengthValidation")
       ),
       AMFValidation(
-        uri = "amf-parser:min-max-length",
+        uri = amfParser("min-max-length"),
         message = "MaxLength must be greater than or equal to minLength",
-        owlClass = "raml-shapes:FileShape",
-        owlProperty = "sh:minLength",
-        constraint = "raml-shapes:minMaxLengthValidation",
+        owlClass = shape("FileShape"),
+        owlProperty = sh("minLength"),
+        constraint = shape("minMaxLengthValidation")
       ),
       AMFValidation(
-        uri = "amf-parser:min-max-properties",
+        uri = amfParser("min-max-properties"),
         message = "MaxProperties must be greater than or equal to minProperties",
-        owlClass = "sh:NodeShape",
-        owlProperty = "raml-shapes:minProperties",
-        constraint = "raml-shapes:minMaxPropertiesValidation",
+        owlClass = sh("NodeShape"),
+        owlProperty = shape("minProperties"),
+        constraint = shape("minMaxPropertiesValidation")
       ),
       AMFValidation(
-        owlClass = "apiContract:Payload",
+        owlClass = apiContract("Payload"),
         message = "Payload media type is mandatory",
-        owlProperty = "core:mediaType",
-        constraint = "sh:minCount",
+        owlProperty = core("mediaType"),
+        constraint = minCount,
         value = "1"
       ),
       AMFValidation(
         message = "Invalid OAuth 1.0 signature. The options are: HMAC-SHA1, RSA-SHA1, or PLAINTEXT",
-        owlClass = "security:Settings",
-        owlProperty = "security:signature",
-        constraint = "sh:pattern",
-        value = "^HMAC-SHA1|RSA-SHA1|PLAINTEXT$",
+        owlClass = security("Settings"),
+        owlProperty = security("signature"),
+        constraint = sh("pattern"),
+        value = "^HMAC-SHA1|RSA-SHA1|PLAINTEXT$"
       ),
       AMFValidation(
-        owlClass = "apiContract:Response",
-        owlProperty = "apiContract:statusCode",
-        constraint = "sh:pattern",
+        owlClass = apiContract("Response"),
+        owlProperty = apiContract("statusCode"),
+        constraint = sh("pattern"),
         value = "^([1-5]{1}[0-9]{2})$|^(default)$",
         ramlErrorMessage = "Status code for a Response must be a value between 100 and 599",
         openApiErrorMessage = "Status code for a Response must be a value between 100 and 599 or 'default'"
       ),
       schemaRequiredInParameter
     )
+
     override def validations(): Seq[AMFValidation] = result
   }
 
   object Raml10Validations extends RamlValidations {
     private lazy val result = super.validations() ++ Seq(
       )
+
     override def validations(): Seq[AMFValidation] = result
   }
 
@@ -810,477 +846,459 @@ object AMFRawValidations {
     private lazy val result = super.validations() ++ Seq(
       AMFValidation(
         message = "Invalid authorization grant. The options are: code, token, owner or credentials",
-        owlClass = "security:Settings",
-        owlProperty = "security:authorizationGrant",
-        constraint = "sh:pattern",
-        value = "^code|token|owner|credentials$",
+        owlClass = security("Settings"),
+        owlProperty = security("authorizationGrant"),
+        constraint = sh("pattern"),
+        value = "^code|token|owner|credentials$"
       ),
       AMFValidation(
-        uri = "amf-parser:raml-schemes",
+        uri = amfParser("raml-schemes"),
         message = "Protocols property must be http or https",
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "apiContract:scheme",
-        constraint = "sh:in",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = apiContract("scheme"),
+        constraint = sh("in"),
         value = "http,https,HTTP,HTTPS",
         ramlErrorMessage = "Protocols must have a case insensitive value matching http or https",
         openApiErrorMessage =
           "Swagger object 'schemes' property must have a case insensitive value matching http or https"
       ),
       AMFValidation(
-        uri = "amf-parser:min-max-inclusive",
-        message = "Maximum must be greater than or equal to minimum",
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:minInclusive",
-        constraint = "raml-shapes:minimumMaximumValidation",
-      ),
-      AMFValidation(
-        uri = "amf-parser:min-max-items",
-        message = "MaxItems must be greater than or equal to minItems",
-        owlClass = "raml-shapes:ArrayShape",
-        owlProperty = "sh:minCount",
-        constraint = "raml-shapes:minMaxItemsValidation",
-      ),
-      AMFValidation(
-        uri = "amf-parser:min-max-length",
-        message = "MaxLength must be greater than or equal to minLength",
-        owlClass = "raml-shapes:ScalarShape",
-        owlProperty = "sh:minLength",
-        constraint = "raml-shapes:minMaxLengthValidation",
-      ),
-      AMFValidation(
-        uri = "amf-parser:min-max-properties",
+        uri = amfParser("min-max-properties"),
         message = "MaxProperties must be greater than or equal to minProperties",
-        owlClass = "sh:NodeShape",
-        owlProperty = "raml-shapes:minProperties",
-        constraint = "raml-shapes:minMaxPropertiesValidation",
+        owlClass = sh("NodeShape"),
+        owlProperty = shape("minProperties"),
+        constraint = shape("minMaxPropertiesValidation"),
       )
     )
+
     override def validations(): Seq[AMFValidation] = result
   }
 
   trait OasValidations extends RamlAndOasValidations with GenericValidations {
     private lazy val result = super.validations() ++ Seq(
       AMFValidation(
-        uri = "amf-parser:mandatory-api-version",
+        uri = amfParser("mandatory-api-version"),
         message = "Missing madatory Swagger / info / version",
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "core:version",
-        constraint = "sh:minCount",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = core("version"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "API Version is Mandatory",
         openApiErrorMessage = "Version is mandatory in Info object"
       ),
       AMFValidation(
-        uri = "amf-parser:openapi-schemes",
+        uri = amfParser("openapi-schemes"),
         message = "Protocols property must be http,https,ws,wss",
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "apiContract:scheme",
-        constraint = "sh:in",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = apiContract("scheme"),
+        constraint = sh("in"),
         value = "http,https,ws,wss",
         ramlErrorMessage = "Protocols must match a value http, https, ws or wss",
         openApiErrorMessage = "Swagger object 'schemes' property must have a value matching http, https, ws or wss"
       ),
       AMFValidation(
-        uri = "amf-parser:mandatory-external-doc-url",
+        uri = amfParser("mandatory-external-doc-url"),
         message = "Swagger external-doc element without URL",
-        owlClass = "core:CreativeWork",
-        owlProperty = "core:url",
-        constraint = "sh:minCount",
+        owlClass = core("CreativeWork"),
+        owlProperty = core("url"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "Documentation URL is mandatory in API external documentation",
         openApiErrorMessage = "URL is mandatory in External Documentation object"
       ),
       AMFValidation(
-        uri = "amf-parser:mandatory-license-name",
+        uri = amfParser("mandatory-license-name"),
         message = "Swagger License node without name",
-        owlClass = "core:License",
-        owlProperty = "core:name",
-        constraint = "sh:minCount",
+        owlClass = core("License"),
+        owlProperty = core("name"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "License name is mandatory if license information is included",
         openApiErrorMessage = "Name is mandatory in License object"
       ),
       AMFValidation(
-        uri = "amf-parser:empty-responses",
+        uri = amfParser("empty-responses"),
         message = "No responses declared",
-        owlClass = "apiContract:Operation",
-        owlProperty = "apiContract:returns",
-        constraint = "sh:minCount",
+        owlClass = apiContract("Operation"),
+        owlProperty = apiContract("returns"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "Responses array cannot be empty",
         openApiErrorMessage = "Responses cannot be empty"
       ),
       AMFValidation(
-        uri = "amf-parser:empty-enum",
+        uri = amfParser("empty-enum"),
         message = "Enum in types cannot be empty",
-        owlClass = "raml-shapes:Shape",
-        owlProperty = "sh:in",
-        constraint = "sh:node",
-        value = "amf-parser:NonEmptyList",
+        owlClass = shape("Shape"),
+        owlProperty = sh("in"),
+        constraint = sh("node"),
+        value = amfParser("NonEmptyList").get.iri(),
         ramlErrorMessage = "Property 'enum' must have at least one value",
         openApiErrorMessage = "Property 'enum' for a Schema object must have at least one value"
       ),
       AMFValidation(
-        uri = "amf-parser:array-shape-items-mandatory",
+        uri = amfParser("array-shape-items-mandatory"),
         message = "Declaration of the type of the items for an array is required",
-        owlClass = "raml-shapes:ArrayShape",
-        owlProperty = "raml-shapes:items",
-        constraint = "sh:minCount",
+        owlClass = shape("ArrayShape"),
+        owlProperty = shape("items"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "items facet of RAML Array type is required",
         openApiErrorMessage = "items property of Schema objects of type 'array' is required"
       ),
       AMFValidation(
-        uri = "amf-parser:path-parameter-required",
+        uri = amfParser("path-parameter-required"),
         message = "Path parameters must have the required property set to true",
-        owlClass = "apiContract:Parameter",
-        owlProperty = "apiContract:binding",
-        constraint = "raml-shapes:pathParameterRequiredProperty",
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = apiContract("binding"),
+        constraint = shape("pathParameterRequiredProperty")
       ),
       AMFValidation(
-        uri = "amf-parser:file-parameter-in-form-data",
+        uri = amfParser("file-parameter-in-form-data"),
         message = "Parameter of type file must set property 'in' to formData",
-        owlClass = "apiContract:Parameter",
-        owlProperty = "raml-shapes:schema",
-        constraint = "raml-shapes:fileParameterMustBeInFormData",
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = shape("schema"),
+        constraint = shape("fileParameterMustBeInFormData")
       ),
       AMFValidation(
-        uri = "amf-parser:description-is-required-in-response",
+        uri = amfParser("description-is-required-in-response"),
         message = "Description must be defined in a response",
-        owlClass = "apiContract:Response",
-        owlProperty = "core:description",
-        constraint = "sh:minCount",
+        owlClass = apiContract("Response"),
+        owlProperty = core("description"),
+        constraint = minCount,
         value = "1",
         openApiErrorMessage = "Response must have a 'description' field"
       ),
-      emailValidation("core:Organization", "core:email"),
-      urlValidation("core:License", "core:url"),
-      urlValidation("core:Organization", "core:url"),
-      urlValidation("core:CreativeWork", "core:url")
+      emailValidation(core("Organization"), core("email")),
+      urlValidation(core("License"), core("url")),
+      urlValidation(core("Organization"), core("url")),
+      urlValidation(core("CreativeWork"), core("url"))
     )
+
     override def validations(): Seq[AMFValidation] = result
   }
 
   object Oas20Validations extends OasValidations {
     private lazy val result = super.validations() ++ Seq(
       AMFValidation(
-        owlClass = "apiContract:Response",
-        owlProperty = "apiContract:statusCode",
-        constraint = "sh:pattern",
+        owlClass = apiContract("Response"),
+        owlProperty = apiContract("statusCode"),
+        constraint = sh("pattern"),
         value = "^([1-5]{1}[0-9]{2})$|^(default)$",
         openApiErrorMessage = "Status code for a Response must be a value between 100 and 599 or 'default'"
       ),
       AMFValidation(
         message = "Invalid flow. The options are: implicit, password, application or accessCode",
-        owlClass = "security:OAuth2Flow",
-        owlProperty = "security:flow",
-        constraint = "sh:pattern",
-        value = "^(implicit|password|application|accessCode)$",
+        owlClass = security("OAuth2Flow"),
+        owlProperty = security("flow"),
+        constraint = sh("pattern"),
+        value = "^(implicit|password|application|accessCode)$"
       ),
       AMFValidation(
         message = "Invalid 'in' value. The options are: query or header",
-        owlClass = "security:Settings",
-        owlProperty = "security:in",
-        constraint = "sh:pattern",
-        value = "^(query|header)$",
+        owlClass = security("Settings"),
+        owlProperty = security("in"),
+        constraint = sh("pattern"),
+        value = "^(query|header)$"
       ),
       schemaRequiredInParameter
     )
+
     override def validations(): Seq[AMFValidation] = result
   }
 
   object Async20Validations extends AmfProfileValidations with GenericValidations {
     private lazy val result = super.validations() ++ Seq(
       AMFValidation(
-        owlClass = "apiContract:WebAPI",
-        owlProperty = "core:version",
-        constraint = "sh:minCount",
+        owlClass = apiContract("WebAPI"),
+        owlProperty = core("version"),
+        constraint = minCount,
         value = "1",
         ramlErrorMessage = "API version is mandatory",
         openApiErrorMessage = "Info object 'version' is mandatory"
       ),
       AMFValidation(
         message = "Documentation 'url' field is mandatory",
-        owlClass = "core:CreativeWork",
-        owlProperty = "core:url",
-        constraint = "sh:minCount",
-        value = "1",
+        owlClass = core("CreativeWork"),
+        owlProperty = core("url"),
+        constraint = minCount,
+        value = "1"
       ),
       AMFValidation(
         message = "License 'name' is mandatory",
-        owlClass = "core:License",
-        owlProperty = "core:name",
-        constraint = "sh:minCount",
-        value = "1",
+        owlClass = core("License"),
+        owlProperty = core("name"),
+        constraint = minCount,
+        value = "1"
       ),
       AMFValidation(
         message = """Parameter name must comply with regex '^[A-Za-z0-9_\-]+$'""",
-        owlClass = "apiContract:Parameter",
-        owlProperty = "core:name",
-        constraint = "sh:pattern",
-        value = """^[A-Za-z0-9_\-]+$""".stripMargin,
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = core("name"),
+        constraint = sh("pattern"),
+        value = """^[A-Za-z0-9_\-]+$""".stripMargin
       ),
       AMFValidation(
         message = """Server name must comply with regex '^[A-Za-z0-9_\-]+$'""",
-        owlClass = "apiContract:Server",
-        owlProperty = "core:name",
-        constraint = "sh:pattern",
-        value = """^[A-Za-z0-9_\-]+$""".stripMargin,
+        owlClass = apiContract("Server"),
+        owlProperty = core("name"),
+        constraint = sh("pattern"),
+        value = """^[A-Za-z0-9_\-]+$""".stripMargin
       ),
       AMFValidation(
         message = "Server 'protocol' field is mandatory",
-        owlClass = "apiContract:Server",
-        owlProperty = "apiContract:protocol",
-        constraint = "sh:minCount",
-        value = "1",
+        owlClass = apiContract("Server"),
+        owlProperty = apiContract("protocol"),
+        constraint = minCount,
+        value = "1"
       ),
       AMFValidation(
         message = "'name' field is mandatory in httpApiKey security scheme",
-        owlClass = "security:HttpApiKeySettings",
-        owlProperty = "core:name",
-        constraint = "sh:minCount",
-        value = "1",
+        owlClass = security("HttpApiKeySettings"),
+        owlProperty = core("name"),
+        constraint = minCount,
+        value = "1"
       ),
       AMFValidation(
         message = "'location' field is mandatory in CorrelationId",
-        owlClass = "core:CorrelationId",
-        owlProperty = "core:location",
-        constraint = "sh:minCount",
-        value = "1",
+        owlClass = core("CorrelationId"),
+        owlProperty = core("location"),
+        constraint = minCount,
+        value = "1"
       ),
       AMFValidation(
         message = "'in' field is mandatory in ApiKey scheme",
-        owlClass = "security:HttpApiKeySettings",
-        owlProperty = "security:in",
-        constraint = "sh:minCount",
-        value = "1",
+        owlClass = security("HttpApiKeySettings"),
+        owlProperty = security("in"),
+        constraint = minCount,
+        value = "1"
       ),
       AMFValidation(
         message = "'in' field is mandatory in HttpApiKey scheme",
-        owlClass = "security:ApiKeySettings",
-        owlProperty = "security:in",
-        constraint = "sh:minCount",
+        owlClass = security("ApiKeySettings"),
+        owlProperty = security("in"),
+        constraint = minCount,
         value = "1"
       ),
       AMFValidation(
         message = "Invalid 'in' value. The options are: query, header or cookie",
-        owlClass = "security:HttpApiKeySettings",
-        owlProperty = "security:in",
-        constraint = "sh:pattern",
+        owlClass = security("HttpApiKeySettings"),
+        owlProperty = security("in"),
+        constraint = sh("pattern"),
         value = "^(query|header|cookie)$"
       ),
       AMFValidation(
         message = "Invalid 'in' value. The options are: user or password",
-        owlClass = "security:ApiKeySettings",
-        owlProperty = "security:in",
-        constraint = "sh:pattern",
+        owlClass = security("ApiKeySettings"),
+        owlProperty = security("in"),
+        constraint = sh("pattern"),
         value = "^(user|password)$"
       ),
       AMFValidation(
         message = "'scheme' field is mandatory in http security scheme",
-        owlClass = "security:HttpSettings",
-        owlProperty = "security:scheme",
-        constraint = "sh:minCount",
+        owlClass = security("HttpSettings"),
+        owlProperty = security("scheme"),
+        constraint = minCount,
         value = "1"
       ),
       AMFValidation(
-        owlClass = "apiBinding:WebSocketsChannelBinding",
-        owlProperty = "apiBinding:method",
-        constraint = "sh:in",
+        owlClass = apiBinding("WebSocketsChannelBinding"),
+        owlProperty = apiBinding("method"),
+        constraint = sh("in"),
         value = "GET,POST",
         openApiErrorMessage = "'method' for channel binding object must be one of 'GET' or 'POST'"
       ),
       AMFValidation(
-        owlClass = "apiBinding:MqttOperationBinding",
-        owlProperty = "apiBinding:qos",
-        constraint = "sh:pattern",
+        owlClass = apiBinding("MqttOperationBinding"),
+        owlProperty = apiBinding("qos"),
+        constraint = sh("pattern"),
         value = "^[0-2]$",
         openApiErrorMessage = "'qos' for mqtt operation binding object must be one of 0, 1 or 2"
       ),
       AMFValidation(
-        owlClass = "apiBinding:Amqp091ChannelBinding",
-        owlProperty = "apiBinding:is",
-        constraint = "sh:in",
+        owlClass = apiBinding("Amqp091ChannelBinding"),
+        owlProperty = apiBinding("is"),
+        constraint = sh("in"),
         value = "routingKey,queue",
         openApiErrorMessage = "'is' for amqp 0.9.1 channel binding object must be one of 'queue' or 'routingKey'"
       ),
       AMFValidation(
-        owlClass = "apiBinding:Amqp091ChannelExchange",
-        owlProperty = "apiBinding:type",
-        constraint = "sh:in",
+        owlClass = apiBinding("Amqp091ChannelExchange"),
+        owlProperty = apiBinding("type"),
+        constraint = sh("in"),
         value = "topic,direct,fanout,default,headers",
         openApiErrorMessage =
           "'type' for amqp 0.9.1 channel exchange object must be one of 'topic', 'direct', 'fanout', 'default' or 'headers'"
       ),
       AMFValidation(
-        owlClass = "apiBinding:HttpOperationBinding",
-        owlProperty = "apiBinding:method",
-        constraint = "sh:in",
+        owlClass = apiBinding("HttpOperationBinding"),
+        owlProperty = apiBinding("method"),
+        constraint = sh("in"),
         value = "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS,CONNECT,TRACE",
         openApiErrorMessage =
           "'method' for http operation binding object must be one of 'GET','POST','PUT','PATCH','DELETE','HEAD','OPTIONS','CONNECT','TRACE'"
       ),
       AMFValidation(
-        owlClass = "apiBinding:HttpOperationBinding",
-        owlProperty = "apiBinding:operationType",
-        constraint = "sh:minCount",
+        owlClass = apiBinding("HttpOperationBinding"),
+        owlProperty = apiBinding("operationType"),
+        constraint = minCount,
         value = "1",
         openApiErrorMessage = "'type' for http operation binding is required"
       ),
       AMFValidation(
-        owlClass = "apiBinding:Amqp091ChannelExchange",
-        owlProperty = "apiBinding:name",
-        constraint = "sh:maxLength",
+        owlClass = apiBinding("Amqp091ChannelExchange"),
+        owlProperty = apiBinding("name"),
+        constraint = sh("maxLength"),
         value = "255",
         openApiErrorMessage = "'type' for http operation binding is required"
       ),
       AMFValidation(
-        owlClass = "apiBinding:Amqp091ChannelExchange",
-        owlProperty = "core:name",
-        constraint = "sh:maxLength",
+        owlClass = apiBinding("Amqp091ChannelExchange"),
+        owlProperty = core("name"),
+        constraint = sh("maxLength"),
         value = "255",
         openApiErrorMessage = "Amqp channel binding name can't be longer than 255 characters"
       ),
       AMFValidation(
-        owlClass = "apiBinding:Amqp091ChannelQueue",
-        owlProperty = "core:name",
-        constraint = "sh:maxLength",
+        owlClass = apiBinding("Amqp091ChannelQueue"),
+        owlProperty = core("name"),
+        constraint = sh("maxLength"),
         value = "255",
         openApiErrorMessage = "Amqp channel binding name can't be longer than 255 characters"
       ),
       AMFValidation(
-        owlClass = "apiBinding:HttpOperationBinding",
-        owlProperty = "apiBinding:operationType",
-        constraint = "sh:pattern",
+        owlClass = apiBinding("HttpOperationBinding"),
+        owlProperty = apiBinding("operationType"),
+        constraint = sh("pattern"),
         value = """^(request|response)$""".stripMargin,
         openApiErrorMessage = "Http operation binding must be either 'request' or 'response'"
       ),
       AMFValidation(
-        owlClass = "apiBinding:Amqp091ChannelExchange",
-        owlProperty = "apiBinding:name",
-        constraint = "sh:pattern",
+        owlClass = apiBinding("Amqp091ChannelExchange"),
+        owlProperty = apiBinding("name"),
+        constraint = sh("pattern"),
         value = """^(request|response)$""".stripMargin,
         openApiErrorMessage = "Http operation binding must be either 'request' or 'response'"
       ),
       AMFValidation(
-        owlClass = "apiBinding:MqttServerBinding",
-        owlProperty = "apiBinding:keepAlive",
-        constraint = "sh:minInclusive ",
+        owlClass = apiBinding("MqttServerBinding"),
+        owlProperty = apiBinding("keepAlive"),
+        constraint = sh("minInclusive"),
         openApiErrorMessage = "'keepAlive' must be greater than 0"
       ),
       AMFValidation(
-        owlClass = "apiBinding:MqttServerLastWill",
-        owlProperty = "apiBinding:qos",
-        constraint = "sh:pattern",
+        owlClass = apiBinding("MqttServerLastWill"),
+        owlProperty = apiBinding("qos"),
+        constraint = sh("pattern"),
         value = "^[0-2]$",
         openApiErrorMessage = "'qos' for mqtt server binding last will object must be one of 0, 1 or 2"
       ),
       AMFValidation(
-        owlClass = "apiBinding:Amqp091OperationBinding",
-        owlProperty = "apiBinding:deliveryMode",
-        constraint = "sh:pattern",
+        owlClass = apiBinding("Amqp091OperationBinding"),
+        owlProperty = apiBinding("deliveryMode"),
+        constraint = sh("pattern"),
         value = "^[1-2]$",
         openApiErrorMessage = "'deliveryMode' for amqp 0.9.1 operation binding object must be one of 1 or 2"
       ),
       AMFValidation(
-        owlClass = "apiBinding:Amqp091OperationBinding",
-        owlProperty = "apiBinding:expiration",
-        constraint = "sh:pattern",
+        owlClass = apiBinding("Amqp091OperationBinding"),
+        owlProperty = apiBinding("expiration"),
+        constraint = sh("pattern"),
         value = "^[0-9]+(.[0-9]+)?$",
         openApiErrorMessage = "'expiration' for amqp 0.9.1 operation binding object must greather than or equal to 0"
       ),
       AMFValidation(
-        owlClass = "apiBinding:MqttServerLastWill",
-        owlProperty = "apiBinding:qos",
-        constraint = "sh:pattern",
+        owlClass = apiBinding("MqttServerLastWill"),
+        owlProperty = apiBinding("qos"),
+        constraint = sh("pattern"),
         value = "^[0-2]$",
         openApiErrorMessage = "'qos' for mqtt server last will binding object must be one 0, 1 or 2"
       ),
       AMFValidation(
-        owlClass = "apiBinding:MqttServerBinding",
-        owlProperty = "apiBinding:expiration",
-        constraint = "sh:minInclusive ",
+        owlClass = apiBinding("MqttServerBinding"),
+        owlProperty = apiBinding("expiration"),
+        constraint = sh("minInclusive"),
         openApiErrorMessage = "'expiration' must be greater than 0"
       ),
       AMFValidation(
         message = "'flows' field is mandatory in OAuth2 security scheme",
-        owlClass = "security:SecurityScheme",
-        owlProperty = "security:settings",
-        constraint = "raml-shapes:requiredFlowsInOAuth2",
+        owlClass = security("SecurityScheme"),
+        owlProperty = security("settings"),
+        constraint = shape("requiredFlowsInOAuth2")
       ),
       AMFValidation(
         message = "'openIdConnectUrl' field is mandatory in openIdConnect security scheme",
-        owlClass = "security:SecurityScheme",
-        owlProperty = "security:settings",
-        constraint = "raml-shapes:requiredOpenIdConnectUrl",
+        owlClass = security("SecurityScheme"),
+        owlProperty = security("settings"),
+        constraint = shape("requiredOpenIdConnectUrl")
       ),
       AMFValidation(
         message = "'query' property of ws channel binding must be of type object and have properties",
-        owlClass = "apiBinding:WebSocketsChannelBinding",
-        owlProperty = "apiBinding:query",
-        constraint = "raml-shapes:mandatoryQueryObjectNodeWithPropertiesFacet",
+        owlClass = apiBinding("WebSocketsChannelBinding"),
+        owlProperty = apiBinding("query"),
+        constraint = shape("mandatoryQueryObjectNodeWithPropertiesFacet")
       ),
       AMFValidation(
         message = "'headers' property of ws channel binding must be of type object and have properties",
-        owlClass = "apiBinding:WebSocketsChannelBinding",
-        owlProperty = "apiBinding:headers",
-        constraint = "raml-shapes:mandatoryHeadersObjectNodeWithPropertiesFacet",
+        owlClass = apiBinding("WebSocketsChannelBinding"),
+        owlProperty = apiBinding("headers"),
+        constraint = shape("mandatoryHeadersObjectNodeWithPropertiesFacet")
       ),
       AMFValidation(
         message = "'headers' property of ws channel binding must be of type object and have properties",
-        owlClass = "apiBinding:HttpMessageBinding",
-        owlProperty = "apiBinding:headers",
-        constraint = "raml-shapes:mandatoryHeadersObjectNodeWithPropertiesFacet",
+        owlClass = apiBinding("HttpMessageBinding"),
+        owlProperty = apiBinding("headers"),
+        constraint = shape("mandatoryHeadersObjectNodeWithPropertiesFacet")
       ),
       AMFValidation(
         message = "'headers' property of ws channel binding must be of type object and have properties",
-        owlClass = "apiBinding:HttpOperationBinding",
-        owlProperty = "apiBinding:query",
-        constraint = "raml-shapes:mandatoryQueryObjectNodeWithPropertiesFacet",
+        owlClass = apiBinding("HttpOperationBinding"),
+        owlProperty = apiBinding("query"),
+        constraint = shape("mandatoryQueryObjectNodeWithPropertiesFacet")
       ),
       AMFValidation(
         message = "Does not comply with runtime expression ABNF syntax",
-        owlClass = "core:CorrelationId",
-        owlProperty = "core:location",
-        constraint = "raml-shapes:validCorrelationIdLocation",
+        owlClass = core("CorrelationId"),
+        owlProperty = core("location"),
+        constraint = shape("validCorrelationIdLocation")
       ),
       AMFValidation(
         message = "Does not comply with runtime expression ABNF syntax",
-        owlClass = "apiContract:Parameter",
-        owlProperty = "apiContract:binding",
-        constraint = "raml-shapes:validParameterLocation",
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = apiContract("binding"),
+        constraint = shape("validParameterLocation")
       ),
       AMFValidation(
         message = "Message headers must be of type object",
-        owlClass = "apiContract:Message",
-        owlProperty = "apiContract:headers",
-        constraint = "raml-shapes:mandatoryHeadersObjectNode",
+        owlClass = apiContract("Message"),
+        owlProperty = apiContract("headers"),
+        constraint = shape("mandatoryHeadersObjectNode")
       ),
       AMFValidation(
-        uri="amf-parser:uri-query-param",
+        uri = amfParser("uri-query-param"),
         message = "Query parameters must not be defined in uri, use bindings instead",
-        owlClass = "apiContract:EndPoint",
-        owlProperty = "apiContract:path",
-        constraint = "sh:pattern",
+        owlClass = apiContract("EndPoint"),
+        owlProperty = apiContract("path"),
+        constraint = sh("pattern"),
         value = """^(?!(.*\?.*=.*)$).*$""".stripMargin // negates the regex for defining a query param
       ),
       AMFValidation(
-        uri="amf-parser:uri-fragment",
+        uri = amfParser("uri-fragment"),
         message = "Fragments must not be defined in uri",
-        owlClass = "apiContract:EndPoint",
-        owlProperty = "apiContract:path",
-        constraint = "sh:pattern",
+        owlClass = apiContract("EndPoint"),
+        owlProperty = apiContract("path"),
+        constraint = sh("pattern"),
         value = """^(?!(.*#.+)$).*$""".stripMargin
       ),
-      emailValidation("core:Organization", "core:email"),
-      urlValidation("core:Organization", "core:url"),
-      urlValidation("core:License", "core:url"),
-      urlValidation("apiContract:WebAPI", "core:termsOfService"),
-      uriValidation("apiContract:WebAPI", "core:identifier"),
-      urlValidation("core:CreativeWork", "core:url"),
-      urlValidation("security:OAuth2Flow", "security:authorizationUri"),
-      urlValidation("security:OAuth2Flow", "security:accessTokenUri"),
-      urlValidation("security:OAuth2Flow", "security:refreshUri")
+      emailValidation(core("Organization"), core("email")),
+      urlValidation(core("Organization"), core("url")),
+      urlValidation(core("License"), core("url")),
+      urlValidation(apiContract("WebAPI"), core("termsOfService")),
+      uriValidation(apiContract("WebAPI"), core("identifier")),
+      urlValidation(core("CreativeWork"), core("url")),
+      urlValidation(security("OAuth2Flow"), security("authorizationUri")),
+      urlValidation(security("OAuth2Flow"), security("accessTokenUri")),
+      urlValidation(security("OAuth2Flow"), security("refreshUri"))
     )
 
     override def validations(): Seq[AMFValidation] = result
@@ -1289,129 +1307,130 @@ object AMFRawValidations {
   object Oas30Validations extends OasValidations {
     private lazy val result = super.validations() ++ Seq(
       AMFValidation(
-        owlClass = "apiContract:Response",
-        owlProperty = "apiContract:statusCode",
-        constraint = "sh:pattern",
+        owlClass = apiContract("Response"),
+        owlProperty = apiContract("statusCode"),
+        constraint = sh("pattern"),
         value = "^([1-5]{1}(([0-9]{2})|XX))$|^(default)$",
         openApiErrorMessage =
           "Status code for a Response must be a value between 100 and 599, a [1-5]XX wildcard, or 'default'"
       ),
       AMFValidation(
         message = "Invalid flow. The options are: implicit, password, clientCredentials or authorizationCode",
-        owlClass = "security:OAuth2Flow",
-        owlProperty = "security:flow",
-        constraint = "sh:pattern",
-        value = "^(implicit|password|clientCredentials|authorizationCode)$",
+        owlClass = security("OAuth2Flow"),
+        owlProperty = security("flow"),
+        constraint = sh("pattern"),
+        value = "^(implicit|password|clientCredentials|authorizationCode)$"
       ),
       AMFValidation(
         message = "Invalid 'in' value. The options are: query, header or cookie",
-        owlClass = "security:Settings",
-        owlProperty = "security:in",
-        constraint = "sh:pattern",
-        value = "^(query|header|cookie)$",
+        owlClass = security("Settings"),
+        owlProperty = security("in"),
+        constraint = sh("pattern"),
+        value = "^(query|header|cookie)$"
       ),
       AMFValidation(
-        uri = "amf-parser:example-mutually-exclusive-fields",
+        uri = amfParser("example-mutually-exclusive-fields"),
         message = "Example 'value' and 'externalValue' fields are mutually exclusive",
-        owlClass = "apiContract:Example",
-        owlProperty = "doc:externalValue",
-        constraint = "raml-shapes:exampleMutuallyExclusiveFields",
+        owlClass = apiContract("Example"),
+        owlProperty = doc("externalValue"),
+        constraint = shape("exampleMutuallyExclusiveFields"),
         openApiErrorMessage = "Example 'value' and 'externalValue' fields are mutually exclusive"
       ),
       AMFValidation(
-        owlClass = "apiContract:Parameter",
-        owlProperty = "apiContract:payload",
-        constraint = "sh:maxCount",
+        owlClass = apiContract(ParameterModel.doc.displayName),
+        owlProperty = apiContract("payload"),
+        constraint = sh("maxCount"),
         value = "1",
         openApiErrorMessage = "Parameters 'content' field must only have one entry"
       ),
-      urlValidation("apiContract:WebAPI", "core:termsOfService"),
+      urlValidation(apiContract("WebAPI"), core("termsOfService")),
       AMFValidation(
         message = "'scheme' field is mandatory in http security scheme",
-        owlClass = "security:HttpSettings",
-        owlProperty = "security:scheme",
-        constraint = "sh:minCount",
+        owlClass = security("HttpSettings"),
+        owlProperty = security("scheme"),
+        constraint = minCount,
         value = "1"
       ),
       AMFValidation(
         message = "'name' field is mandatory in apiKey security scheme",
-        owlClass = "security:ApiKeySettings",
-        owlProperty = "core:name",
-        constraint = "sh:minCount",
+        owlClass = security("ApiKeySettings"),
+        owlProperty = core("name"),
+        constraint = minCount,
         value = "1"
       ),
       AMFValidation(
         message = "'in' field is mandatory in apiKey security scheme",
-        owlClass = "security:ApiKeySettings",
-        owlProperty = "security:in",
-        constraint = "sh:minCount",
+        owlClass = security("ApiKeySettings"),
+        owlProperty = security("in"),
+        constraint = minCount,
         value = "1"
       ),
       AMFValidation(
         message = "'openIdConnectUrl' field is mandatory in openIdConnect security scheme",
-        owlClass = "security:SecurityScheme",
-        owlProperty = "security:settings",
-        constraint = "raml-shapes:requiredOpenIdConnectUrl",
+        owlClass = security("SecurityScheme"),
+        owlProperty = security("settings"),
+        constraint = shape("requiredOpenIdConnectUrl")
       ),
       AMFValidation(
         message = "'flows' field is mandatory in OAuth2 security scheme",
-        owlClass = "security:SecurityScheme",
-        owlProperty = "security:settings",
-        constraint = "raml-shapes:requiredFlowsInOAuth2",
+        owlClass = security("SecurityScheme"),
+        owlProperty = security("settings"),
+        constraint = shape("requiredFlowsInOAuth2")
       ),
       AMFValidation(
         message = "Does not comply with runtime expression ABNF syntax",
-        owlClass = "apiContract:Callback",
-        owlProperty = "apiContract:expression",
-        constraint = "raml-shapes:validCallbackExpression",
+        owlClass = apiContract("Callback"),
+        owlProperty = apiContract("expression"),
+        constraint = shape("validCallbackExpression")
       ),
       AMFValidation(
         message = "Does not comply with runtime expression ABNF syntax",
-        owlClass = "apiContract:TemplatedLink",
-        owlProperty = "apiContract:requestBody",
-        constraint = "raml-shapes:validLinkRequestBody",
+        owlClass = apiContract("TemplatedLink"),
+        owlProperty = apiContract("requestBody"),
+        constraint = shape("validLinkRequestBody")
       ),
       AMFValidation(
         message = "Does not comply with runtime expression ABNF syntax",
-        owlClass = "apiContract:TemplatedLink",
-        owlProperty = "apiContract:mapping",
-        constraint = "raml-shapes:validLinkParameterExpressions",
+        owlClass = apiContract("TemplatedLink"),
+        owlProperty = apiContract("mapping"),
+        constraint = shape("validLinkParameterExpressions")
       ),
       AMFValidation(
         message = "Property 'name' in Tag object cannot be empty",
-        owlClass = "apiContract:Tag",
-        owlProperty = "core:name",
-        constraint = "sh:minLength",
+        owlClass = apiContract("Tag"),
+        owlProperty = core("name"),
+        constraint = sh("minLength"),
         value = "1",
       )
     )
+
     override def validations(): Seq[AMFValidation] = result
   }
 
   trait GenericValidations {
-    def urlValidation(owlClass: String, owlProperty: String): AMFValidation =
+    def urlValidation(owlClass: ValueType, owlProperty: ValueType): AMFValidation =
       AMFValidation(
         message = "Must be in the format of a URL",
         owlClass = owlClass,
         owlProperty = owlProperty,
-        constraint = "sh:pattern",
+        constraint = sh("pattern"),
         value = """^((https?|ftp|file)://)?[-a-zA-Z0-9()+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9()+&@#/%=~_|]$""".stripMargin
       )
 
-    def uriValidation(owlClass: String, owlProperty: String): AMFValidation =
+    def uriValidation(owlClass: ValueType, owlProperty: ValueType): AMFValidation =
       AMFValidation(
         message = "Must be in the format of a URI",
         owlClass = owlClass,
         owlProperty = owlProperty,
-        constraint = "sh:pattern",
+        constraint = sh("pattern"),
         value = """^\w+:(\/?\/?)[^\s]+$""".stripMargin
       )
 
-    def emailValidation(owlClass: String, owlProperty: String): AMFValidation =
+    def emailValidation(owlClass: ValueType, owlProperty: ValueType): AMFValidation =
       AMFValidation(
         owlClass = owlClass,
         owlProperty = owlProperty,
-        constraint = "sh:pattern",
+        constraint = sh("pattern"),
         value =
           """^[a-zA-Z0-9\.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$""".stripMargin,
         openApiErrorMessage = "Field 'email' must be in the format of an email address",

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/DefaultWebApiValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/DefaultWebApiValidations.scala
@@ -8,21 +8,18 @@ import amf.plugins.document.webapi.validation.AMFRawValidations.AMFValidation
 import amf.plugins.features.validation.Validations
 
 trait ImportUtils {
-
-  // def validationNS(postfix: String) = (Namespace.AmfParser + postfix).iri()
-
   protected def validationId(validation: AMFValidation): String =
     validation.uri match {
       case Some(s) => Namespace.expand(s.trim).iri()
       case None =>
         val classPostfix    = postfix(validation.owlClass, "domain")
         val propertyPostfix = postfix(validation.owlProperty, "property")
-        val constraint      = postfix(Some(validation.constraint), "constraint")
+        val constraint      = postfix(validation.constraint, "constraint")
         Namespace.AmfParser.base + classPostfix + "-" + propertyPostfix.trim + "-" + constraint.trim
     }
 
-  protected def postfix(s: Option[String], default: String): String = s match {
-    case Some(p) =>
+  protected def postfix(s: String, default: String): String = s match {
+    case p: String if p.nonEmpty =>
       if (p.indexOf("#") > -1) {
         p.split("#")(1).trim
       } else if (p.indexOf("/") == -1 && p.indexOf(":") != -1) {
@@ -30,17 +27,15 @@ trait ImportUtils {
       } else {
         p.split("/").last.trim
       }
-    case None => default
+    case _ => default
   }
 
 }
 
 object DefaultAMFValidations extends ImportUtils {
 
-  private def validations(): Map[ProfileName, Seq[AMFValidation]] = AMFRawValidations.map
-
-  def profiles(): List[ValidationProfile] = {
-    val list = validations().map {
+  def profiles(): List[ValidationProfile] =
+    AMFRawValidations.map.map {
       case (profile, validationsInGroup) =>
         val violationValidations = parseValidation(validationsInGroup.filter(_.severity == SeverityLevels.VIOLATION))
         val infoValidations      = parseValidation(validationsInGroup.filter(_.severity == SeverityLevels.INFO))
@@ -73,8 +68,6 @@ object DefaultAMFValidations extends ImportUtils {
           validations = infoValidations ++ warningValidations ++ violationValidations ++ Validations.validations
         )
     }.toList
-    list
-  }
 
   private def parseValidation(validations: Seq[AMFValidation]): Seq[ValidationSpecification] = {
     validations.map { validation =>
@@ -88,7 +81,7 @@ object DefaultAMFValidations extends ImportUtils {
         message = validation.message.getOrElse(""),
         ramlMessage = Some(validation.ramlErrorMessage),
         oasMessage = Some(validation.openApiErrorMessage),
-        targetClass = Seq(validation.owlClass.getOrElse((Namespace.Document + "DomainElement").iri()))
+        targetClass = Seq(validation.owlClass)
       )
 
       Namespace.expand(validation.target.trim).iri() match {
@@ -105,9 +98,9 @@ object DefaultAMFValidations extends ImportUtils {
             case _ => spec
           }
 
-        case "http://www.w3.org/ns/shacl#targetObjectsOf" if validation.owlProperty.isDefined =>
+        case "http://www.w3.org/ns/shacl#targetObjectsOf" =>
           spec.copy(
-            targetObject = Seq(validation.owlProperty.get),
+            targetObject = Seq(validation.owlProperty),
             nodeConstraints = Seq(NodeConstraint(validation.constraint, validation.value))
           )
         case _ => throw new Exception(s"Unknown validation target ${validation.target}")
@@ -119,7 +112,7 @@ object DefaultAMFValidations extends ImportUtils {
                                       validation: AMFValidation,
                                       sh: ValueType): PropertyConstraint = {
     val constraint = PropertyConstraint(
-      ramlPropertyId = validation.owlProperty.get,
+      ramlPropertyId = validation.owlProperty,
       name = constraintUri,
       message = validation.message
     )


### PR DESCRIPTION
- make validations use ValueType
- add standard ValueType constructors
- remove Optional from owlClass and owlProperty
- remove optional checking and casting