### PR TITLE
APIMF-1964: validate 'consumes' property in a parameter of type 'file'

### DIFF
--- a/amf-client/shared/src/test/resources/validations/oas2/invalid-consumes-property.json
+++ b/amf-client/shared/src/test/resources/validations/oas2/invalid-consumes-property.json
@@ -1,0 +1,28 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "testing API"
+  },
+  "consumes": [
+    "asdf"
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "test"
+          }
+        }
+      }
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/validations/oas2/missing-file-consumes-property.json
+++ b/amf-client/shared/src/test/resources/validations/oas2/missing-file-consumes-property.json
@@ -1,0 +1,25 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "testing API"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "test"
+          }
+        }
+      }
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/validations/reports/oas2/invalid-consumes-property.report
+++ b/amf-client/shared/src/test/resources/validations/reports/oas2/invalid-consumes-property.report
@@ -1,0 +1,14 @@
+Model: file://amf-client/shared/src/test/resources/validations/oas2/invalid-consumes-property.json
+Profile: OAS 2.0
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/resolution#invalid-consumes-with-file-parameter
+  Message: Consumes must be either 'multipart/form-data', 'application/x-www-form-urlencoded', or both when a file parameter is present
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/oas2/invalid-consumes-property.json#/web-api/end-points/%2Ftest/get/request/formData/formData/property/file
+  Property: 
+  Position: Some(LexicalInformation([(14,10)-(18,11)]))
+  Location: file://amf-client/shared/src/test/resources/validations/oas2/invalid-consumes-property.json

--- a/amf-client/shared/src/test/resources/validations/reports/oas2/missing-file-consumes-property.report
+++ b/amf-client/shared/src/test/resources/validations/reports/oas2/missing-file-consumes-property.report
@@ -1,0 +1,14 @@
+Model: file://amf-client/shared/src/test/resources/validations/oas2/missing-file-consumes-property.json
+Profile: OAS 2.0
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/resolution#invalid-consumes-with-file-parameter
+  Message: Consumes must be either 'multipart/form-data', 'application/x-www-form-urlencoded', or both when a file parameter is present
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/oas2/missing-file-consumes-property.json#/web-api/end-points/%2Ftest/get/request/formData/formData/property/file
+  Property: 
+  Position: Some(LexicalInformation([(11,10)-(15,11)]))
+  Location: file://amf-client/shared/src/test/resources/validations/oas2/missing-file-consumes-property.json

--- a/amf-client/shared/src/test/scala/amf/validation/Oas20UniquePlatformUnitValidationsTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/Oas20UniquePlatformUnitValidationsTest.scala
@@ -9,6 +9,14 @@ class Oas20UniquePlatformUnitValidationsTest extends UniquePlatformReportGenTest
   override val reportsPath: String = "amf-client/shared/src/test/resources/validations/reports/oas2/"
   override val hint: Hint          = OasYamlHint
 
+  test("parameter of type 'file' with missing 'consumes' property") {
+    validate("missing-file-consumes-property.json", Some("missing-file-consumes-property.report"), Oas20Profile)
+  }
+
+  test("parameter of type 'file' with invalid 'consumes' property") {
+    validate("invalid-consumes-property.json", Some("invalid-consumes-property.report"), Oas20Profile)
+  }
+
   test("Oas path uri is invalid") {
     validate("invalid-endpoint-path-still-parses.json",
              Some("invalid-endpoint-path-still-parses.report"),

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
@@ -739,8 +739,7 @@ object AMFRawValidations {
         value = "^authorization_code|password|client_credentials|implicit|(\\w+:(\\/?\\/?)[^\\s]+)$"
       ),
       AMFValidation(
-        message =
-          "requestTokenUri is required when security type is OAuth 1.0",
+        message = "requestTokenUri is required when security type is OAuth 1.0",
         owlClass = security("OAuth1Settings"),
         owlProperty = security("requestTokenUri"),
         constraint = minCount,
@@ -748,8 +747,7 @@ object AMFRawValidations {
         severity = Severity.WARNING
       ),
       AMFValidation(
-        message =
-          "authorizationUri is required when security type is OAuth 1.0",
+        message = "authorizationUri is required when security type is OAuth 1.0",
         owlClass = security("OAuth1Settings"),
         owlProperty = security("authorizationUri"),
         constraint = minCount,
@@ -757,8 +755,7 @@ object AMFRawValidations {
         severity = Severity.WARNING
       ),
       AMFValidation(
-        message =
-          "tokenCredentialsUri is required when security type is OAuth 1.0",
+        message = "tokenCredentialsUri is required when security type is OAuth 1.0",
         owlClass = security("OAuth1Settings"),
         owlProperty = security("tokenCredentialsUri"),
         constraint = minCount,


### PR DESCRIPTION
add tests to validate 'consumes' property in a parameter of type 'file'