### PR TITLE
APIMF-2625: remove enum values from shape when validating each enum value

### DIFF
--- a/amf-webapi/shared/src/main/scala/amf/plugins/domain/shapes/validation/ShapesNodesValidator.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/domain/shapes/validation/ShapesNodesValidator.scala
@@ -1,6 +1,7 @@
 package amf.plugins.domain.shapes.validation
 
 import amf.core.metamodel.document.PayloadFragmentModel
+import amf.core.metamodel.domain.ShapeModel
 import amf.core.model.document.PayloadFragment
 import amf.core.model.domain.{DataNode, ScalarNode, Shape}
 import amf.core.utils.MediaTypeMatcher
@@ -30,12 +31,18 @@ object ShapesNodesValidator {
       .groupBy(_.shape)
       .keys
       .flatMap({
-        case s: Shape if s.values.nonEmpty =>
-          s.values.map(v => ValidationCandidate(s, PayloadFragment(v, defaultMediaTypeFor(v))))
-        case _ => Nil
+        case s: Shape if s.values.nonEmpty => shapeEnumCandidates(s)
+        case _                             => Nil
       })
     //call to validation
     PayloadValidationPluginsHandler.validateAll(enumsCandidates.toSeq, severity, env)
+  }
+
+  private[validation] def shapeEnumCandidates(shape: Shape): Seq[ValidationCandidate] = {
+    val enums       = shape.values
+    val shallowCopy = shape.copyShape()
+    shallowCopy.fields.removeField(ShapeModel.Values) // remove enum values from shape as is in not necessary when validating each enum value.
+    enums.map(v => ValidationCandidate(shallowCopy, PayloadFragment(v, defaultMediaTypeFor(v))))
   }
 
   def defaultMediaTypeFor(dataNode: DataNode): String = dataNode match {

--- a/amf-webapi/shared/src/test/scala/amf/plugins/domain/shapes/validation/ShapesNodesValidatorTest.scala
+++ b/amf-webapi/shared/src/test/scala/amf/plugins/domain/shapes/validation/ShapesNodesValidatorTest.scala
@@ -1,0 +1,24 @@
+package amf.plugins.domain.shapes.validation
+
+import amf.core.model.domain.ScalarNode
+import amf.plugins.domain.shapes.models.NodeShape
+import org.scalatest.{FunSuite, Matchers}
+
+class ShapesNodesValidatorTest extends FunSuite with Matchers {
+
+  test("generation of validation candidates for enums in shape") {
+    val shape = NodeShape().withId("id")
+    shape.withValues(List(ScalarNode("value 1", None), ScalarNode("value 1", None)))
+
+    val candidates = ShapesNodesValidator.shapeEnumCandidates(shape)
+
+    val candidateShape = candidates.head.shape
+
+    candidates.size shouldBe 2
+    // shape that is use for validation should not contain enum values to avoid performance issues
+    candidateShape.values shouldBe empty
+    // original shape must not be modified, its enum value should still be defined
+    shape.values should not be empty
+
+  }
+}


### PR DESCRIPTION
validation of a raml type with 70k enum values passes from 2 minutes to 7 seconds.