### PR TITLE
APIMF-2499: remove raml as known vendor in async plugin

### DIFF
--- a/amf-client/shared/src/test/scala/amf/core/registries/WebApiPluginsRegistryTest.scala
+++ b/amf-client/shared/src/test/scala/amf/core/registries/WebApiPluginsRegistryTest.scala
@@ -1,0 +1,17 @@
+package amf.core.registries
+import amf.plugins.document.webapi.{Async20Plugin, Raml10Plugin}
+import org.scalatest.FunSuite
+import org.scalatest.Matchers._
+
+class WebApiPluginsRegistryTest extends FunSuite {
+
+  test("obtain raml plugin from registry when raml and async plugins are registered") {
+    AMFPluginsRegistry.registerDocumentPlugin(Async20Plugin)
+    AMFPluginsRegistry.registerDocumentPlugin(Raml10Plugin)
+
+    val plugins = AMFPluginsRegistry.documentPluginForVendor(Raml10Plugin.vendors.head)
+
+    plugins.size shouldBe 1
+    plugins.head shouldBe Raml10Plugin
+  }
+}

--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,3 +1,3 @@
 amf.webapi=4.4.0-SNAPSHOT
-amf.aml=4.1.164
+amf.aml=4.1.165
 amf.model=2.1.2

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/AsyncPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/AsyncPlugin.scala
@@ -25,7 +25,9 @@ import org.yaml.model.YDocument
 
 sealed trait AsyncPlugin extends OasLikePlugin {
 
-  override val vendors: Seq[String] = Seq(vendor.name, AsyncApi.name, Raml10.name)
+  override val vendors: Seq[String] = Seq(vendor.name, AsyncApi.name)
+
+  override val validVendorsToReference: Seq[Vendor] = Seq(Raml10)
 
   override def specContext(options: RenderOptions): AsyncSpecEmitterContext
 


### PR DESCRIPTION
depends on https://github.com/aml-org/amf-core/pull/115