### PR TITLE
APIMF-2559: example has same filename as a type filename

### DIFF
--- a/amf-client/shared/src/test/resources/validations/raml/examples/examples/pet-a.json
+++ b/amf-client/shared/src/test/resources/validations/raml/examples/examples/pet-a.json
@@ -1,0 +1,11 @@
+{
+  "id": "118dbd8c-5ba0-47a9-a850-34bbb1dbf3b7",
+  "genus": "Canis",
+  "quantity": 30,
+  "exercisePolicy": {
+    "period": {
+      "duration": 15,
+      "interval": "minute"
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/validations/raml/examples/period.json
+++ b/amf-client/shared/src/test/resources/validations/raml/examples/period.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "id": "period.json",
+  "properties": {
+    "duration": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "interval": {
+      "type": "string",
+      "enum": [
+        "minute",
+        "hour",
+        "day",
+        "week",
+        "month"
+      ]
+    }
+  },
+  "required": [
+    "duration",
+    "interval"
+  ],
+  "additionalProperties": false
+}

--- a/amf-client/shared/src/test/resources/validations/raml/examples/pet-a.json
+++ b/amf-client/shared/src/test/resources/validations/raml/examples/pet-a.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "pet-a.json",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "genus": {
+      "type": "string"
+    },
+    "quantity": {
+      "type": "integer"
+    },
+    "exercisePolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "period": {
+          "type": "object",
+          "$ref": "period.json"
+        }
+      }
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "additionalProperties": false
+}

--- a/amf-client/shared/src/test/resources/validations/raml/examples/same-filename-example.raml
+++ b/amf-client/shared/src/test/resources/validations/raml/examples/same-filename-example.raml
@@ -1,0 +1,16 @@
+#%RAML 1.0
+
+title: The parent schema has 1x $ref to a child schema. The example filename is the same as the parent schema.
+
+types:
+  petSchema: !include pet-a.json
+
+/pets-reports:
+  /pets:
+    get:
+      responses:
+        200:
+          body:
+            application/json:
+              type: petSchema
+              example: !include examples/pet-a.json

--- a/amf-client/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
@@ -1,6 +1,6 @@
 package amf.validation
 
-import amf.Raml08Profile
+import amf.{Raml08Profile, Raml10Profile}
 import amf.core.remote.{Hint, RamlYamlHint}
 
 class ValidRamlModelParserTest extends ValidModelTest {
@@ -261,6 +261,10 @@ class ValidRamlModelParserTest extends ValidModelTest {
 
   test("Referencing external example with @type key") {
     checkValid("external-example/api.raml")
+  }
+
+  test("example has same filename as a type filename") {
+    checkValid("/raml/examples/same-filename-example.raml")
   }
 
   override val hint: Hint = RamlYamlHint


### PR DESCRIPTION
APIMF-2559: add test when example has same filename as a type filename. Wrong behavior was fixed in 4.4.0, this test ensures it keeps that way.