### PR TITLE
APIMF-1967

### DIFF
--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/pipelines/compatibility/RamlCompatibilityPipeline.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/pipelines/compatibility/RamlCompatibilityPipeline.scala
@@ -1,9 +1,14 @@
 package amf.plugins.document.webapi.resolution.pipelines.compatibility
 
 import amf.core.errorhandling.{ErrorHandler, UnhandledErrorHandler}
+import amf.core.model.document.{BaseUnit, Document}
+import amf.core.model.domain.{AmfElement, Shape}
 import amf.core.resolution.pipelines.ResolutionPipeline
 import amf.core.resolution.stages.ResolutionStage
+import amf.core.utils.IdCounter
+import amf.plugins.document.webapi.ParsedFromJsonSchema
 import amf.plugins.document.webapi.resolution.pipelines.compatibility.raml._
+import amf.plugins.domain.webapi.models.SchemaContainer
 import amf.plugins.domain.webapi.resolution.stages.RamlCompatiblePayloadAndParameterResolutionStage
 import amf.{ProfileName, RamlProfile}
 
@@ -25,6 +30,7 @@ class RamlCompatibilityPipeline(override val eh: ErrorHandler) extends Resolutio
     new EscapeTypeNames(),
     new MakeRequiredFieldImplicitForOptionalProperties(),
     new ResolveRamlCompatibleDeclarations(),
+    new ExtractCommonShapesToDeclarations(),
     new ResolveLinksWithNonDeclaredTargets(),
     new RamlCompatiblePayloadAndParameterResolutionStage(profileName),
     new SanitizeCustomTypeNames(),
@@ -36,4 +42,62 @@ class RamlCompatibilityPipeline(override val eh: ErrorHandler) extends Resolutio
 
 object RamlCompatibilityPipeline {
   def unhandled = new RamlCompatibilityPipeline(UnhandledErrorHandler)
+}
+
+class ExtractCommonShapesToDeclarations()(implicit errorHandler: ErrorHandler)
+    extends ResolutionStage()(errorHandler) {
+
+  override def resolve[T <: BaseUnit](model: T): T = {
+    model match {
+      case doc: Document =>
+        resolve(doc)
+        model
+      case _ => model
+    }
+  }
+
+  private def resolve(doc: Document): Unit = {
+    val schemaContainersWithJsonSchemaShapes = getSchemaContainers(doc)
+    val externalEmbeddedSchemas              = groupSchemas(schemaContainersWithJsonSchemaShapes)
+    val idCounter                            = new IdCounter()
+    externalEmbeddedSchemas.foreach {
+      case (_, containers) =>
+        val schema = containers.head.schema
+        doc.withDeclaredElement(schema)
+        val label = idCounter.genId("Generated")
+        schema.withName(label)
+        val link = schema.link[Shape](label)
+        containers.foreach(_.setSchema(link))
+    }
+  }
+
+  private def groupSchemas(schemaContainersWithJsonSchemaShapes: List[AmfElement with SchemaContainer]) = {
+    schemaContainersWithJsonSchemaShapes
+      .groupBy(x => x.schema.effectiveLinkTarget().annotations.find(classOf[ParsedFromJsonSchema]).get.fullRef)
+      .filter {
+        case (_, containers) =>
+          containers.length > 1 && containers.head.schema
+            .effectiveLinkTarget()
+            .annotations
+            .find(classOf[ParsedFromJsonSchema])
+            .get
+            .fragment
+            .nonEmpty
+      }
+  }
+
+  private def getSchemaContainers(doc: Document) = {
+    doc
+      .iterator()
+      .collect {
+        case container: SchemaContainer if hasJsonSchemaShape(container) => container
+      }
+      .toList
+  }
+
+  private def hasJsonSchemaShape(container: SchemaContainer): Boolean =
+    Option(container.schema) match {
+      case Some(schema) => schema.effectiveLinkTarget().annotations.contains(classOf[ParsedFromJsonSchema])
+      case None         => false
+    }
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/pipelines/compatibility/raml/ResolveLinksWithNonDeclaredTargets.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/pipelines/compatibility/raml/ResolveLinksWithNonDeclaredTargets.scala
@@ -3,6 +3,7 @@ package amf.plugins.document.webapi.resolution.pipelines.compatibility.raml
 import amf.core.errorhandling.ErrorHandler
 import amf.core.model.document.{BaseUnit, Document}
 import amf.core.model.domain.Linkable
+import amf.plugins.document.webapi.ParsedFromJsonSchema
 import amf.plugins.document.webapi.resolution.pipelines.compatibility.common.AmfElementLinkResolutionStage
 
 // TODO we need to do this because some links might point to properties within declared elements
@@ -11,10 +12,16 @@ class ResolveLinksWithNonDeclaredTargets()(override implicit val errorHandler: E
 
   override def selector[T <: BaseUnit](l: Linkable, model: T): Boolean = {
     model match {
-      case doc: Document =>
+      case doc: Document if isExternalJsonSchema(l) =>
         val targetId = l.effectiveLinkTarget().id
         !doc.declares.exists(_.id == targetId)
       case _ => false
+    }
+  }
+
+  private def isExternalJsonSchema(linkable: Linkable): Boolean = {
+    linkable.effectiveLinkTarget().annotations.find(classOf[ParsedFromJsonSchema]).exists { annon =>
+      annon.fragment.nonEmpty
     }
   }
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/pipelines/compatibility/raml/ResolveLinksWithNonDeclaredTargets.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/pipelines/compatibility/raml/ResolveLinksWithNonDeclaredTargets.scala
@@ -12,14 +12,14 @@ class ResolveLinksWithNonDeclaredTargets()(override implicit val errorHandler: E
 
   override def selector[T <: BaseUnit](l: Linkable, model: T): Boolean = {
     model match {
-      case doc: Document if isExternalJsonSchema(l) =>
+      case doc: Document if isJsonInnerSchema(l) =>
         val targetId = l.effectiveLinkTarget().id
         !doc.declares.exists(_.id == targetId)
       case _ => false
     }
   }
 
-  private def isExternalJsonSchema(linkable: Linkable): Boolean = {
+  private def isJsonInnerSchema(linkable: Linkable): Boolean = {
     linkable.effectiveLinkTarget().annotations.find(classOf[ParsedFromJsonSchema]).exists { annon =>
       annon.fragment.nonEmpty
     }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/domain/webapi/models/SchemaContainer.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/domain/webapi/models/SchemaContainer.scala
@@ -6,6 +6,7 @@ import amf.plugins.domain.shapes.models.Example
 trait SchemaContainer {
   def schema: Shape
   def setSchema(shape: Shape): Shape
+  def hasSchema(): Boolean = Option(schema).isDefined
   def id: String
   def examples: Seq[Example]
   def removeExamples(): Unit


### PR DESCRIPTION
PoC for https://www.mulesoft.org/jira/browse/APIMF-1967.

Pros:
- OAS -> RAML webapi converted emission will be much smaller in size.

Cons:
- Adds processing time to a non-critical transformation.
- It is based on an annotation. If someone converts a webapi from a parsed json-ld this stage wouldn't be applied leading to inconsistent results.
- Extracted schemas have a generated name
- We are heavily modifying the underlying AMF graph. This isn't the best decision but it is currently the only one.

This PR has 2 parts:
- First commit: grouping of inner schemas of a JsonSchema. They are extracted to declarations and have a generated name.
- Second commit: stop resolving schemas coming from single schema JsonSchema files.