### PR TITLE
APIMF-1962: OAS2 - warn when example field is present in a parameter

### DIFF
--- a/amf-client/shared/src/test/resources/validations/oas2/invalid-example-field.json
+++ b/amf-client/shared/src/test/resources/validations/oas2/invalid-example-field.json
@@ -1,0 +1,26 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "testing API"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "parameters": [
+          {
+            "name": "test-parameter",
+            "in": "header",
+            "type": "string",
+            "example": "2018-08-04T12:23:34Z"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "test"
+          }
+        }
+      }
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/validations/reports/oas2/invalid-example-field.report
+++ b/amf-client/shared/src/test/resources/validations/reports/oas2/invalid-example-field.report
@@ -1,0 +1,14 @@
+Model: file://amf-client/shared/src/test/resources/validations/oas2/invalid-example-field.json
+Profile: OAS 2.0
+Conforms? true
+Number of results: 1
+
+Level: Warning
+
+- Source: http://a.ml/vocabularies/amf/parser#invalid-example-field-warning
+  Message: Property 'example' not supported in a parameter node
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/oas2/invalid-example-field.json#/web-api/end-points/%2Ftest/get/request/parameter/test-parameter
+  Property: 
+  Position: Some(LexicalInformation([(11,10)-(16,11)]))
+  Location: file://amf-client/shared/src/test/resources/validations/oas2/invalid-example-field.json

--- a/amf-client/shared/src/test/scala/amf/validation/Oas20UniquePlatformUnitValidationsTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/Oas20UniquePlatformUnitValidationsTest.scala
@@ -96,4 +96,8 @@ class Oas20UniquePlatformUnitValidationsTest extends UniquePlatformReportGenTest
   test("JSON with duplicate keys") {
     validate("duplicate-keys.json", Some("duplicate-keys.report"), Oas20Profile, overridedHint = Some(OasJsonHint))
   }
+
+  test("invalid 'example' field in parameter object") {
+    validate("invalid-example-field.json", Some("invalid-example-field.report"), Oas20Profile)
+  }
 }

--- a/amf-webapi/shared/src/main/scala/amf/validations/ParserSideValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/validations/ParserSideValidations.scala
@@ -608,9 +608,16 @@ object ParserSideValidations extends Validations {
     "'items' field is required when type is array"
   )
 
+  // TODO: Should be removed and used the violation in the next major
   val ItemsFieldRequiredWarning = validation(
     "items-field-required-warning",
     "'items' field is required when type is array"
+  )
+
+  // TODO: Should be removed and used the violation in the next major
+  val invalidExampleFieldWarning = validation(
+    "invalid-example-field-warning",
+    "Property 'example' not supported"
   )
 
   val InvalidIdentifier = validation(
@@ -674,7 +681,7 @@ object ParserSideValidations extends Validations {
       Oas30Profile  -> WARNING,
       AmfProfile    -> WARNING
     ),
-    ItemsFieldRequiredWarning.id         -> all(WARNING),
+    ItemsFieldRequiredWarning.id         -> all(WARNING), // TODO: should be violation
     NullAbstractDeclaration.id           -> all(WARNING),
     SchemaDeprecated.id                  -> all(WARNING),
     SchemasDeprecated.id                 -> all(WARNING),
@@ -683,6 +690,7 @@ object ParserSideValidations extends Validations {
     CrossSecurityWarningSpecification.id -> all(WARNING),
     ReadOnlyPropertyMarkedRequired.id    -> all(WARNING),
     MissingRequiredFieldForGrantType.id  -> all(WARNING),
+    invalidExampleFieldWarning.id        -> all(WARNING), // TODO: should be violation
     OasInvalidParameterSchema.id         -> all(WARNING), // TODO: should be violation
     InvalidAllowedTargets.id             -> all(WARNING), // TODO: should be violation
     MissingDiscriminatorProperty.id      -> all(VIOLATION),


### PR DESCRIPTION
should become a closed shape violation in the next major release