### PR TITLE
APIMF-2322: add warnings for missing required oauth1 fields

### DIFF
--- a/amf-client/shared/src/test/resources/validations/raml/oauth1/missing-authorizationUri-oauth1.raml
+++ b/amf-client/shared/src/test/resources/validations/raml/oauth1/missing-authorizationUri-oauth1.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: My Sample API
+
+securitySchemes:
+  oauth_1_0:
+    description: |
+      OAuth 1.0 continues to be supported for all API requests, but OAuth 2.0 is now preferred.
+    type: OAuth 1.0
+    settings:
+      requestTokenUri: https://api.mysampleapi.com/1/oauth/request_token
+      tokenCredentialsUri: https://api.mysampleapi.com/1/oauth/access_token
+      signatures: [ 'HMAC-SHA1', 'PLAINTEXT' ]

--- a/amf-client/shared/src/test/resources/validations/raml/oauth1/missing-requestTokenUri-oauth1.raml
+++ b/amf-client/shared/src/test/resources/validations/raml/oauth1/missing-requestTokenUri-oauth1.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: My Sample API
+
+securitySchemes:
+  oauth_1_0:
+    description: |
+      OAuth 1.0 continues to be supported for all API requests, but OAuth 2.0 is now preferred.
+    type: OAuth 1.0
+    settings:
+      authorizationUri: https://api.mysampleapi.com/1/oauth/authorize
+      tokenCredentialsUri: https://api.mysampleapi.com/1/oauth/access_token
+      signatures: [ 'HMAC-SHA1', 'PLAINTEXT' ]

--- a/amf-client/shared/src/test/resources/validations/raml/oauth1/missing-tokenCredentialsUri-oauth1.raml
+++ b/amf-client/shared/src/test/resources/validations/raml/oauth1/missing-tokenCredentialsUri-oauth1.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: My Sample API
+
+securitySchemes:
+  oauth_1_0:
+    description: |
+      OAuth 1.0 continues to be supported for all API requests, but OAuth 2.0 is now preferred.
+    type: OAuth 1.0
+    settings:
+      requestTokenUri: https://api.mysampleapi.com/1/oauth/request_token
+      authorizationUri: https://api.mysampleapi.com/1/oauth/authorize
+      signatures: [ 'HMAC-SHA1', 'PLAINTEXT' ]

