### PR TITLE
Declaring missing JS interface

### DIFF
--- a/amf-client/js/typings/amf-client-js.d.ts
+++ b/amf-client/js/typings/amf-client-js.d.ts
@@ -455,9 +455,19 @@ declare module 'amf-client-js' {
       remove(): void
     }
 
+    class AnyField extends ValueField<any> implements BaseField {
+      option: any | undefined;
+
+      remove(): void;
+
+      value(): any;
+
+      annotations(): Annotations;
+
+    }
+
     namespace document {
 
-      /* Not exported */
       abstract class EncodesModel {
         encodes: domain.DomainElement
 
@@ -552,7 +562,6 @@ declare module 'amf-client-js' {
 
       export class DocumentationItem extends Fragment {}
 
-      export class DataType extends Fragment {}
 
       export class NamedExample extends Fragment {}
 
@@ -565,9 +574,24 @@ declare module 'amf-client-js' {
       export class SecuritySchemeFragment extends Fragment {}
 
       export class Dialect extends BaseUnit {
-        name: StrField
-        declares: domain.NodeMapping[]
-        encodes: domain.NodeMapping
+        name: StrField;
+        declares: domain.DomainElement[];
+        encodes: domain.DomainElement;
+        version: StrField;
+        documents: model.domain.DocumentsModel;
+        nameAndVersion: string
+        withName(name: string): Dialect;
+        withVersion(version: string): Dialect
+        withExternals(externals: model.domain.External[]): DialectLibrary;
+        withDocuments(documentsMapping: model.domain.DocumentsModel): Dialect
+      }
+
+      export class DialectLibrary extends  BaseUnit {
+        externals: model.domain.External[];
+        declares: domain.DomainElement[]
+        nodeMappings(): model.domain.NodeMapping[];
+        withExternals(externals: model.domain.External[]): DialectLibrary;
+        withNodeMappings(nodeMappings: model.domain.NodeMapping[]): DialectLibrary;
       }
 
       export class DialectInstance extends Document {
@@ -604,6 +628,8 @@ declare module 'amf-client-js' {
       class AmfScalar {
         value: any
       }
+
+      export class DataType extends model.document.Fragment {}
 
       /* Not exported */
       abstract class DomainElement implements Annotable {
@@ -650,15 +676,110 @@ declare module 'amf-client-js' {
         getObjectPropertyUri(propertyId: String): DialectDomainElement[];
       }
 
-      export class NodeMapping extends DomainElement {
-        name: StrField
-        nodetypeMapping: StrField
-        propertiesMapping(): PropertyMapping[]
+      export class DocumentsModel extends DomainElement {
+        root(): DocumentMapping;
+        withRoot(documentMapping: DocumentMapping): DocumentsModel;
+        fragments(): DocumentMapping[];
+        withFragments(fragments: DocumentMapping): DocumentsModel;
+        library(): DocumentMapping;
+        withLibrary(library: DocumentMapping): DocumentsModel;
+        selfEncoded(): BoolField;
+        withSelfEncoded(selfEncoded: boolean): DocumentsModel;
+        declarationsPath(): StrField;
+        withDeclarationsPath(declarationsPath: string): DocumentsModel;
+        keyProperty(): BoolField;
+        withKeyProperty(keyProperty: boolean): DocumentsModel;
+      }
+
+      export class DocumentMapping extends DomainElement {
+        documentName(): StrField;
+        withDocumentName(name: String): DocumentMapping;
+        encoded(): StrField;
+        withEncoded(encodedNode: StrField): DocumentMapping;
+        declaredNodes(): PublicNodeMapping[];
+        withDeclaredNodes(declarations: PublicNodeMapping[]): DocumentMapping;
+      }
+
+      export class PublicNodeMapping extends DomainElement {
+        name: StrField;
+        withName(name: string): PublicNodeMapping;
+        mappedNode(): StrField;
+        withMappedNode(mappedNode: string): PublicNodeMapping;
+      }
+
+
+      export class NodeMapping extends DomainElement implements Linkable {
+        name: StrField;
+        nodetypeMapping: StrField;
+        propertiesMapping(): PropertyMapping[];
+        idTemplate: StrField;
+        mergePolicy: StrField;
+
+        isLink: boolean;
+        linkLabel: StrField;
+        linkTarget: DomainElement | undefined;
+
+        linkCopy(): NodeMapping;
+        withLinkLabel(label: string): this;
+        withLinkTarget(target: Linkable): this;
+
+        withName(name: string): NodeMapping;
+        withNodeTypeMapping(nodeType: string): NodeMapping;
+        withPropertiesMapping(props: string[]): NodeMapping;
+        withIdTemplate(idTemplate: string): NodeMapping;
+        withMergePolicy(mergePolicy: string): NodeMapping;
+      }
+
+      export class UnionNodeMapping extends DomainElement implements Linkable {
+        isLink: boolean;
+        linkLabel: StrField;
+        linkTarget: DomainElement | undefined;
+        linkCopy(): UnionNodeMapping;
+        withLinkLabel(label: string): this;
+        withLinkTarget(target: Linkable): this;
+
+        name: StrField;
+        withName(name: StrField): UnionNodeMapping;
+        typeDiscriminatorName(): StrField;
+        typeDiscriminator():  {[name:string]: string};
+        objectRange(): StrField[];
+        withObjectRange(range: string[]): UnionNodeMapping;
+        withTypeDiscriminatorName(name: string):UnionNodeMapping;
+        withTypeDiscriminator(typesMapping: {[name:string]: string}): UnionNodeMapping;
       }
 
       export class PropertyMapping extends DomainElement {
+        withName(name: string): PropertyMapping;
         name(): StrField
+        withNodePropertyMapping(propertyId: string): PropertyMapping;
         nodePropertyMapping(): StrField
+        withLiteralRange(range: string): PropertyMapping;
+        literalRange(): StrField;
+        withObjectRange(range: string[]): PropertyMapping
+        objectRange(): StrField[];
+        mapKeyProperty(): StrField;
+        withMapKeyProperty(key: string): PropertyMapping
+        mapValueProperty(): StrField;
+        withMapValueProperty(value: string): PropertyMapping
+        minCount(): IntField;
+        withMinCount(minCount: number): IntField
+        pattern(): StrField
+        withPattern(pattern: string): PropertyMapping;
+        minimum(): DoubleField;
+        withMinimum(min: number): PropertyMapping;
+        maximum(): DoubleField;
+        withMaximum(max: number): PropertyMapping;
+        allowMultiple(): BoolField;
+        withAllowMultiple(allow: Boolean): PropertyMapping
+        enum(): AnyField;
+        withEnum(values: any[]): PropertyMapping;
+        sorted(): BoolField
+        withSorted(sorted: Boolean): PropertyMapping
+        typeDiscriminator(): {[t:string]: string};
+        withTypeDiscriminator(typesMapping: {[t:string]:string} ): PropertyMapping;
+        typeDiscriminatorName(): StrField;
+        withTypeDiscriminatorName(name: string): PropertyMapping
+        classification(): string;
       }
 
       export class ClassTerm extends DomainElement {
@@ -1929,7 +2050,6 @@ declare module 'amf-client-js' {
   /* Not exported */
   namespace parse {
 
-    /* Not exported */
     class Parser {
       constructor(vendor: string, mediaType: string)
 
@@ -1941,9 +2061,15 @@ declare module 'amf-client-js' {
 
       parseFileAsync(url: string): Promise<model.document.BaseUnit>
 
+      parseFileAsync(url: string, options: parser.ParsingOptions): Promise<model.document.BaseUnit>
+
       parseStringAsync(url: string, stream: string): Promise<model.document.BaseUnit>
 
       parseStringAsync(stream: string): Promise<model.document.BaseUnit>
+
+      parseStringAsync(stream: string, options: parser.ParsingOptions): Promise<model.document.BaseUnit>
+
+      parseStringAsync(url: string, stream: string, options: parser.ParsingOptions): Promise<model.document.BaseUnit>
 
       reportValidation(profileName: string, messageStyle: string): Promise<client.validate.ValidationReport>
 
@@ -2037,6 +2163,19 @@ declare module 'amf-client-js' {
           static readonly COMPATIBILITY_PIPELINE: 'compatibility'
         }
       }
+    }
+  }
+
+  namespace parser {
+    export class ParsingOptions {
+      withoutAmfJsonLdSerialization: ParsingOptions;
+      withAmfJsonLdSerialization: ParsingOptions;
+      withBaseUnitUrl(baseUnit: string): ParsingOptions;
+      withoutBaseUnitUrl(): ParsingOptions;
+      setMaxYamlReferences(value: number): ParsingOptions;
+      isAmfJsonLdSerilization: boolean;
+      definedBaseUrl: String|undefined;
+      getMaxYamlReferences: number|undefined;
     }
   }
 }

--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,3 +1,3 @@
 amf.webapi=4.2.0-SNAPSHOT
-amf.aml=4.1.123
+amf.aml=4.1.124
 amf.model=2.1.0


### PR DESCRIPTION
Exposing missing AML interface in JS:

- Exporting missing JS methods
- Support for scala to native map conversions (used input arguments in some functions)
- Typings

Associated PRs in core and aml:

See: https://github.com/aml-org/amf-aml/pull/71
See: https://github.com/aml-org/amf-core/pull/79