### PR TITLE
APIMF-2174: RAML - validate user documentation can't be empty strings

### DIFF
--- a/amf-client/shared/src/test/resources/validations/raml/documentation-non-empty.raml
+++ b/amf-client/shared/src/test/resources/validations/raml/documentation-non-empty.raml
@@ -1,0 +1,5 @@
+#%RAML 1.0
+title: Test API
+documentation:
+ - title:
+   content:

--- a/amf-client/shared/src/test/resources/validations/reports/model/raml/documentation-non-empty.report
+++ b/amf-client/shared/src/test/resources/validations/reports/model/raml/documentation-non-empty.report
@@ -1,0 +1,22 @@
+Model: file://amf-client/shared/src/test/resources/validations/raml/documentation-non-empty.raml
+Profile: RAML 1.0
+Conforms? true
+Number of results: 2
+
+Level: Warning
+
+- Source: http://a.ml/vocabularies/amf/parser#CreativeWork-title-minLength
+  Message: Documentation title MUST be a non-empty string
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/raml/documentation-non-empty.raml#/web-api/creative-work/
+  Property: http://a.ml/vocabularies/core#title
+  Position: Some(LexicalInformation([(4,9)-(4,9)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/documentation-non-empty.raml
+
+- Source: http://a.ml/vocabularies/amf/parser#CreativeWork-description-minLength
+  Message: Documentation content MUST be a non-empty string
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/raml/documentation-non-empty.raml#/web-api/creative-work/
+  Property: http://a.ml/vocabularies/core#description
+  Position: Some(LexicalInformation([(5,11)-(5,11)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/documentation-non-empty.raml

--- a/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -503,4 +503,8 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
              Some("raml/included-json-with-duplicate-keys.report"),
              Raml10Profile)
   }
+
+  test("Documentation - title and description MUST be a non-empty string") {
+    validate("raml/documentation-non-empty.raml", Some("raml/documentation-non-empty.report"), Raml10Profile)
+  }
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
@@ -45,7 +45,7 @@ object AMFRawValidations {
     ): AMFValidation = {
 
       def iri(s: String) = Namespace.uri(s).iri()
-      val sameMessage    = !message.isEmpty && ramlErrorMessage.isEmpty && openApiErrorMessage.isEmpty
+      val sameMessage    = message.nonEmpty && ramlErrorMessage.isEmpty && openApiErrorMessage.isEmpty
 
       new AMFValidation(
         uri = optional(uri).map(Namespace.uri(_).iri()),
@@ -74,7 +74,7 @@ object AMFRawValidations {
         severity: String = Severity.VIOLATION
     ): AMFValidation = {
 
-      val sameMessage = !message.isEmpty && ramlErrorMessage.isEmpty && openApiErrorMessage.isEmpty
+      val sameMessage = message.nonEmpty && ramlErrorMessage.isEmpty && openApiErrorMessage.isEmpty
 
       new AMFValidation(
         uri = uri.map(_.iri()),
@@ -723,6 +723,22 @@ object AMFRawValidations {
         openApiErrorMessage = "Documentation object 'description' is mandatory"
       ),
       AMFValidation(
+        owlClass = core("CreativeWork"),
+        owlProperty = core("title"),
+        message = "Documentation title MUST be a non-empty string",
+        constraint = sh("minLength"),
+        value = "1",
+        severity = Severity.WARNING // should be violation
+      ),
+      AMFValidation(
+        owlClass = core("CreativeWork"),
+        owlProperty = core("description"),
+        message = "Documentation content MUST be a non-empty string",
+        constraint = sh("minLength"),
+        value = "1",
+        severity = Severity.WARNING // should be violation
+      ),
+      AMFValidation(
         owlClass = doc("DomainProperty"),
         owlProperty = shape("schema"),
         constraint = minCount,
@@ -739,8 +755,7 @@ object AMFRawValidations {
         value = "^authorization_code|password|client_credentials|implicit|(\\w+:(\\/?\\/?)[^\\s]+)$"
       ),
       AMFValidation(
-        message =
-          "requestTokenUri is required when security type is OAuth 1.0",
+        message = "requestTokenUri is required when security type is OAuth 1.0",
         owlClass = security("OAuth1Settings"),
         owlProperty = security("requestTokenUri"),
         constraint = minCount,
@@ -748,8 +763,7 @@ object AMFRawValidations {
         severity = Severity.WARNING
       ),
       AMFValidation(
-        message =
-          "authorizationUri is required when security type is OAuth 1.0",
+        message = "authorizationUri is required when security type is OAuth 1.0",
         owlClass = security("OAuth1Settings"),
         owlProperty = security("authorizationUri"),
         constraint = minCount,
@@ -757,8 +771,7 @@ object AMFRawValidations {
         severity = Severity.WARNING
       ),
       AMFValidation(
-        message =
-          "tokenCredentialsUri is required when security type is OAuth 1.0",
+        message = "tokenCredentialsUri is required when security type is OAuth 1.0",
         owlClass = security("OAuth1Settings"),
         owlProperty = security("tokenCredentialsUri"),
         constraint = minCount,


### PR DESCRIPTION
inserted as warning, must be violation in the next major release.