### PR TITLE
APIMF-1996: add apiKey type validations as warnings

### DIFF
--- a/amf-client/shared/src/test/resources/validations/oas2/security/invalid-apikey-type.json
+++ b/amf-client/shared/src/test/resources/validations/oas2/security/invalid-apikey-type.json
@@ -1,0 +1,13 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1",
+    "title": "test"
+  },
+  "paths": {},
+  "securityDefinitions": {
+    "Bearer": {
+      "type": "apiKey"
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/validations/reports/oas2/invalid-apikey-type.report
+++ b/amf-client/shared/src/test/resources/validations/reports/oas2/invalid-apikey-type.report
@@ -1,0 +1,22 @@
+Model: file://amf-client/shared/src/test/resources/validations/oas2/security/invalid-apikey-type.json
+Profile: OAS 2.0
+Conforms? true
+Number of results: 2
+
+Level: Warning
+
+- Source: http://a.ml/vocabularies/amf/aml#closed-shape-warning
+  Message: Property 'in' is required in a OAS 2.0 apiKey node
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/oas2/security/invalid-apikey-type.json#/declarations/securitySchemes/Bearer
+  Property: 
+  Position: Some(LexicalInformation([(9,14)-(11,5)]))
+  Location: file://amf-client/shared/src/test/resources/validations/oas2/security/invalid-apikey-type.json
+
+- Source: http://a.ml/vocabularies/amf/aml#closed-shape-warning
+  Message: Property 'name' is required in a OAS 2.0 apiKey node
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/oas2/security/invalid-apikey-type.json#/declarations/securitySchemes/Bearer
+  Property: 
+  Position: Some(LexicalInformation([(9,14)-(11,5)]))
+  Location: file://amf-client/shared/src/test/resources/validations/oas2/security/invalid-apikey-type.json

--- a/amf-client/shared/src/test/scala/amf/validation/Oas20UniquePlatformUnitValidationsTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/Oas20UniquePlatformUnitValidationsTest.scala
@@ -41,6 +41,10 @@ class Oas20UniquePlatformUnitValidationsTest extends UniquePlatformReportGenTest
     validate("security/invalid-security-scheme-type.json", Some("invalid-security-scheme-type.report"), Oas20Profile)
   }
 
+  test("apiKey security type missing in and name fields") {
+    validate("security/invalid-apikey-type.json", Some("invalid-apikey-type.report"), Oas20Profile)
+  }
+
   test("invalid ref inside paths object") {
     validate("invalid-ref-inside-paths-object.json", Some("invalid-ref-inside-paths-object.report"), Oas20Profile)
   }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/contexts/CustomClosedShapeContextDecorator.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/contexts/CustomClosedShapeContextDecorator.scala
@@ -4,10 +4,10 @@ import amf.core.model.domain.Shape
 import amf.core.remote.Vendor
 import amf.core.validation.SeverityLevels
 import amf.plugins.document.webapi.contexts.parser.{OasLikeSpecVersionFactory, OasLikeWebApiContext}
-import amf.plugins.document.webapi.parser.spec.SpecSyntax
+import amf.plugins.document.webapi.parser.spec.{CustomSyntax, SpecNode, SpecSyntax}
 import org.yaml.model.{YMap, YNode, YPart}
 
-class CustomClosedShapeContextDecorator(decorated: OasLikeWebApiContext, customSyntax: Map[String, SpecNode])
+class CustomClosedShapeContextDecorator(decorated: OasLikeWebApiContext, customSyntax: CustomSyntax)
     extends OasLikeWebApiContext(
       decorated.loc,
       decorated.refs,
@@ -62,10 +62,3 @@ class CustomClosedShapeContextDecorator(decorated: OasLikeWebApiContext, customS
   private def getAstEntry(ast: YMap, entry: String): YPart =
     ast.entries.find(yMapEntry => yMapEntry.key.asScalar.map(_.text).get == entry).get
 }
-
-case class SpecNode(
-    requiredFields: Set[SpecField] = Set(),
-    possibleFields: Set[String] = Set()
-)
-
-case class SpecField(name: String, severity: String = SeverityLevels.VIOLATION)

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/CustomSyntax.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/CustomSyntax.scala
@@ -1,0 +1,17 @@
+package amf.plugins.document.webapi.parser.spec
+
+import amf.core.validation.SeverityLevels
+
+trait CustomSyntax {
+  val nodes: Map[String, SpecNode]
+
+  def apply(shape: String): SpecNode   = nodes(shape)
+  def contains(shape: String): Boolean = nodes.contains(shape)
+}
+
+case class SpecNode(
+    requiredFields: Set[SpecField] = Set(),
+    possibleFields: Set[String] = Set()
+)
+
+case class SpecField(name: String, severity: String = SeverityLevels.VIOLATION)

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/OasSecuritySchemeParser.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/OasSecuritySchemeParser.scala
@@ -1,61 +1,15 @@
 package amf.plugins.document.webapi.parser.spec.declaration
 
 import amf.core.parser._
-import amf.core.validation.SeverityLevels
+import amf.plugins.document.webapi.contexts.CustomClosedShapeContextDecorator
 import amf.plugins.document.webapi.contexts.parser.OasLikeWebApiContext
-import amf.plugins.document.webapi.contexts.{CustomClosedShapeContextDecorator, SpecField, SpecNode}
+import amf.plugins.document.webapi.parser.spec.oas.OasCustomSyntax
 import amf.plugins.domain.webapi.models.security.SecurityScheme
 import org.yaml.model.{YMap, YPart}
 
 object Oas2SecuritySchemeParser {
   def apply(part: YPart, adopt: SecurityScheme => SecurityScheme)(implicit ctx: OasLikeWebApiContext) =
-    new Oas2SecuritySchemeParser(part, adopt)(new CustomClosedShapeContextDecorator(ctx, Oas2SecuritySchemeNodes))
-
-  val flowPossibleFields = Set(
-    "type",
-    "description",
-    "flow",
-    "scopes"
-  )
-
-  val Oas2SecuritySchemeNodes = Map(
-    "basic" -> SpecNode(
-      possibleFields = Set("type", "description")
-    ),
-    "oauth2" -> SpecNode(
-      requiredFields = Set(
-        SpecField("flow", SeverityLevels.WARNING),
-        SpecField("scopes", SeverityLevels.WARNING)
-      ),
-      possibleFields = Set(
-        "type",
-        "description",
-        "authorizationUrl",
-        "tokenUrl",
-        "flow",
-        "scopes",
-      )
-    ),
-    "implicit" -> SpecNode(
-      requiredFields = Set(SpecField("authorizationUrl", SeverityLevels.WARNING)),
-      possibleFields = flowPossibleFields
-    ),
-    "accessCode" -> SpecNode(
-      requiredFields = Set(
-        SpecField("authorizationUrl", SeverityLevels.WARNING),
-        SpecField("tokenUrl", SeverityLevels.WARNING)
-      ),
-      possibleFields = flowPossibleFields
-    ),
-    "application" -> SpecNode(
-      requiredFields = Set(SpecField("tokenUrl", SeverityLevels.WARNING)),
-      possibleFields = flowPossibleFields
-    ),
-    "password" -> SpecNode(
-      requiredFields = Set(SpecField("tokenUrl", SeverityLevels.WARNING)),
-      possibleFields = flowPossibleFields
-    )
-  )
+    new Oas2SecuritySchemeParser(part, adopt)(new CustomClosedShapeContextDecorator(ctx, OasCustomSyntax))
 }
 
 case class Oas2SecuritySchemeParser(part: YPart, adopt: SecurityScheme => SecurityScheme)(
@@ -75,7 +29,7 @@ case class Oas2SecuritySchemeParser(part: YPart, adopt: SecurityScheme => Securi
   }
 
   private def getSchemeType(map: YMap) = map.key("type").map(_.value.as[String]).collect {
-    case schemeType @ ("basic" | "oauth2") => schemeType
+    case schemeType @ ("basic" | "oauth2" | "apiKey") => schemeType
   }
 }
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/oas/OasCustomSyntax.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/oas/OasCustomSyntax.scala
@@ -1,0 +1,59 @@
+package amf.plugins.document.webapi.parser.spec.oas
+
+import amf.core.validation.SeverityLevels
+import amf.plugins.document.webapi.parser.spec.{CustomSyntax, SpecField, SpecNode}
+
+object OasCustomSyntax extends CustomSyntax {
+  val flowPossibleFields = Set(
+    "type",
+    "description",
+    "flow",
+    "scopes"
+  )
+
+  override val nodes: Map[String, SpecNode] = Map(
+    "basic" -> SpecNode(
+      possibleFields = Set("type", "description")
+    ),
+    "apiKey" -> SpecNode(
+      requiredFields = Set(
+        SpecField("in", SeverityLevels.WARNING),
+        SpecField("name", SeverityLevels.WARNING)
+      ),
+      possibleFields = Set("type", "description")
+    ),
+    "oauth2" -> SpecNode(
+      requiredFields = Set(
+        SpecField("flow", SeverityLevels.WARNING),
+        SpecField("scopes", SeverityLevels.WARNING)
+      ),
+      possibleFields = Set(
+        "type",
+        "description",
+        "authorizationUrl",
+        "tokenUrl",
+        "flow",
+        "scopes",
+      )
+    ),
+    "implicit" -> SpecNode(
+      requiredFields = Set(SpecField("authorizationUrl", SeverityLevels.WARNING)),
+      possibleFields = flowPossibleFields
+    ),
+    "accessCode" -> SpecNode(
+      requiredFields = Set(
+        SpecField("authorizationUrl", SeverityLevels.WARNING),
+        SpecField("tokenUrl", SeverityLevels.WARNING)
+      ),
+      possibleFields = flowPossibleFields
+    ),
+    "application" -> SpecNode(
+      requiredFields = Set(SpecField("tokenUrl", SeverityLevels.WARNING)),
+      possibleFields = flowPossibleFields
+    ),
+    "password" -> SpecNode(
+      requiredFields = Set(SpecField("tokenUrl", SeverityLevels.WARNING)),
+      possibleFields = flowPossibleFields
+    )
+  )
+}


### PR DESCRIPTION
Added validation of 'in' and 'name' fields when the security type is apiKey in OAS20. Moreover, I've refactored the code creating a trait and extracting the new CustomSyntax outside the parser to make it more scalable.