### PR TITLE
APIMF-2320: safe adoption for id of json schema links

### DIFF
--- a/amf-client/shared/src/test/resources/upanddown/examples.json.expanded.jsonld
+++ b/amf-client/shared/src/test/resources/upanddown/examples.json.expanded.jsonld
@@ -96,7 +96,7 @@
                             ],
                             "http://www.w3.org/ns/shacl#and": [
                               {
-                                "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599",
+                                "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0",
                                 "@type": [
                                   "http://www.w3.org/ns/shacl#NodeShape",
                                   "http://a.ml/vocabularies/shapes#AnyShape",
@@ -126,16 +126,16 @@
                                 ],
                                 "http://a.ml/vocabularies/document-source-maps#sources": [
                                   {
-                                    "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599/source-map",
+                                    "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0/source-map",
                                     "@type": [
                                       "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                     ],
                                     "http://a.ml/vocabularies/document-source-maps#lexical": [
                                       {
-                                        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599/source-map/lexical/element_0",
+                                        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0/source-map/lexical/element_0",
                                         "http://a.ml/vocabularies/document-source-maps#element": [
                                           {
-                                            "@value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599"
+                                            "@value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0"
                                           }
                                         ],
                                         "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1114,7 +1114,7 @@
                             ],
                             "http://www.w3.org/ns/shacl#and": [
                               {
-                                "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432",
+                                "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0",
                                 "@type": [
                                   "http://www.w3.org/ns/shacl#NodeShape",
                                   "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1144,16 +1144,16 @@
                                 ],
                                 "http://a.ml/vocabularies/document-source-maps#sources": [
                                   {
-                                    "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432/source-map",
+                                    "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0/source-map",
                                     "@type": [
                                       "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                     ],
                                     "http://a.ml/vocabularies/document-source-maps#lexical": [
                                       {
-                                        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432/source-map/lexical/element_0",
+                                        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0/source-map/lexical/element_0",
                                         "http://a.ml/vocabularies/document-source-maps#element": [
                                           {
-                                            "@value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432"
+                                            "@value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0"
                                           }
                                         ],
                                         "http://a.ml/vocabularies/document-source-maps#value": [

--- a/amf-client/shared/src/test/resources/upanddown/examples.json.flattened.jsonld
+++ b/amf-client/shared/src/test/resources/upanddown/examples.json.flattened.jsonld
@@ -1,3247 +1,3247 @@
 {
-"@graph": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api",
-"@type": [
-"http://a.ml/vocabularies/apiContract#WebAPI",
-"http://a.ml/vocabularies/document#RootDomainElement",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/core#name": "API with Examples",
-"http://a.ml/vocabularies/core#version": "1.0",
-"http://a.ml/vocabularies/apiContract#endpoint": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization",
-"@type": [
-"http://a.ml/vocabularies/apiContract#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/apiContract#path": "/organization",
-"http://a.ml/vocabularies/apiContract#supportedOperation": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#source-vendor": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/source-vendor/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_2"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/apiContract#method": "post",
-"http://a.ml/vocabularies/apiContract#expects": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request"
-}
-],
-"http://a.ml/vocabularies/apiContract#returns": [],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/apiContract#method": "get",
-"http://a.ml/vocabularies/core#description": "Returns an organization entity.",
-"http://a.ml/vocabularies/apiContract#returns": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/source-vendor/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api",
-"http://a.ml/vocabularies/document-source-maps#value": "OAS 2.0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
-"http://a.ml/vocabularies/document-source-maps#value": "[(5,4)-(5,20)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(4,4)-(4,32)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#endpoint",
-"http://a.ml/vocabularies/document-source-maps#value": "[(7,11)-(86,3)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api",
-"http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(122,1)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Request",
-"http://a.ml/vocabularies/apiContract#Message",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/apiContract#payload": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson"
-}
-],
-"http://a.ml/vocabularies/apiContract#header": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/synthesized-field/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Response",
-"http://a.ml/vocabularies/apiContract#Message",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/apiContract#statusCode": "201",
-"http://a.ml/vocabularies/core#name": "201",
-"http://a.ml/vocabularies/core#description": "",
-"http://a.ml/vocabularies/apiContract#payload": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson"
-}
-],
-"http://a.ml/vocabularies/apiContract#examples": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_1"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization",
-"http://a.ml/vocabularies/document-source-maps#value": "[(8,4)-(85,5)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Payload",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/core#name": "bodyParam",
-"http://a.ml/vocabularies/core#mediaType": "application/json",
-"http://a.ml/vocabularies/shapes#schema": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam"
-},
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/core#name": "UserID",
-"http://a.ml/vocabularies/apiContract#paramName": "UserID",
-"http://a.ml/vocabularies/core#description": "description: the identifier for the user who posts a new organization",
-"http://a.ml/vocabularies/apiContract#required": false,
-"http://a.ml/vocabularies/apiContract#binding": "header",
-"http://a.ml/vocabularies/shapes#schema": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema"
-},
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_1"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/synthesized-field/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
-"http://a.ml/vocabularies/document-source-maps#value": "true"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post",
-"http://a.ml/vocabularies/document-source-maps#value": "[(9,6)-(39,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
-"http://a.ml/vocabularies/document-source-maps#value": "[(38,8)-(38,23)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Payload",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/core#mediaType": "application/json",
-"http://a.ml/vocabularies/shapes#schema": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default"
-},
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Example",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/core#name": "application/json",
-"http://a.ml/vocabularies/document#strict": false,
-"http://a.ml/vocabularies/core#mediaType": "application/json",
-"http://a.ml/vocabularies/document#structuredValue": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1"
-},
-"http://a.ml/vocabularies/document#raw": "\"name\": \"Puma\"\n\"type\": \"Dog\"\n\"color\": \"Black\"\n\"gender\": \"Female\"\n\"breed\": \"Mixed\"",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Example",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/core#name": "application/xml",
-"http://a.ml/vocabularies/document#strict": false,
-"http://a.ml/vocabularies/core#mediaType": "application/xml",
-"http://a.ml/vocabularies/document#structuredValue": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1"
-},
-"http://a.ml/vocabularies/document#raw": "\"name\": \"Puma\"\n\"type\": \"Dog\"\n\"color\": \"Black\"\n\"gender\": \"Female\"\n\"breed\": \"Mixed\"",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_1"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-"http://a.ml/vocabularies/document-source-maps#value": "[(41,8)-(41,56)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
-"http://a.ml/vocabularies/document-source-maps#value": "[(42,8)-(83,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get",
-"http://a.ml/vocabularies/document-source-maps#value": "[(40,6)-(84,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam",
-"@type": [
-"http://www.w3.org/ns/shacl#NodeShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#closed": false,
-"http://www.w3.org/ns/shacl#name": "bodyParam",
-"http://www.w3.org/ns/shacl#and": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599"
-}
-],
-"http://a.ml/vocabularies/apiContract#examples": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#body-parameter": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/body-parameter/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_2"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": "schema",
-"http://a.ml/vocabularies/core#description": "description: the identifier for the user who posts a new organization",
-"http://a.ml/vocabularies/apiContract#examples": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_5"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_4"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
-"http://a.ml/vocabularies/document-source-maps#value": "[(10,8)-(37,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
-"http://a.ml/vocabularies/document-source-maps#value": "[(10,8)-(37,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request",
-"http://a.ml/vocabularies/document-source-maps#value": "[(9,14)-(39,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default",
-"@type": [
-"http://www.w3.org/ns/shacl#NodeShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#closed": false,
-"http://www.w3.org/ns/shacl#name": "default",
-"http://www.w3.org/ns/shacl#and": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432"
-}
-],
-"http://a.ml/vocabularies/apiContract#examples": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_1"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1",
-"@type": [
-"http://a.ml/vocabularies/data#Object",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#name": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2"
-},
-"http://a.ml/vocabularies/data#type": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3"
-},
-"http://a.ml/vocabularies/data#color": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4"
-},
-"http://a.ml/vocabularies/data#gender": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5"
-},
-"http://a.ml/vocabularies/data#breed": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6"
-},
-"http://a.ml/vocabularies/core#name": "object_1",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/synthesized-field/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_1"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#tracked-element": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/tracked-element/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1",
-"@type": [
-"http://a.ml/vocabularies/data#Object",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#name": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2"
-},
-"http://a.ml/vocabularies/data#type": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3"
-},
-"http://a.ml/vocabularies/data#color": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4"
-},
-"http://a.ml/vocabularies/data#gender": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5"
-},
-"http://a.ml/vocabularies/data#breed": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6"
-},
-"http://a.ml/vocabularies/core#name": "object_1",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/synthesized-field/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_1"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#tracked-element": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/tracked-element/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-"http://a.ml/vocabularies/document-source-maps#value": "[(81,12)-(81,29)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
-"http://a.ml/vocabularies/document-source-maps#value": "[(65,12)-(80,13)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201",
-"http://a.ml/vocabularies/document-source-maps#value": "[(43,10)-(82,11)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599",
-"@type": [
-"http://www.w3.org/ns/shacl#NodeShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/document#link-target": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org"
-}
-],
-"http://a.ml/vocabularies/document#link-label": "Org",
-"http://a.ml/vocabularies/document#recursive": true,
-"http://www.w3.org/ns/shacl#name": "item0",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Example",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/document#strict": true,
-"http://a.ml/vocabularies/document#structuredValue": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1"
-},
-"http://a.ml/vocabularies/document#raw": "\"name\": \"Doe Enterprise\"\n\"value\": \"Silver\"",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#parameter-binding-in-body-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/parameter-binding-in-body-lexical-info/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_2"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/type-property-lexical-info/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/body-parameter/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson",
-"http://a.ml/vocabularies/document-source-maps#value": "true"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#mediaType",
-"http://a.ml/vocabularies/document-source-maps#value": "[(34,12)-(34,49)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(19,12)-(19,31)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
-"http://a.ml/vocabularies/document-source-maps#value": "[(20,12)-(33,13)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson",
-"http://a.ml/vocabularies/document-source-maps#value": "[(18,10)-(36,11)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Example",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/document#strict": true,
-"http://a.ml/vocabularies/document#structuredValue": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1"
-},
-"http://a.ml/vocabularies/document#raw": "SWED-123",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/type-property-lexical-info/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_2"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_5",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
-"http://a.ml/vocabularies/document-source-maps#value": "[(15,12)-(15,26)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID",
-"http://a.ml/vocabularies/document-source-maps#value": "[(11,10)-(17,11)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-"http://a.ml/vocabularies/document-source-maps#value": "[(14,12)-(14,98)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
-"http://a.ml/vocabularies/document-source-maps#value": "[(11,10)-(17,11)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(13,12)-(13,28)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_4",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
-"http://a.ml/vocabularies/document-source-maps#value": "[(13,12)-(13,28)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432",
-"@type": [
-"http://www.w3.org/ns/shacl#NodeShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/document#link-target": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org"
-}
-],
-"http://a.ml/vocabularies/document#link-label": "Org",
-"http://a.ml/vocabularies/document#recursive": true,
-"http://www.w3.org/ns/shacl#name": "item0",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Example",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/core#name": "softwareCorp",
-"http://a.ml/vocabularies/document#strict": true,
-"http://a.ml/vocabularies/document#structuredValue": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1"
-},
-"http://a.ml/vocabularies/document#raw": "\"name\": \"Software Corp\"\n\"address\": \"35 Central Street\"\n\"value\": \"Gold\"",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Example",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/document#strict": true,
-"http://a.ml/vocabularies/document#structuredValue": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1"
-},
-"http://a.ml/vocabularies/document#raw": "\"name\": \"Acme\"",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/auto-generated-name/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_1"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/type-property-lexical-info/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#mediaType",
-"http://a.ml/vocabularies/document-source-maps#value": "[(44,12)-(44,49)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
-"http://a.ml/vocabularies/document-source-maps#value": "[(45,12)-(64,13)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson",
-"http://a.ml/vocabularies/document-source-maps#value": "[(45,12)-(64,13)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Puma",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Dog",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "type",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Black",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "color",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Female",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "gender",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Mixed",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "breed",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_5"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_4"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/synthesized-field/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
-"http://a.ml/vocabularies/document-source-maps#value": "true"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
-"http://a.ml/vocabularies/document-source-maps#value": "[(66,34)-(72,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
-"http://a.ml/vocabularies/document-source-maps#value": "[(66,34)-(72,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson",
-"http://a.ml/vocabularies/document-source-maps#value": "[(66,14)-(72,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/tracked-element/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson",
-"http://a.ml/vocabularies/document-source-maps#value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Puma",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Dog",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "type",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Black",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "color",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Female",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "gender",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Mixed",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "breed",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_5"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_4"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/synthesized-field/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
-"http://a.ml/vocabularies/document-source-maps#value": "true"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
-"http://a.ml/vocabularies/document-source-maps#value": "[(73,33)-(79,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
-"http://a.ml/vocabularies/document-source-maps#value": "[(73,33)-(79,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml",
-"http://a.ml/vocabularies/document-source-maps#value": "[(73,14)-(79,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/tracked-element/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml",
-"http://a.ml/vocabularies/document-source-maps#value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1",
-"@type": [
-"http://a.ml/vocabularies/data#Object",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#name": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2"
-},
-"http://a.ml/vocabularies/data#value": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3"
-},
-"http://a.ml/vocabularies/core#name": "object_1",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/synthesized-field/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_1"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#tracked-element": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/tracked-element/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/parameter-binding-in-body-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam",
-"http://a.ml/vocabularies/document-source-maps#value": "[(35,12)-(35,24)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#and",
-"http://a.ml/vocabularies/document-source-maps#value": "[(28,23)-(32,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(19,12)-(19,31)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
-"http://a.ml/vocabularies/document-source-maps#value": "[(22,14)-(27,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam",
-"http://a.ml/vocabularies/document-source-maps#value": "[(20,12)-(33,13)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/type-property-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam",
-"http://a.ml/vocabularies/document-source-maps#value": "[(21,14)-(21,20)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "SWED-123",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "scalar_1",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/synthesized-field/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_1"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/type-property-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema",
-"http://a.ml/vocabularies/document-source-maps#value": "[(12,12)-(12,18)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-"http://a.ml/vocabularies/document-source-maps#value": "[(14,12)-(14,98)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-"http://a.ml/vocabularies/document-source-maps#value": "[(12,12)-(12,28)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
-"http://a.ml/vocabularies/document-source-maps#value": "[(16,12)-(16,33)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema",
-"http://a.ml/vocabularies/document-source-maps#value": "[(11,10)-(17,11)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1",
-"@type": [
-"http://a.ml/vocabularies/data#Object",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#name": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2"
-},
-"http://a.ml/vocabularies/data#address": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3"
-},
-"http://a.ml/vocabularies/data#value": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4"
-},
-"http://a.ml/vocabularies/core#name": "object_1",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/synthesized-field/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_2"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#tracked-element": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/tracked-element/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1",
-"@type": [
-"http://a.ml/vocabularies/data#Object",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#name": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2"
-},
-"http://a.ml/vocabularies/core#name": "object_1",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/synthesized-field/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_1"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#tracked-element": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/tracked-element/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/auto-generated-name/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default",
-"http://a.ml/vocabularies/document-source-maps#value": ""
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#and",
-"http://a.ml/vocabularies/document-source-maps#value": "[(59,23)-(63,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
-"http://a.ml/vocabularies/document-source-maps#value": "[(50,14)-(58,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default",
-"http://a.ml/vocabularies/document-source-maps#value": "[(45,12)-(64,13)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/type-property-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default",
-"http://a.ml/vocabularies/document-source-maps#value": "[(46,14)-(46,20)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_5",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#gender",
-"http://a.ml/vocabularies/document-source-maps#value": "[(70,16)-(70,34)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1",
-"http://a.ml/vocabularies/document-source-maps#value": "[(66,34)-(72,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#color",
-"http://a.ml/vocabularies/document-source-maps#value": "[(69,16)-(69,32)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#breed",
-"http://a.ml/vocabularies/document-source-maps#value": "[(71,16)-(71,32)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(67,16)-(67,30)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_4",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#type",
-"http://a.ml/vocabularies/document-source-maps#value": "[(68,16)-(68,29)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_5",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#gender",
-"http://a.ml/vocabularies/document-source-maps#value": "[(77,16)-(77,34)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1",
-"http://a.ml/vocabularies/document-source-maps#value": "[(73,33)-(79,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#color",
-"http://a.ml/vocabularies/document-source-maps#value": "[(76,16)-(76,32)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#breed",
-"http://a.ml/vocabularies/document-source-maps#value": "[(78,16)-(78,32)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(74,16)-(74,30)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_4",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#type",
-"http://a.ml/vocabularies/document-source-maps#value": "[(75,16)-(75,29)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--575329599",
-"http://a.ml/vocabularies/document-source-maps#value": "[(29,16)-(31,17)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Doe Enterprise",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Silver",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "value",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_1"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/synthesized-field/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
-"http://a.ml/vocabularies/document-source-maps#value": "true"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
-"http://a.ml/vocabularies/document-source-maps#value": "[(23,25)-(26,17)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
-"http://a.ml/vocabularies/document-source-maps#value": "[(23,25)-(26,17)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example",
-"http://a.ml/vocabularies/document-source-maps#value": "[(22,14)-(27,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/tracked-element/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example",
-"http://a.ml/vocabularies/document-source-maps#value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/synthesized-field/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
-"http://a.ml/vocabularies/document-source-maps#value": "true"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
-"http://a.ml/vocabularies/document-source-maps#value": "[(16,23)-(16,33)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
-"http://a.ml/vocabularies/document-source-maps#value": "[(16,23)-(16,33)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example",
-"http://a.ml/vocabularies/document-source-maps#value": "[(16,23)-(16,33)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/link--188856432",
-"http://a.ml/vocabularies/document-source-maps#value": "[(60,16)-(62,17)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Software Corp",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "35 Central Street",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "address",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Gold",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "value",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_2"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/synthesized-field/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
-"http://a.ml/vocabularies/document-source-maps#value": "true"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
-"http://a.ml/vocabularies/document-source-maps#value": "[(52,27)-(56,19)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(51,16)-(57,17)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
-"http://a.ml/vocabularies/document-source-maps#value": "[(52,27)-(56,19)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp",
-"http://a.ml/vocabularies/document-source-maps#value": "[(51,16)-(57,17)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/tracked-element/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp",
-"http://a.ml/vocabularies/document-source-maps#value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Acme",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/synthesized-field/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
-"http://a.ml/vocabularies/document-source-maps#value": "true"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
-"http://a.ml/vocabularies/document-source-maps#value": "[(47,25)-(49,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
-"http://a.ml/vocabularies/document-source-maps#value": "[(47,25)-(49,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example",
-"http://a.ml/vocabularies/document-source-maps#value": "[(47,14)-(49,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/tracked-element/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example",
-"http://a.ml/vocabularies/document-source-maps#value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2",
-"http://a.ml/vocabularies/document-source-maps#value": "[(67,24)-(67,30)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3",
-"http://a.ml/vocabularies/document-source-maps#value": "[(68,24)-(68,29)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4",
-"http://a.ml/vocabularies/document-source-maps#value": "[(69,25)-(69,32)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5",
-"http://a.ml/vocabularies/document-source-maps#value": "[(70,26)-(70,34)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6",
-"http://a.ml/vocabularies/document-source-maps#value": "[(71,25)-(71,32)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2",
-"http://a.ml/vocabularies/document-source-maps#value": "[(74,24)-(74,30)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3",
-"http://a.ml/vocabularies/document-source-maps#value": "[(75,24)-(75,29)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4",
-"http://a.ml/vocabularies/document-source-maps#value": "[(76,25)-(76,32)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5",
-"http://a.ml/vocabularies/document-source-maps#value": "[(77,26)-(77,34)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6",
-"http://a.ml/vocabularies/document-source-maps#value": "[(78,25)-(78,32)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(24,18)-(24,42)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#value",
-"http://a.ml/vocabularies/document-source-maps#value": "[(25,18)-(25,35)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1",
-"http://a.ml/vocabularies/document-source-maps#value": "[(23,25)-(26,17)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1",
-"http://a.ml/vocabularies/document-source-maps#value": "[(16,23)-(16,33)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#address",
-"http://a.ml/vocabularies/document-source-maps#value": "[(54,20)-(54,50)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(53,20)-(53,43)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#value",
-"http://a.ml/vocabularies/document-source-maps#value": "[(55,20)-(55,35)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1",
-"http://a.ml/vocabularies/document-source-maps#value": "[(52,27)-(56,19)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1",
-"http://a.ml/vocabularies/document-source-maps#value": "[(47,25)-(49,15)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(48,16)-(48,30)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2",
-"http://a.ml/vocabularies/document-source-maps#value": "[(24,26)-(24,42)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3",
-"http://a.ml/vocabularies/document-source-maps#value": "[(25,27)-(25,35)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2",
-"http://a.ml/vocabularies/document-source-maps#value": "[(53,28)-(53,43)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3",
-"http://a.ml/vocabularies/document-source-maps#value": "[(54,31)-(54,50)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4",
-"http://a.ml/vocabularies/document-source-maps#value": "[(55,29)-(55,35)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2",
-"http://a.ml/vocabularies/document-source-maps#value": "[(48,24)-(48,30)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json",
-"http://a.ml/vocabularies/document#declares": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org"
-}
-],
-"@type": [
-"http://a.ml/vocabularies/document#Document",
-"http://a.ml/vocabularies/document#Fragment",
-"http://a.ml/vocabularies/document#Module",
-"http://a.ml/vocabularies/document#Unit"
-],
-"http://a.ml/vocabularies/document#encodes": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api"
-},
-"http://a.ml/vocabularies/document#version": "2.1.0",
-"http://a.ml/vocabularies/document#root": true
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User",
-"@type": [
-"http://www.w3.org/ns/shacl#NodeShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#closed": false,
-"http://www.w3.org/ns/shacl#property": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname"
-}
-],
-"http://www.w3.org/ns/shacl#name": "User",
-"http://a.ml/vocabularies/apiContract#examples": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org",
-"@type": [
-"http://www.w3.org/ns/shacl#NodeShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#closed": false,
-"http://www.w3.org/ns/shacl#property": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value"
-}
-],
-"http://www.w3.org/ns/shacl#name": "Org",
-"http://a.ml/vocabularies/apiContract#examples": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name",
-"@type": [
-"http://www.w3.org/ns/shacl#PropertyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#path": [
-{
-"@id": "http://a.ml/vocabularies/data#name"
-}
-],
-"http://a.ml/vocabularies/shapes#range": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name"
-},
-"http://www.w3.org/ns/shacl#minCount": 0,
-"http://www.w3.org/ns/shacl#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname",
-"@type": [
-"http://www.w3.org/ns/shacl#PropertyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#path": [
-{
-"@id": "http://a.ml/vocabularies/data#lastname"
-}
-],
-"http://a.ml/vocabularies/shapes#range": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname"
-},
-"http://www.w3.org/ns/shacl#minCount": 0,
-"http://www.w3.org/ns/shacl#name": "lastname",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Example",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/document#strict": true,
-"http://a.ml/vocabularies/document#structuredValue": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1"
-},
-"http://a.ml/vocabularies/document#raw": "\"name\": \"Bob\"\n\"lastname\": \"Marley\"",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#declared-element": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/declared-element/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_2"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/type-property-lexical-info/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name",
-"@type": [
-"http://www.w3.org/ns/shacl#PropertyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#path": [
-{
-"@id": "http://a.ml/vocabularies/data#name"
-}
-],
-"http://a.ml/vocabularies/shapes#range": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name"
-},
-"http://www.w3.org/ns/shacl#minCount": 0,
-"http://www.w3.org/ns/shacl#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address",
-"@type": [
-"http://www.w3.org/ns/shacl#PropertyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#path": [
-{
-"@id": "http://a.ml/vocabularies/data#address"
-}
-],
-"http://a.ml/vocabularies/shapes#range": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address"
-},
-"http://www.w3.org/ns/shacl#minCount": 0,
-"http://www.w3.org/ns/shacl#name": "address",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value",
-"@type": [
-"http://www.w3.org/ns/shacl#PropertyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#path": [
-{
-"@id": "http://a.ml/vocabularies/data#value"
-}
-],
-"http://a.ml/vocabularies/shapes#range": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value"
-},
-"http://www.w3.org/ns/shacl#minCount": 0,
-"http://www.w3.org/ns/shacl#name": "value",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example",
-"@type": [
-"http://a.ml/vocabularies/apiContract#Example",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/document#strict": true,
-"http://a.ml/vocabularies/document#structuredValue": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1"
-},
-"http://a.ml/vocabularies/document#raw": "\"name\": \"Bob\"\n\"lastname\": \"Marley\"",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#declared-element": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/declared-element/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_3"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_2"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/type-property-lexical-info/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": "lastname",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1",
-"@type": [
-"http://a.ml/vocabularies/data#Object",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#name": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2"
-},
-"http://a.ml/vocabularies/data#lastname": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3"
-},
-"http://a.ml/vocabularies/core#name": "object_1",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/synthesized-field/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_1"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/declared-element/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User",
-"http://a.ml/vocabularies/document-source-maps#value": ""
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(88,4)-(88,10)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#property",
-"http://a.ml/vocabularies/document-source-maps#value": "[(90,6)-(97,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
-"http://a.ml/vocabularies/document-source-maps#value": "[(98,6)-(101,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User",
-"http://a.ml/vocabularies/document-source-maps#value": "[(88,4)-(102,5)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/type-property-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User",
-"http://a.ml/vocabularies/document-source-maps#value": "[(89,6)-(89,12)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": "address",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://a.ml/vocabularies/shapes#AnyShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": "value",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1",
-"@type": [
-"http://a.ml/vocabularies/data#Object",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#name": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2"
-},
-"http://a.ml/vocabularies/data#lastname": {
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3"
-},
-"http://a.ml/vocabularies/core#name": "object_1",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/synthesized-field/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_1"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/declared-element/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org",
-"http://a.ml/vocabularies/document-source-maps#value": ""
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_3",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(103,4)-(103,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#property",
-"http://a.ml/vocabularies/document-source-maps#value": "[(105,6)-(115,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
-"http://a.ml/vocabularies/document-source-maps#value": "[(116,6)-(119,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org",
-"http://a.ml/vocabularies/document-source-maps#value": "[(103,4)-(120,5)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/type-property-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org",
-"http://a.ml/vocabularies/document-source-maps#value": "[(104,6)-(104,12)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/type-property-lexical-info/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(91,8)-(93,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/type-property-lexical-info/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname",
-"http://a.ml/vocabularies/document-source-maps#value": "[(94,8)-(96,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Bob",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Marley",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "lastname",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_1"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/synthesized-field/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
-"http://a.ml/vocabularies/document-source-maps#value": "true"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
-"http://a.ml/vocabularies/document-source-maps#value": "[(98,17)-(101,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
-"http://a.ml/vocabularies/document-source-maps#value": "[(98,17)-(101,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example",
-"http://a.ml/vocabularies/document-source-maps#value": "[(98,6)-(101,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/type-property-lexical-info/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(106,8)-(108,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/type-property-lexical-info/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address",
-"http://a.ml/vocabularies/document-source-maps#value": "[(109,8)-(111,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/type-property-lexical-info/element_0"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/lexical/element_1"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value",
-"http://a.ml/vocabularies/document-source-maps#value": "[(112,8)-(114,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Bob",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "name",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "Marley",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "lastname",
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3/source-map"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_2"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_0"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_1"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/synthesized-field/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
-"http://a.ml/vocabularies/document-source-maps#value": "true"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
-"http://a.ml/vocabularies/document-source-maps#value": "[(116,17)-(119,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
-"http://a.ml/vocabularies/document-source-maps#value": "[(116,17)-(119,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example",
-"http://a.ml/vocabularies/document-source-maps#value": "[(116,6)-(119,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/type-property-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(92,10)-(92,16)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(91,8)-(93,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-"http://a.ml/vocabularies/document-source-maps#value": "[(92,10)-(92,26)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/type-property-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname",
-"http://a.ml/vocabularies/document-source-maps#value": "[(95,10)-(95,16)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname",
-"http://a.ml/vocabularies/document-source-maps#value": "[(94,8)-(96,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-"http://a.ml/vocabularies/document-source-maps#value": "[(95,10)-(95,26)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(99,21)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#lastname",
-"http://a.ml/vocabularies/document-source-maps#value": "[(100,8)-(100,28)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1",
-"http://a.ml/vocabularies/document-source-maps#value": "[(98,17)-(101,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/type-property-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(107,10)-(107,16)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(106,8)-(108,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-"http://a.ml/vocabularies/document-source-maps#value": "[(107,10)-(107,26)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/type-property-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address",
-"http://a.ml/vocabularies/document-source-maps#value": "[(110,10)-(110,16)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address",
-"http://a.ml/vocabularies/document-source-maps#value": "[(109,8)-(111,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-"http://a.ml/vocabularies/document-source-maps#value": "[(110,10)-(110,26)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/type-property-lexical-info/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value",
-"http://a.ml/vocabularies/document-source-maps#value": "[(113,10)-(113,16)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value",
-"http://a.ml/vocabularies/document-source-maps#value": "[(112,8)-(114,9)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-"http://a.ml/vocabularies/document-source-maps#value": "[(113,10)-(113,26)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3/source-map/lexical/element_0"
-}
-]
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_2",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
-"http://a.ml/vocabularies/document-source-maps#value": "[(117,8)-(117,21)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#lastname",
-"http://a.ml/vocabularies/document-source-maps#value": "[(118,8)-(118,28)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_1",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1",
-"http://a.ml/vocabularies/document-source-maps#value": "[(116,17)-(119,7)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2",
-"http://a.ml/vocabularies/document-source-maps#value": "[(99,16)-(99,21)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3",
-"http://a.ml/vocabularies/document-source-maps#value": "[(100,20)-(100,28)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2",
-"http://a.ml/vocabularies/document-source-maps#value": "[(117,16)-(117,21)]"
-},
-{
-"@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3/source-map/lexical/element_0",
-"http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3",
-"http://a.ml/vocabularies/document-source-maps#value": "[(118,20)-(118,28)]"
-}
-]
+  "@graph": [
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#WebAPI",
+        "http://a.ml/vocabularies/document#RootDomainElement",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "API with Examples",
+      "http://a.ml/vocabularies/core#version": "1.0",
+      "http://a.ml/vocabularies/apiContract#endpoint": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#EndPoint",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#path": "/organization",
+      "http://a.ml/vocabularies/apiContract#supportedOperation": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#source-vendor": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/source-vendor/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_2"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#method": "post",
+      "http://a.ml/vocabularies/apiContract#expects": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#returns": [],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#method": "get",
+      "http://a.ml/vocabularies/core#description": "Returns an organization entity.",
+      "http://a.ml/vocabularies/apiContract#returns": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/source-vendor/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api",
+      "http://a.ml/vocabularies/document-source-maps#value": "OAS 2.0"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(5,4)-(5,20)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(4,4)-(4,32)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#endpoint",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(7,11)-(86,3)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(122,1)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Request",
+        "http://a.ml/vocabularies/apiContract#Message",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#payload": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#header": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/apiContract#Message",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#statusCode": "201",
+      "http://a.ml/vocabularies/core#name": "201",
+      "http://a.ml/vocabularies/core#description": "",
+      "http://a.ml/vocabularies/apiContract#payload": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#examples": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(8,4)-(85,5)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "bodyParam",
+      "http://a.ml/vocabularies/core#mediaType": "application/json",
+      "http://a.ml/vocabularies/shapes#schema": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam"
+      },
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Parameter",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "UserID",
+      "http://a.ml/vocabularies/apiContract#paramName": "UserID",
+      "http://a.ml/vocabularies/core#description": "description: the identifier for the user who posts a new organization",
+      "http://a.ml/vocabularies/apiContract#required": false,
+      "http://a.ml/vocabularies/apiContract#binding": "header",
+      "http://a.ml/vocabularies/shapes#schema": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema"
+      },
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#expects",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(9,6)-(39,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(38,8)-(38,23)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#mediaType": "application/json",
+      "http://a.ml/vocabularies/shapes#schema": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default"
+      },
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Example",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "application/json",
+      "http://a.ml/vocabularies/document#strict": false,
+      "http://a.ml/vocabularies/core#mediaType": "application/json",
+      "http://a.ml/vocabularies/document#structuredValue": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1"
+      },
+      "http://a.ml/vocabularies/document#raw": "\"name\": \"Puma\"\n\"type\": \"Dog\"\n\"color\": \"Black\"\n\"gender\": \"Female\"\n\"breed\": \"Mixed\"",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Example",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "application/xml",
+      "http://a.ml/vocabularies/document#strict": false,
+      "http://a.ml/vocabularies/core#mediaType": "application/xml",
+      "http://a.ml/vocabularies/document#structuredValue": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1"
+      },
+      "http://a.ml/vocabularies/document#raw": "\"name\": \"Puma\"\n\"type\": \"Dog\"\n\"color\": \"Black\"\n\"gender\": \"Female\"\n\"breed\": \"Mixed\"",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(41,8)-(41,56)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(42,8)-(83,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(40,6)-(84,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#closed": false,
+      "http://www.w3.org/ns/shacl#name": "bodyParam",
+      "http://www.w3.org/ns/shacl#and": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#examples": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#body-parameter": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/body-parameter/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_2"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "schema",
+      "http://a.ml/vocabularies/core#description": "description: the identifier for the user who posts a new organization",
+      "http://a.ml/vocabularies/apiContract#examples": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_5"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_4"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(10,8)-(37,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#header",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(10,8)-(37,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(9,14)-(39,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#closed": false,
+      "http://www.w3.org/ns/shacl#name": "default",
+      "http://www.w3.org/ns/shacl#and": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0"
+        }
+      ],
+      "http://a.ml/vocabularies/apiContract#examples": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2"
+      },
+      "http://a.ml/vocabularies/data#type": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3"
+      },
+      "http://a.ml/vocabularies/data#color": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4"
+      },
+      "http://a.ml/vocabularies/data#gender": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5"
+      },
+      "http://a.ml/vocabularies/data#breed": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_1"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/tracked-element/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2"
+      },
+      "http://a.ml/vocabularies/data#type": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3"
+      },
+      "http://a.ml/vocabularies/data#color": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4"
+      },
+      "http://a.ml/vocabularies/data#gender": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5"
+      },
+      "http://a.ml/vocabularies/data#breed": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_1"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/tracked-element/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(81,12)-(81,29)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(65,12)-(80,13)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(43,10)-(82,11)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/document#link-target": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org"
+        }
+      ],
+      "http://a.ml/vocabularies/document#link-label": "Org",
+      "http://a.ml/vocabularies/document#recursive": true,
+      "http://www.w3.org/ns/shacl#name": "item0",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Example",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/document#strict": true,
+      "http://a.ml/vocabularies/document#structuredValue": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1"
+      },
+      "http://a.ml/vocabularies/document#raw": "\"name\": \"Doe Enterprise\"\n\"value\": \"Silver\"",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#parameter-binding-in-body-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/parameter-binding-in-body-lexical-info/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_2"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/type-property-lexical-info/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/body-parameter/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#mediaType",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(34,12)-(34,49)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(19,12)-(19,31)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(20,12)-(33,13)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(18,10)-(36,11)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Example",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/document#strict": true,
+      "http://a.ml/vocabularies/document#structuredValue": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1"
+      },
+      "http://a.ml/vocabularies/document#raw": "SWED-123",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/type-property-lexical-info/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_2"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_5",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(15,12)-(15,26)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(11,10)-(17,11)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(14,12)-(14,98)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(11,10)-(17,11)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(13,12)-(13,28)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(13,12)-(13,28)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/document#link-target": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org"
+        }
+      ],
+      "http://a.ml/vocabularies/document#link-label": "Org",
+      "http://a.ml/vocabularies/document#recursive": true,
+      "http://www.w3.org/ns/shacl#name": "item0",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Example",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "softwareCorp",
+      "http://a.ml/vocabularies/document#strict": true,
+      "http://a.ml/vocabularies/document#structuredValue": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1"
+      },
+      "http://a.ml/vocabularies/document#raw": "\"name\": \"Software Corp\"\n\"address\": \"35 Central Street\"\n\"value\": \"Gold\"",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Example",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/document#strict": true,
+      "http://a.ml/vocabularies/document#structuredValue": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1"
+      },
+      "http://a.ml/vocabularies/document#raw": "\"name\": \"Acme\"",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#auto-generated-name": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/auto-generated-name/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_1"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/type-property-lexical-info/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#mediaType",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(44,12)-(44,49)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(45,12)-(64,13)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(45,12)-(64,13)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Puma",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Dog",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "type",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Black",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "color",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Female",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "gender",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Mixed",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "breed",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_5"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_4"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(66,34)-(72,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(66,34)-(72,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(66,14)-(72,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/source-map/tracked-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson",
+      "http://a.ml/vocabularies/document-source-maps#value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Puma",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Dog",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "type",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Black",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "color",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Female",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "gender",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Mixed",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "breed",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_5"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_4"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(73,33)-(79,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(73,33)-(79,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(73,14)-(79,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/source-map/tracked-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml",
+      "http://a.ml/vocabularies/document-source-maps#value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2"
+      },
+      "http://a.ml/vocabularies/data#value": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_1"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/tracked-element/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/parameter-binding-in-body-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(35,12)-(35,24)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#and",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(28,23)-(32,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(19,12)-(19,31)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(22,14)-(27,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(20,12)-(33,13)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(21,14)-(21,20)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "SWED-123",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "scalar_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(12,12)-(12,18)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(14,12)-(14,98)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(12,12)-(12,28)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(16,12)-(16,33)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(11,10)-(17,11)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2"
+      },
+      "http://a.ml/vocabularies/data#address": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3"
+      },
+      "http://a.ml/vocabularies/data#value": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_2"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/tracked-element/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_1"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#tracked-element": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/tracked-element/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/auto-generated-name/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#and",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(59,23)-(63,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(50,14)-(58,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(45,12)-(64,13)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(46,14)-(46,20)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_5",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#gender",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(70,16)-(70,34)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(66,34)-(72,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#color",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(69,16)-(69,32)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#breed",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(71,16)-(71,32)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(67,16)-(67,30)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#type",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(68,16)-(68,29)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_5",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#gender",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(77,16)-(77,34)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(73,33)-(79,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#color",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(76,16)-(76,32)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#breed",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(78,16)-(78,32)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(74,16)-(74,30)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#type",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(75,16)-(75,29)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/and/0/item0",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(29,16)-(31,17)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Doe Enterprise",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Silver",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "value",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,25)-(26,17)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,25)-(26,17)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(22,14)-(27,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/source-map/tracked-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example",
+      "http://a.ml/vocabularies/document-source-maps#value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(16,23)-(16,33)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(16,23)-(16,33)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(16,23)-(16,33)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/and/0/item0",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(60,16)-(62,17)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Software Corp",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "35 Central Street",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "address",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Gold",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "value",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_2"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(52,27)-(56,19)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(51,16)-(57,17)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(52,27)-(56,19)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(51,16)-(57,17)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/source-map/tracked-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp",
+      "http://a.ml/vocabularies/document-source-maps#value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Acme",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(47,25)-(49,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(47,25)-(49,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(47,14)-(49,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/source-map/tracked-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example",
+      "http://a.ml/vocabularies/document-source-maps#value": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_2",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(67,24)-(67,30)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_3",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(68,24)-(68,29)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_4",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(69,25)-(69,32)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_5",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(70,26)-(70,34)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fjson/object_1/scalar_6",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(71,25)-(71,32)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_2",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(74,24)-(74,30)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_3",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(75,24)-(75,29)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_4",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(76,25)-(76,32)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_5",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(77,26)-(77,34)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/example/application%2Fxml/object_1/scalar_6",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(78,25)-(78,32)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(24,18)-(24,42)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#value",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(25,18)-(25,35)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,25)-(26,17)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/parameter/UserID/scalar/schema/example/default-example/scalar_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(16,23)-(16,33)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#address",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(54,20)-(54,50)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(53,20)-(53,43)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#value",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(55,20)-(55,35)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(52,27)-(56,19)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(47,25)-(49,15)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(48,16)-(48,30)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_2",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(24,26)-(24,42)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/post/request/application%2Fjson/bodyParam/example/default-example/object_1/scalar_3",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(25,27)-(25,35)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_2",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(53,28)-(53,43)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_3",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(54,31)-(54,50)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/softwareCorp/object_1/scalar_4",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(55,29)-(55,35)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api/end-points/%2Forganization/get/201/application%2Fjson/default/example/default-example/object_1/scalar_2",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(48,24)-(48,30)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json",
+      "http://a.ml/vocabularies/document#declares": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org"
+        }
+      ],
+      "@type": [
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#encodes": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/web-api"
+      },
+      "http://a.ml/vocabularies/document#version": "2.1.0",
+      "http://a.ml/vocabularies/document#root": true
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#closed": false,
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "User",
+      "http://a.ml/vocabularies/apiContract#examples": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#closed": false,
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "Org",
+      "http://a.ml/vocabularies/apiContract#examples": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#name"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name"
+      },
+      "http://www.w3.org/ns/shacl#minCount": 0,
+      "http://www.w3.org/ns/shacl#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#lastname"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname"
+      },
+      "http://www.w3.org/ns/shacl#minCount": 0,
+      "http://www.w3.org/ns/shacl#name": "lastname",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Example",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/document#strict": true,
+      "http://a.ml/vocabularies/document#structuredValue": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1"
+      },
+      "http://a.ml/vocabularies/document#raw": "\"name\": \"Bob\"\n\"lastname\": \"Marley\"",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#declared-element": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/declared-element/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_2"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/type-property-lexical-info/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#name"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name"
+      },
+      "http://www.w3.org/ns/shacl#minCount": 0,
+      "http://www.w3.org/ns/shacl#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#address"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address"
+      },
+      "http://www.w3.org/ns/shacl#minCount": 0,
+      "http://www.w3.org/ns/shacl#name": "address",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#value"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value"
+      },
+      "http://www.w3.org/ns/shacl#minCount": 0,
+      "http://www.w3.org/ns/shacl#name": "value",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Example",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/document#strict": true,
+      "http://a.ml/vocabularies/document#structuredValue": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1"
+      },
+      "http://a.ml/vocabularies/document#raw": "\"name\": \"Bob\"\n\"lastname\": \"Marley\"",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#declared-element": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/declared-element/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_2"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/type-property-lexical-info/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "lastname",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2"
+      },
+      "http://a.ml/vocabularies/data#lastname": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/declared-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(88,4)-(88,10)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#property",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(90,6)-(97,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(98,6)-(101,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(88,4)-(102,5)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(89,6)-(89,12)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "address",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "value",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2"
+      },
+      "http://a.ml/vocabularies/data#lastname": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/declared-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(103,4)-(103,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#property",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(105,6)-(115,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#examples",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(116,6)-(119,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(103,4)-(120,5)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(104,6)-(104,12)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/type-property-lexical-info/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(91,8)-(93,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/type-property-lexical-info/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(94,8)-(96,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Bob",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Marley",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "lastname",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(98,17)-(101,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(98,17)-(101,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(98,6)-(101,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/type-property-lexical-info/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(106,8)-(108,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/type-property-lexical-info/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(109,8)-(111,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/type-property-lexical-info/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(112,8)-(114,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Bob",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Marley",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "lastname",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#structuredValue",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(116,17)-(119,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(116,17)-(119,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(116,6)-(119,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(92,10)-(92,16)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(91,8)-(93,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/name/scalar/name/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(92,10)-(92,26)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(95,10)-(95,16)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(94,8)-(96,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/property/lastname/scalar/lastname/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(95,10)-(95,26)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(99,8)-(99,21)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#lastname",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(100,8)-(100,28)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(98,17)-(101,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(107,10)-(107,16)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(106,8)-(108,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/name/scalar/name/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(107,10)-(107,26)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(110,10)-(110,16)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(109,8)-(111,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/address/scalar/address/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(110,10)-(110,26)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(113,10)-(113,16)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(112,8)-(114,9)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/property/value/scalar/value/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(113,10)-(113,26)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(117,8)-(117,21)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#lastname",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(118,8)-(118,28)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(116,17)-(119,7)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_2",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(99,16)-(99,21)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/User/example/default-example/object_1/scalar_3",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(100,20)-(100,28)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_2",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(117,16)-(117,21)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/examples.json#/declarations/types/Org/example/default-example/object_1/scalar_3",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(118,20)-(118,28)]"
+    }
+  ]
 }

