### PR TITLE
APIMF-1880: RAML - validate target value in 'allowedTargets' field

### DIFF
--- a/amf-client/shared/src/test/resources/validations/raml/invalid-annotation-type.raml
+++ b/amf-client/shared/src/test/resources/validations/raml/invalid-annotation-type.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+title: Illustrating allowed targets
+mediaType: application/json
+annotationTypes:
+  meta-invalid-target:
+    allowedTargets: Action
+  meta-invalid-targets:
+    allowedTargets: [ Resource, Action ]
+
+/users:
+  (meta-invalid-targets): someValue

--- a/amf-client/shared/src/test/resources/validations/reports/model/raml/invalid-annotation-type.report
+++ b/amf-client/shared/src/test/resources/validations/reports/model/raml/invalid-annotation-type.report
@@ -1,0 +1,22 @@
+Model: file://amf-client/shared/src/test/resources/validations/raml/invalid-annotation-type.raml
+Profile: RAML 1.0
+Conforms? true
+Number of results: 2
+
+Level: Warning
+
+- Source: http://a.ml/vocabularies/amf/parser#invalid-allowed-targets
+  Message: Action is not a valid target
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/raml/invalid-annotation-type.raml#/declarations/annotations/meta-invalid-target
+  Property: 
+  Position: Some(LexicalInformation([(6,20)-(6,26)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/invalid-annotation-type.raml
+
+- Source: http://a.ml/vocabularies/amf/parser#invalid-allowed-targets
+  Message: Action is not a valid target
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/raml/invalid-annotation-type.raml#/declarations/annotations/meta-invalid-targets
+  Property: 
+  Position: Some(LexicalInformation([(8,20)-(8,40)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/invalid-annotation-type.raml

--- a/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -507,4 +507,8 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
   test("Documentation - title and description MUST be a non-empty string") {
     validate("raml/documentation-non-empty.raml", Some("raml/documentation-non-empty.report"), Raml10Profile)
   }
+
+  test("Annotation types - check target locations are valid") {
+    validate("raml/invalid-annotation-type.raml", Some("raml/invalid-annotation-type.report"), Raml10Profile)
+  }
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlDocumentParser.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlDocumentParser.scala
@@ -569,6 +569,46 @@ abstract class RamlSpecParser(implicit ctx: RamlWebApiContext) extends WebApiBas
   }
 
   case class AnnotationTypesParser(ast: YPart, annotationName: String, map: YMap, adopt: CustomDomainProperty => Unit) {
+
+    def checkValidTarget(entry: YMapEntry, nodeId: String): Unit = {
+      val targets = entry.value.value match {
+        case value: YScalar =>
+          Seq(value.text)
+        case values: YSequence =>
+          values.nodes.map(node => node.asScalar.get.text)
+      }
+
+      val validTargets: Set[String] = Set(
+        "API",
+        "DocumentationItem",
+        "Resource",
+        "Method",
+        "Response",
+        "RequestBody",
+        "ResponseBody",
+        "TypeDeclaration",
+        "Example",
+        "ResourceType",
+        "Trait",
+        "SecurityScheme",
+        "SecuritySchemeSettings",
+        "AnnotationType",
+        "Library",
+        "Overlay",
+        "Extension"
+      )
+
+      targets.foreach(target => {
+        if (!validTargets.contains(target))
+          ctx.eh.warning(
+            InvalidAllowedTargets,
+            nodeId,
+            s"$target is not a valid target",
+            entry.value
+          )
+      })
+    }
+
     def parse(): CustomDomainProperty = {
 
       val custom = CustomDomainProperty(ast)
@@ -600,6 +640,7 @@ abstract class RamlSpecParser(implicit ctx: RamlWebApiContext) extends WebApiBas
               val annotations = Annotations(entry)
               val targets: AmfArray = entry.value.tagType match {
                 case YType.Seq =>
+                  checkValidTarget(entry, custom.id)
                   ArrayNode(entry.value).string()
                 case YType.Map =>
                   ctx.eh.violation(
@@ -610,6 +651,7 @@ abstract class RamlSpecParser(implicit ctx: RamlWebApiContext) extends WebApiBas
                   )
                   AmfArray(Seq())
                 case _ =>
+                  checkValidTarget(entry, custom.id)
                   annotations += SingleValueArray()
                   AmfArray(Seq(ScalarNode(entry.value).string()))
               }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
@@ -728,7 +728,7 @@ object AMFRawValidations {
         message = "Documentation title MUST be a non-empty string",
         constraint = sh("minLength"),
         value = "1",
-        severity = Severity.WARNING // should be violation
+        severity = Severity.WARNING // TODO: should be violation
       ),
       AMFValidation(
         owlClass = core("CreativeWork"),
@@ -736,7 +736,7 @@ object AMFRawValidations {
         message = "Documentation content MUST be a non-empty string",
         constraint = sh("minLength"),
         value = "1",
-        severity = Severity.WARNING // should be violation
+        severity = Severity.WARNING // TODO: should be violation
       ),
       AMFValidation(
         owlClass = doc("DomainProperty"),

--- a/amf-webapi/shared/src/main/scala/amf/validations/ParserSideValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/validations/ParserSideValidations.scala
@@ -514,6 +514,11 @@ object ParserSideValidations extends Validations {
     "Invalid allowedTargets type"
   )
 
+  val InvalidAllowedTargets = validation(
+    "invalid-allowed-targets",
+    "Invalid allowedTargets value"
+  )
+
   val InvalidExtensionsType = validation(
     "invalid-extension-type",
     "Invalid extension type"
@@ -678,7 +683,8 @@ object ParserSideValidations extends Validations {
     CrossSecurityWarningSpecification.id -> all(WARNING),
     ReadOnlyPropertyMarkedRequired.id    -> all(WARNING),
     MissingRequiredFieldForGrantType.id  -> all(WARNING),
-    OasInvalidParameterSchema.id         -> all(WARNING), // should be violation
+    OasInvalidParameterSchema.id         -> all(WARNING), // TODO: should be violation
+    InvalidAllowedTargets.id             -> all(WARNING), // TODO: should be violation
     MissingDiscriminatorProperty.id      -> all(VIOLATION),
     InvalidPayload.id                    -> all(VIOLATION)
   )


### PR DESCRIPTION
This issue had to be resolved in parsing because the value of the 'allowedTargets' has to be a valid string, and if it's later parsed, the value of that string can't be retreived.
For example:
String "Method" when parsed becomes a full Operation model, thus we can't obtain the string value in the API spec.