### PR TITLE
APIMF-2187: fix 'date' format emission

### DIFF
--- a/amf-client/shared/src/test/resources/upanddown/all-type-types.json.raml
+++ b/amf-client/shared/src/test/resources/upanddown/all-type-types.json.raml
@@ -32,7 +32,6 @@ types:
     type: datetime
   DateOnlyType:
     type: date-only
-    format: date
   BooleanType:
     type: boolean
   ObjectType:

--- a/amf-client/shared/src/test/resources/upanddown/date-format.json
+++ b/amf-client/shared/src/test/resources/upanddown/date-format.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "API with Types",
+    "version": ""
+  },
+  "paths": {},
+  "definitions": {
+    "Thing": {
+      "type": "object",
+      "properties": {
+        "dateOfBirth": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/upanddown/date-format.raml
+++ b/amf-client/shared/src/test/resources/upanddown/date-format.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0
+types:
+  Thing:
+    type: object
+    properties:
+      dateOfBirth:
+        type: date-only
+        required: false
+title: API with Types
+version: ""

--- a/amf-client/shared/src/test/scala/amf/emit/CompleteCycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/emit/CompleteCycleTest.scala
@@ -8,7 +8,7 @@ class CompleteCycleTest extends FunSuiteCycleTests {
 
   override val basePath = "amf-client/shared/src/test/resources/upanddown/"
   val base08Path        = "amf-client/shared/src/test/resources/upanddown/raml08/"
-  val baseRaml10Path        = "amf-client/shared/src/test/resources/upanddown/raml10/"
+  val baseRaml10Path    = "amf-client/shared/src/test/resources/upanddown/raml10/"
   val referencesPath    = "amf-client/shared/src/test/resources/references/"
   val productionPath    = "amf-client/shared/src/test/resources/production/"
   val validationsPath   = "amf-client/shared/src/test/resources/validations/"
@@ -738,6 +738,10 @@ class CompleteCycleTest extends FunSuiteCycleTests {
 
   test("CollectionFormat shape oas to raml") {
     cycle("collection-format.json", "collection-format.raml", OasJsonHint, target = Raml)
+  }
+
+  test("Date format oas to raml") {
+    cycle("date-format.json", "date-format.raml", OasJsonHint, target = Raml)
   }
 
   test("Tags node oas to oas") {

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/OasTypeDefMatcher.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/OasTypeDefMatcher.scala
@@ -10,6 +10,7 @@ object OasTypeDefMatcher {
 
   val knownFormats: Set[String] = Set("time-only",
                                       "date-only",
+                                      "date",
                                       "date-time",
                                       "date-time-only",
                                       "password",

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/emitters/raml/Raml10TypeEmitter.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/emitters/raml/Raml10TypeEmitter.scala
@@ -22,6 +22,7 @@ case class Raml10TypeEmitter(shape: Shape,
   def emitters(): Seq[Emitter] = {
     shape match {
       case _
+          // TODO: encapsulate in an object. This is too hard to read and holds too many conditionals.
           if Option(shape).isDefined && shape.isInstanceOf[AnyShape]
             && shape.asInstanceOf[AnyShape].fromExternalSource
             && references.nonEmpty
@@ -33,10 +34,6 @@ case class Raml10TypeEmitter(shape: Shape,
               })
               .isDefined => // need to check ref to ask if resolution has run.
         Seq(RamlExternalSourceEmitter(shape.asInstanceOf[AnyShape], references))
-//      case _
-//          if Option(shape).isDefined && shape
-//            .isInstanceOf[AnyShape] && shape.asInstanceOf[AnyShape].fromTypeExpression =>
-//        Seq(RamlTypeExpressionEmitter(shape.asInstanceOf[AnyShape]))
       case _ if Option(shape).isDefined && shape.annotations.contains(classOf[ExternalReferenceUrl]) =>
         Seq(RamlExternalReferenceUrlEmitter(shape)())
       case l: Linkable if l.isLink =>

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/emitters/raml/Raml10TypePartEmitter.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/emitters/raml/Raml10TypePartEmitter.scala
@@ -16,9 +16,9 @@ case class Raml10TypePartEmitter(shape: Shape,
 
   override def emitters: Seq[Emitter] = {
     val annotationEmitters = annotations.map(_.emitters).getOrElse(Nil)
-    ordering.sorted(
-      Raml10TypeEmitter(shape, ordering, ignored, references, forceEntry = annotationEmitters.nonEmpty)
-        .emitters() ++ annotationEmitters)
+    val typeEmitterAnnotations =
+      Raml10TypeEmitter(shape, ordering, ignored, references, forceEntry = annotationEmitters.nonEmpty).emitters()
+    ordering.sorted(typeEmitterAnnotations ++ annotationEmitters)
   }
 
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/emitters/raml/RamlNamedTypeEmitter.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/emitters/raml/RamlNamedTypeEmitter.scala
@@ -27,7 +27,7 @@ case class RamlNamedTypeEmitter(shape: AnyShape,
                                     Seq[BaseUnit]) => RamlTypePartEmitter)(implicit spec: SpecEmitterContext)
     extends EntryEmitter {
   override def emit(b: EntryBuilder): Unit = {
-    val name = shape.name.option().getOrElse("schema") // this used to throw an exception, but with the resolution optimizacion, we use the father shape, so it could have not name (if it's from an endpoint for example, and you want to write a new single shape, like a json schema)
+    val name = shape.name.option().getOrElse("schema") // this used to throw an exception, but with the resolution optimization, we use the father shape, so it could have not name (if it's from an endpoint for example, and you want to write a new single shape, like a json schema)
     b.entry(name, b => emitLinkOr(shape, b, references)(emitInline(b)))
   }
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/emitters/raml/RamlScalarShapeEmitter.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/emitters/raml/RamlScalarShapeEmitter.scala
@@ -54,18 +54,18 @@ case class RamlScalarShapeEmitter(scalar: ScalarShape, ordering: SpecOrdering, r
 
     emitOASFields(fs, result)
 
-    fs.entry(ScalarShapeModel.Pattern).map { f =>
+    fs.entry(ScalarShapeModel.Pattern).foreach { f =>
       result += RamlScalarEmitter("pattern", processRamlPattern(f))
     }
 
     fs.entry(ScalarShapeModel.Minimum)
-      .map(f => result += ValueEmitter("minimum", f, Some(NumberTypeToYTypeConverter.convert(rawTypeDef))))
+      .foreach(f => result += ValueEmitter("minimum", f, Some(NumberTypeToYTypeConverter.convert(rawTypeDef))))
 
     fs.entry(ScalarShapeModel.Maximum)
-      .map(f => result += ValueEmitter("maximum", f, Some(NumberTypeToYTypeConverter.convert(rawTypeDef))))
+      .foreach(f => result += ValueEmitter("maximum", f, Some(NumberTypeToYTypeConverter.convert(rawTypeDef))))
 
     fs.entry(ScalarShapeModel.MultipleOf)
-      .map(f => result += RamlScalarEmitter("multipleOf", f, Some(NumberTypeToYTypeConverter.convert(rawTypeDef))))
+      .foreach(f => result += RamlScalarEmitter("multipleOf", f, Some(NumberTypeToYTypeConverter.convert(rawTypeDef))))
 
     result ++= emitFormat(rawTypeDef, fs, format)
 
@@ -83,8 +83,8 @@ case class RamlScalarShapeEmitter(scalar: ScalarShape, ordering: SpecOrdering, r
     val translationFormats = OasTypeDefMatcher.knownFormats.diff(RamlTypeDefMatcher.knownFormats)
 
     val explicitFormatOption = fs.entry(ScalarShapeModel.Format) flatMap {
-      case entry if entry.value.value.isInstanceOf[AmfScalar] =>
-        val entryFormat = entry.value.value.asInstanceOf[AmfScalar].value.toString
+      case entry if entry.element.isInstanceOf[AmfScalar] =>
+        val entryFormat = entry.scalar.value.toString
         Some(entryFormat).filter(fmt => !translationFormats(fmt))
       case _ => None
     }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlDocumentEmitter.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlDocumentEmitter.scala
@@ -85,11 +85,10 @@ case class Raml10RootLevelEmitters(document: BaseUnit with DeclaresModel, orderi
     extends RamlRootLevelEmitters(document, ordering) {
 
   override def emitters: Seq[EntryEmitter] = {
-    val declares   = declarationsEmitter()
-    val references = ReferencesEmitter(document, ordering)
-    val extension  = extensionEmitter()
-    val usage: Option[ValueEmitter] =
-      document.fields.entry(BaseUnitModel.Usage).map(f => ValueEmitter("usage", f))
+    val declares                    = declarationsEmitter()
+    val references                  = ReferencesEmitter(document, ordering)
+    val extension                   = extensionEmitter()
+    val usage: Option[ValueEmitter] = document.fields.entry(BaseUnitModel.Usage).map(f => ValueEmitter("usage", f))
 
     declares ++ extension ++ usage :+ references
   }
@@ -214,7 +213,7 @@ case class ReferencesEmitter(baseUnit: BaseUnit, ordering: SpecOrdering) extends
             case _ => None
           }
       }.toSeq
-      val missingModuleEmitters = modules.filter(m => modulesEmitted.get(m.id).isEmpty).map { module =>
+      val missingModuleEmitters = modules.filter(m => !modulesEmitted.contains(m.id)).map { module =>
         Some(ReferenceEmitter(module, Some(Aliases(Set())), ordering, () => idCounter.genId("uses")))
       }
       val finalEmitters = (aliasesEmitters ++ missingModuleEmitters).collect { case Some(e) => e }


### PR DESCRIPTION
`format: date` was incorrectly being emmited from OAS20 to RAML10, added it to OAS known types. Also fixed some code smells.