### PR TITLE
APIMF-2261: Parse SecuritySchemes in RAML fragments

### DIFF
--- a/amf-client/shared/src/test/resources/parser-results/raml/error/invalid-scope-secured-by-fragment.raml
+++ b/amf-client/shared/src/test/resources/parser-results/raml/error/invalid-scope-secured-by-fragment.raml
@@ -1,0 +1,8 @@
+#%RAML 1.0 SecurityScheme
+
+type: OAuth 2.0
+settings:
+  scopes: [ADMINISTRATOR, COLLABORATOR]
+  authorizationUri: https://www.dropbox.com/1/oauth2/authorize
+  accessTokenUri: https://api.dropbox.com/1/oauth2/token
+  authorizationGrants: [ authorization_code ]

--- a/amf-client/shared/src/test/resources/parser-results/raml/error/invalid-scope-secured-by-in-fragment.raml
+++ b/amf-client/shared/src/test/resources/parser-results/raml/error/invalid-scope-secured-by-in-fragment.raml
@@ -1,0 +1,9 @@
+#%RAML 1.0
+title: GitHub API
+
+securitySchemes:
+  oauth_2_0: !include /invalid-scope-secured-by-fragment.raml
+
+/users:
+  get:
+    securedBy: [null, oauth_2_0: { scopes: [ USER ] } ]

--- a/amf-client/shared/src/test/resources/upanddown/unnamed-security-scheme.raml.json
+++ b/amf-client/shared/src/test/resources/upanddown/unnamed-security-scheme.raml.json
@@ -22,7 +22,9 @@
         "responses": {},
         "security": [
           {
-            "oauth_2_0": []
+            "oauth_2_0": [
+              "GUEST"
+            ]
           }
         ],
         "x-amf-security": [

--- a/amf-client/shared/src/test/scala/amf/error/ParserErrorTest.scala
+++ b/amf-client/shared/src/test/scala/amf/error/ParserErrorTest.scala
@@ -33,7 +33,7 @@ trait ParserErrorTest extends AsyncFunSuite with PlatformSecrets with Matchers {
           val report = eh.getErrors
           if (report.size != fixture.size) {
             report.foreach(println)
-            fail(s"Expected results has lenght of ${fixture.size} while actual results are ${report.size}")
+            fail(s"Expected results has length of ${fixture.size} while actual results are ${report.size}")
           }
           fixture.zip(report).foreach {
             case (fn, result) => fn(result)

--- a/amf-client/shared/src/test/scala/amf/error/RamlParserErrorTest.scala
+++ b/amf-client/shared/src/test/scala/amf/error/RamlParserErrorTest.scala
@@ -322,6 +322,17 @@ class RamlParserErrorTest extends ParserErrorTest {
     )
   }
 
+  test("Invalid scope at secured by defined in fragment") {
+    validate(
+      "/error/invalid-scope-secured-by-in-fragment.raml",
+      violation => {
+        violation.level should be("Violation")
+        violation.message should be("Scope 'USER' not found in settings of declared secured by oauth_2_0.")
+        violation.position.map(_.range) should be(Some(Range((9, 45), (9, 49))))
+      }
+    )
+  }
+
   test("Test invalid map in resource type use") {
     validate("/valid/invalid-map-resource-type.raml")
   }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/domain/RamlParametrizedSecuritySchemeParser.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/domain/RamlParametrizedSecuritySchemeParser.scala
@@ -28,8 +28,13 @@ case class RamlParametrizedSecuritySchemeParser(node: YNode, producer: String =>
         case Some(declaration) =>
           scheme.set(ParametrizedSecuritySchemeModel.Scheme, declaration)
 
+          val effectiveDeclaration =
+            if (declaration.isLink)
+              declaration.effectiveLinkTarget().asInstanceOf[SecurityScheme]
+            else declaration
+
           val settings =
-            RamlSecuritySettingsParser(schemeEntry.value.as[YMap], declaration.`type`.value(), scheme).parse()
+            RamlSecuritySettingsParser(schemeEntry.value.as[YMap], effectiveDeclaration.`type`.value(), scheme).parse()
 
           scheme.set(ParametrizedSecuritySchemeModel.Settings, settings)
         case None =>


### PR DESCRIPTION
Parse SecuritySchemes in RAML fragments by catching links and obtaining the SecurityScheme in it's effective target 