--- a/amf-client/shared/src/test/resources/validations/ref-from-allof-facet/api.json
+++ b/amf-client/shared/src/test/resources/validations/ref-from-allof-facet/api.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "0.1",
+    "title": "AES Key Synchronisation",
+    "description": "A REST API for the exchange and synchronisation of AES Keys following the OpenAPI 3.0 specification"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "OmsKey": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewOmsKey"
+          },
+          {
+            "properties": {
+              "id": {
+                "type": "integer"
+              }
+            }
+          }
+        ]
+      },
+      "NewOmsKey": {
+        "properties": {
+          "deviceId": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/validations/ref-from-allof-facet/result.expanded.jsonld
+++ b/amf-client/shared/src/test/resources/validations/ref-from-allof-facet/result.expanded.jsonld
@@ -1,0 +1,374 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#10",
+        "@type": [
+          "apiContract:WebAPI",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "AES Key Synchronisation"
+          }
+        ],
+        "core:description": [
+          {
+            "@value": "A REST API for the exchange and synchronisation of AES Keys following the OpenAPI 3.0 specification"
+          }
+        ],
+        "core:version": [
+          {
+            "@value": "0.1"
+          }
+        ],
+        "smaps": {
+          "source-vendor": {
+            "#10": "OAS 3.0"
+          },
+          "lexical": {
+            "core:version": "[(4,4)-(4,20)]",
+            "core:name": "[(5,4)-(5,38)]",
+            "#10": "[(1,0)-(34,1)]",
+            "core:description": "[(6,4)-(6,120)]"
+          }
+        }
+      }
+    ],
+    "doc:version": [
+      {
+        "@value": "2.1.0"
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#1",
+        "@type": [
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:name": [
+          {
+            "@value": "OmsKey"
+          }
+        ],
+        "shacl:and": [
+          {
+            "@id": "#2",
+            "@type": [
+              "shacl:NodeShape",
+              "raml-shapes:AnyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:closed": [
+              {
+                "@value": false
+              }
+            ],
+            "shacl:property": [
+              {
+                "@id": "#3",
+                "@type": [
+                  "shacl:PropertyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#deviceId"
+                  }
+                ],
+                "raml-shapes:range": [
+                  {
+                    "@id": "#4",
+                    "@type": [
+                      "raml-shapes:ScalarShape",
+                      "raml-shapes:AnyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "shacl:datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "deviceId"
+                      }
+                    ],
+                    "smaps": {
+                      "type-property-lexical-info": {
+                        "#4": "[(28,12)-(28,18)]"
+                      },
+                      "lexical": {
+                        "shacl:datatype": "[(28,12)-(28,28)]",
+                        "#4": "[(27,10)-(29,11)]"
+                      }
+                    }
+                  }
+                ],
+                "shacl:minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "deviceId"
+                  }
+                ],
+                "smaps": {
+                  "lexical": {
+                    "#3": "[(27,10)-(29,11)]"
+                  }
+                }
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "NewOmsKey"
+              }
+            ],
+            "smaps": {
+              "resolved-link-target": {
+                "#2": "amf://id#6"
+              },
+              "declared-element": {
+                "#2": ""
+              },
+              "lexical": {
+                "shacl:name": "[(25,6)-(25,17)]",
+                "#2": "[(25,6)-(31,7)]"
+              },
+              "resolved-link": {
+                "#2": "amf://id#5"
+              }
+            }
+          },
+          {
+            "@id": "#7",
+            "@type": [
+              "shacl:NodeShape",
+              "raml-shapes:AnyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:closed": [
+              {
+                "@value": false
+              }
+            ],
+            "shacl:property": [
+              {
+                "@id": "#8",
+                "@type": [
+                  "shacl:PropertyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#id"
+                  }
+                ],
+                "raml-shapes:range": [
+                  {
+                    "@id": "#9",
+                    "@type": [
+                      "raml-shapes:ScalarShape",
+                      "raml-shapes:AnyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "shacl:datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                      }
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "id"
+                      }
+                    ],
+                    "smaps": {
+                      "type-property-lexical-info": {
+                        "#9": "[(19,16)-(19,22)]"
+                      },
+                      "lexical": {
+                        "shacl:datatype": "[(19,16)-(19,33)]",
+                        "#9": "[(18,14)-(20,15)]"
+                      }
+                    }
+                  }
+                ],
+                "shacl:minCount": [
+                  {
+                    "@value": 0
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "id"
+                  }
+                ],
+                "smaps": {
+                  "lexical": {
+                    "#8": "[(18,14)-(20,15)]"
+                  }
+                }
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "item1"
+              }
+            ],
+            "smaps": {
+              "lexical": {
+                "#7": "[(16,10)-(22,11)]"
+              }
+            }
+          }
+        ],
+        "smaps": {
+          "declared-element": {
+            "#1": ""
+          },
+          "lexical": {
+            "shacl:and": "[(12,17)-(23,9)]",
+            "#1": "[(11,6)-(24,7)]",
+            "shacl:name": "[(11,6)-(11,14)]"
+          }
+        }
+      },
+      {
+        "@id": "#2",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:closed": [
+          {
+            "@value": false
+          }
+        ],
+        "shacl:property": [
+          {
+            "@id": "#3",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#deviceId"
+              }
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#4",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "deviceId"
+                  }
+                ],
+                "smaps": {
+                  "type-property-lexical-info": {
+                    "#4": "[(28,12)-(28,18)]"
+                  },
+                  "lexical": {
+                    "shacl:datatype": "[(28,12)-(28,28)]",
+                    "#4": "[(27,10)-(29,11)]"
+                  }
+                }
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "deviceId"
+              }
+            ],
+            "smaps": {
+              "lexical": {
+                "#3": "[(27,10)-(29,11)]"
+              }
+            }
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "NewOmsKey"
+          }
+        ],
+        "smaps": {
+          "resolved-link-target": {
+            "#2": "amf://id#6"
+          },
+          "declared-element": {
+            "#2": ""
+          },
+          "lexical": {
+            "shacl:name": "[(25,6)-(25,17)]",
+            "#2": "[(25,6)-(31,7)]"
+          },
+          "resolved-link": {
+            "#2": "amf://id#5"
+          }
+        }
+      }
+    ],
+    "@context": {
+      "@base": "amf://id",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-client/shared/src/test/resources/validations/ref-from-allof-facet/result.flattened.jsonld
+++ b/amf-client/shared/src/test/resources/validations/ref-from-allof-facet/result.flattened.jsonld
@@ -1,0 +1,236 @@
+{
+  "@graph": [
+    {
+      "@id": "#10",
+      "@type": [
+        "apiContract:WebAPI",
+        "doc:RootDomainElement",
+        "doc:DomainElement"
+      ],
+      "core:name": "AES Key Synchronisation",
+      "core:description": "A REST API for the exchange and synchronisation of AES Keys following the OpenAPI 3.0 specification",
+      "core:version": "0.1",
+      "smaps": {
+        "source-vendor": {
+          "#10": "OAS 3.0"
+        },
+        "lexical": {
+          "core:version": "[(4,4)-(4,20)]",
+          "core:name": "[(5,4)-(5,38)]",
+          "#10": "[(1,0)-(34,1)]",
+          "core:description": "[(6,4)-(6,120)]"
+        }
+      }
+    },
+    {
+      "@id": "",
+      "doc:declares": [
+        {
+          "@id": "#1"
+        },
+        {
+          "@id": "#2"
+        }
+      ],
+      "@type": [
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "doc:encodes": {
+        "@id": "#10"
+      },
+      "doc:version": "2.1.0",
+      "doc:root": true
+    },
+    {
+      "@id": "#1",
+      "@type": [
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:name": "OmsKey",
+      "shacl:and": [
+        {
+          "@id": "#2"
+        },
+        {
+          "@id": "#7"
+        }
+      ],
+      "smaps": {
+        "declared-element": {
+          "#1": ""
+        },
+        "lexical": {
+          "shacl:and": "[(12,17)-(23,9)]",
+          "#1": "[(11,6)-(24,7)]",
+          "shacl:name": "[(11,6)-(11,14)]"
+        }
+      }
+    },
+    {
+      "@id": "#2",
+      "@type": [
+        "shacl:NodeShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:closed": false,
+      "shacl:property": [
+        {
+          "@id": "#3"
+        }
+      ],
+      "shacl:name": "NewOmsKey",
+      "smaps": {
+        "resolved-link-target": {
+          "#2": "amf://id#6"
+        },
+        "declared-element": {
+          "#2": ""
+        },
+        "lexical": {
+          "shacl:name": "[(25,6)-(25,17)]",
+          "#2": "[(25,6)-(31,7)]"
+        },
+        "resolved-link": {
+          "#2": "amf://id#5"
+        }
+      }
+    },
+    {
+      "@id": "#7",
+      "@type": [
+        "shacl:NodeShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:closed": false,
+      "shacl:property": [
+        {
+          "@id": "#8"
+        }
+      ],
+      "shacl:name": "item1",
+      "smaps": {
+        "lexical": {
+          "#7": "[(16,10)-(22,11)]"
+        }
+      }
+    },
+    {
+      "@id": "#3",
+      "@type": [
+        "shacl:PropertyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#deviceId"
+        }
+      ],
+      "raml-shapes:range": {
+        "@id": "#4"
+      },
+      "shacl:minCount": 0,
+      "shacl:name": "deviceId",
+      "smaps": {
+        "lexical": {
+          "#3": "[(27,10)-(29,11)]"
+        }
+      }
+    },
+    {
+      "@id": "#8",
+      "@type": [
+        "shacl:PropertyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#id"
+        }
+      ],
+      "raml-shapes:range": {
+        "@id": "#9"
+      },
+      "shacl:minCount": 0,
+      "shacl:name": "id",
+      "smaps": {
+        "lexical": {
+          "#8": "[(18,14)-(20,15)]"
+        }
+      }
+    },
+    {
+      "@id": "#4",
+      "@type": [
+        "raml-shapes:ScalarShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "shacl:name": "deviceId",
+      "smaps": {
+        "type-property-lexical-info": {
+          "#4": "[(28,12)-(28,18)]"
+        },
+        "lexical": {
+          "shacl:datatype": "[(28,12)-(28,28)]",
+          "#4": "[(27,10)-(29,11)]"
+        }
+      }
+    },
+    {
+      "@id": "#9",
+      "@type": [
+        "raml-shapes:ScalarShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#integer"
+        }
+      ],
+      "shacl:name": "id",
+      "smaps": {
+        "type-property-lexical-info": {
+          "#9": "[(19,16)-(19,22)]"
+        },
+        "lexical": {
+          "shacl:datatype": "[(19,16)-(19,33)]",
+          "#9": "[(18,14)-(20,15)]"
+        }
+      }
+    }
+  ],
+  "@context": {
+    "@base": "amf://id",
+    "shacl": "http://www.w3.org/ns/shacl#",
+    "raml-shapes": "http://a.ml/vocabularies/shapes#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "apiContract": "http://a.ml/vocabularies/apiContract#",
+    "core": "http://a.ml/vocabularies/core#"
+  }
+}

--- a/amf-client/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
@@ -762,6 +762,18 @@ class EditingResolutionTest extends ResolutionTest {
     )
   }
 
+  multiGoldenTest("reference to declared schema from allOf facet", "result.%s") { config =>
+    cycle(
+      "api.json",
+      config.golden,
+      OasJsonHint,
+      target = Amf,
+      directory = validationsPath + "ref-from-allof-facet/",
+      transformWith = Some(Oas30),
+      renderOptions = Some(config.renderOptions)
+    )
+  }
+
   override def render(unit: BaseUnit, config: CycleConfig, useAmfJsonldSerialization: Boolean): Future[String] = {
     new AMFRenderer(unit, config.target, defaultRenderOptions, config.syntax).renderToString
   }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/OasTypeParser.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/OasTypeParser.scala
@@ -462,7 +462,7 @@ case class OasTypeParser(entryOrNode: Either[YMapEntry, YNode],
                 .map {
                   case (node, index) =>
                     val entry = YMapEntry(YNode(s"item$index"), node)
-                    OasTypeParser(entry, item => if (!item.isLink) item.adopted(shape.id + "/or/" + index), version)
+                    OasTypeParser(entry, item => item.adopted(shape.id + "/or/" + index), version)
                       .parse()
                 }
                 .filter(_.isDefined)
@@ -492,7 +492,7 @@ case class OasTypeParser(entryOrNode: Either[YMapEntry, YNode],
                 .map {
                   case (node, index) =>
                     val entry = YMapEntry(YNode(s"item$index"), node)
-                    OasTypeParser(entry, item => if (!item.isLink) item.adopted(shape.id + "/and/" + index), version)
+                    OasTypeParser(entry, item => item.adopted(shape.id + "/and/" + index), version)
                       .parse()
                 }
                 .filter(_.isDefined)
@@ -514,29 +514,26 @@ case class OasTypeParser(entryOrNode: Either[YMapEntry, YNode],
 
     def parse(): Unit = {
       map.key(
-        "oneOf", {
-          entry =>
-            adopt(shape)
-            entry.value.to[Seq[YNode]] match {
-              case Right(seq) =>
-                val nodes = seq.zipWithIndex
-                  .map {
-                    case (node, index) =>
-                      val entry = YMapEntry(YNode(s"item$index"), node)
-                      OasTypeParser(entry,
-                                    item => if (!item.isLink) item.adopted(shape.id + "/xone/" + index),
-                                    version).parse()
-                  }
-                  .filter(_.isDefined)
-                  .map(_.get)
-                shape.setArrayWithoutId(ShapeModel.Xone, nodes, Annotations(entry.value))
-              case _ =>
-                ctx.eh.violation(InvalidXoneType,
-                                 shape.id,
-                                 "Xone constraints are built from multiple shape nodes",
-                                 entry.value)
+        "oneOf", { entry =>
+          adopt(shape)
+          entry.value.to[Seq[YNode]] match {
+            case Right(seq) =>
+              val nodes = seq.zipWithIndex
+                .map {
+                  case (node, index) =>
+                    val entry = YMapEntry(YNode(s"item$index"), node)
+                    OasTypeParser(entry, item => item.adopted(shape.id + "/xone/" + index), version).parse()
+                }
+                .filter(_.isDefined)
+                .map(_.get)
+              shape.setArrayWithoutId(ShapeModel.Xone, nodes, Annotations(entry.value))
+            case _ =>
+              ctx.eh.violation(InvalidXoneType,
+                               shape.id,
+                               "Xone constraints are built from multiple shape nodes",
+                               entry.value)
 
-            }
+          }
         }
       )
     }


### PR DESCRIPTION
This issue have the same objetive as the changes made for APIMF-2183.
In the first approach a bug was introduced as some links where left with no id (due to the logic of adoption in OasTypeParser). This change is more general and will insure no duplicate ids are generated from incorrect adoptions.