--- a/amf-client/shared/src/test/resources/validations/reports/model/missing-authorizationUri-oauth1.report
+++ b/amf-client/shared/src/test/resources/validations/reports/model/missing-authorizationUri-oauth1.report
@@ -1,0 +1,14 @@
+Model: file://amf-client/shared/src/test/resources/validations/raml/oauth1/missing-authorizationUri-oauth1.raml
+Profile: RAML 1.0
+Conforms? true
+Number of results: 1
+
+Level: Warning
+
+- Source: http://a.ml/vocabularies/amf/parser#OAuth1Settings-authorizationUri-minCount
+  Message: authorizationUri is required when security type is OAuth 1.0
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/raml/oauth1/missing-authorizationUri-oauth1.raml#/declarations/securitySchemes/oauth_1_0/settings/oauth1
+  Property: http://a.ml/vocabularies/security#authorizationUri
+  Position: Some(LexicalInformation([(10,0)-(13,0)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/oauth1/missing-authorizationUri-oauth1.raml

--- a/amf-client/shared/src/test/resources/validations/reports/model/missing-requestTokenUri-oauth1.report
+++ b/amf-client/shared/src/test/resources/validations/reports/model/missing-requestTokenUri-oauth1.report
@@ -1,0 +1,14 @@
+Model: file://amf-client/shared/src/test/resources/validations/raml/oauth1/missing-requestTokenUri-oauth1.raml
+Profile: RAML 1.0
+Conforms? true
+Number of results: 1
+
+Level: Warning
+
+- Source: http://a.ml/vocabularies/amf/parser#OAuth1Settings-requestTokenUri-minCount
+  Message: requestTokenUri is required when security type is OAuth 1.0
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/raml/oauth1/missing-requestTokenUri-oauth1.raml#/declarations/securitySchemes/oauth_1_0/settings/oauth1
+  Property: http://a.ml/vocabularies/security#requestTokenUri
+  Position: Some(LexicalInformation([(10,0)-(13,0)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/oauth1/missing-requestTokenUri-oauth1.raml

--- a/amf-client/shared/src/test/resources/validations/reports/model/missing-tokenCredentialsUri-oauth1.report
+++ b/amf-client/shared/src/test/resources/validations/reports/model/missing-tokenCredentialsUri-oauth1.report
@@ -1,0 +1,14 @@
+Model: file://amf-client/shared/src/test/resources/validations/raml/oauth1/missing-tokenCredentialsUri-oauth1.raml
+Profile: RAML 1.0
+Conforms? true
+Number of results: 1
+
+Level: Warning
+
+- Source: http://a.ml/vocabularies/amf/parser#OAuth1Settings-tokenCredentialsUri-minCount
+  Message: tokenCredentialsUri is required when security type is OAuth 1.0
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/raml/oauth1/missing-tokenCredentialsUri-oauth1.raml#/declarations/securitySchemes/oauth_1_0/settings/oauth1
+  Property: http://a.ml/vocabularies/security#tokenCredentialsUri
+  Position: Some(LexicalInformation([(10,0)-(13,0)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/oauth1/missing-tokenCredentialsUri-oauth1.raml

--- a/amf-client/shared/src/test/scala/amf/validation/RamlExtendsValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/RamlExtendsValidationTest.scala
@@ -256,11 +256,11 @@ class RamlUniquePlatformExtendsValidationTest extends UniquePlatformReportGenTes
   }
 
   // Merging security schemes
-  test("Merging security schemes in RAML 0.8"){
+  test("Merging security schemes in RAML 0.8") {
     validate("extends/raml08-with-security-schemes-in-trait.raml")
   }
 
-  test("Merging security schemes in RAML 1.0"){
+  test("Merging security schemes in RAML 1.0") {
     validate("extends/raml10-with-security-schemes-in-trait.raml")
   }
 

--- a/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -454,6 +454,20 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
     validate("overlays/overlay-with-example-overloading/overlay.raml", None, Raml10Profile)
   }
 
+  // OAuth 1.0
+  test("Missing requestTokenUri field in OAuth 1.0 security type") {
+    validate("/raml/oauth1/missing-requestTokenUri-oauth1.raml", Some("missing-requestTokenUri-oauth1.report"))
+  }
+
+  test("Missing authorizationUri field in OAuth 1.0 security type") {
+    validate("/raml/oauth1/missing-authorizationUri-oauth1.raml", Some("missing-authorizationUri-oauth1.report"))
+  }
+
+  test("Missing tokenCredentialsUri field in OAuth 1.0 security type") {
+    validate("/raml/oauth1/missing-tokenCredentialsUri-oauth1.raml", Some("missing-tokenCredentialsUri-oauth1.report"))
+  }
+
+  // OAuth 2.0
   test("OAuth 2.0 security settings - authorization code") {
     validate("security-schemes/oauth-2/authorization-code.raml",
              Some("missing-authorization-code-fields.report"),

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
@@ -739,6 +739,33 @@ object AMFRawValidations {
         value = "^authorization_code|password|client_credentials|implicit|(\\w+:(\\/?\\/?)[^\\s]+)$"
       ),
       AMFValidation(
+        message =
+          "requestTokenUri is required when security type is OAuth 1.0",
+        owlClass = security("OAuth1Settings"),
+        owlProperty = security("requestTokenUri"),
+        constraint = minCount,
+        value = "1",
+        severity = Severity.WARNING
+      ),
+      AMFValidation(
+        message =
+          "authorizationUri is required when security type is OAuth 1.0",
+        owlClass = security("OAuth1Settings"),
+        owlProperty = security("authorizationUri"),
+        constraint = minCount,
+        value = "1",
+        severity = Severity.WARNING
+      ),
+      AMFValidation(
+        message =
+          "tokenCredentialsUri is required when security type is OAuth 1.0",
+        owlClass = security("OAuth1Settings"),
+        owlProperty = security("tokenCredentialsUri"),
+        constraint = minCount,
+        value = "1",
+        severity = Severity.WARNING
+      ),
+      AMFValidation(
         uri = amfParser("raml-root-schemes-values"),
         message = "Protocols property must be http or https",
         owlClass = apiContract("WebAPI"),


### PR DESCRIPTION
add warnings when requestTokenUri, authorizationUri, or/and tokenCredentialsUri are missing in an OAuth 1.0 Security Scheme in RAML. 