### PR TITLE
APIMF-2238: changed validation of scopes in oauth2 in RAML, when scop…

### DIFF
--- a/amf-client/shared/src/test/resources/validations/security-schema-scope.raml
+++ b/amf-client/shared/src/test/resources/validations/security-schema-scope.raml
@@ -1,0 +1,14 @@
+#%RAML 1.0
+title: GitHub API
+
+securitySchemes:
+  oauth_2_0:
+    description: This API supports OAuth 2.0 for authenticating all API requests.
+    type: OAuth 2.0
+    settings:
+      accessTokenUri:   https://esboam-dev.hhq.hud.dev/openam/oauth2/access_token
+      authorizationGrants: [ client_credentials ]
+
+/users:
+  get:
+    securedBy: [ oauth_2_0: { scopes: [ USER ] } ]

--- a/amf-client/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
@@ -255,5 +255,9 @@ class ValidRamlModelParserTest extends ValidModelTest {
     checkValid("recursion-in-trait.raml")
   }
 
+  test("Valid SecurityScheme scope for empty scopes in declaration") {
+    checkValid("security-schema-scope.raml")
+  }
+
   override val hint: Hint = RamlYamlHint
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/domain/ParametrizedSecuritySchemeParsers.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/domain/ParametrizedSecuritySchemeParsers.scala
@@ -135,8 +135,7 @@ case class RamlSecuritySettingsParser(map: YMap, `type`: String, scheme: DomainE
       scheme match {
         case ss: ParametrizedSecurityScheme =>
           ss.scheme.settings match {
-            case se: OAuth2Settings
-                if se.flows.headOption.exists(_.scopes.map(_.name.value()).contains(element.toString)) =>
+            case se: OAuth2Settings if isValidScope(se.flows.headOption, element.toString()) =>
               Scope().set(ScopeModel.Name, ScalarNode(n).text()).adopted(flow.getOrCreate.id)
             case _: OAuth2Settings =>
               val scope = Scope().adopted(flow.getOrCreate.id)
@@ -174,4 +173,8 @@ case class RamlSecuritySettingsParser(map: YMap, `type`: String, scheme: DomainE
 
     dynamicSettings(settings, "requestTokenUri", "authorizationUri", "tokenCredentialsUri", "signatures")
   }
+
+  private def isValidScope(maybeFlow: Option[OAuth2Flow], scope: String): Boolean =
+    maybeFlow.exists(flow => flow.scopes.isEmpty || flow.scopes.map(_.name.value()).contains(scope))
+
 }


### PR DESCRIPTION
…es is not defined in the SecuritySchema declaration any scope is allowed in the implementation