### PR TITLE
APIMF-2760: moved PayloadValidatorMatcher to amf-core. Added ValidatorAware interface to AnyShape

### DIFF
--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,4 +1,4 @@
 amf.webapi=4.6.0-SNAPSHOT
-amf.core=4.1.160
+amf.core=4.1.163
 amf.custom.validations=5.2.0-SNAPSHOT
 amf.model=2.3.0

--- a/amf-webapi/shared/src/main/scala/amf/client/convert/WebApiBaseConverter.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/convert/WebApiBaseConverter.scala
@@ -57,8 +57,8 @@ import amf.client.model.domain.{
   WebSocketsChannelBinding => ClientWebSocketsChannelBinding
 }
 import amf.client.validate.{PayloadValidator => ClientInternalPayloadValidator}
-import amf.core.unsafe.PlatformSecrets
 import amf.core.validation.PayloadValidator
+import amf.core.unsafe.PlatformSecrets
 import amf.plugins.domain.shapes.models.CreativeWork
 import amf.plugins.domain.webapi.models._
 import amf.plugins.domain.webapi.models.bindings.amqp._
@@ -92,7 +92,6 @@ trait WebApiBaseConverter
     with TemplatedLinkConverter
     with CallbackConverter
     with EncodingConverter
-    with PayloadValidatorConverter
     with OAuth2FlowConverter
     with SecurityRequirementConverter
     with CorrelationIdConverter
@@ -546,16 +545,5 @@ trait TemplatedLinkConverter extends PlatformSecrets {
   implicit object TemplatedLinkConverter extends BidirectionalMatcher[TemplatedLink, ClientTemplatedLink] {
     override def asClient(from: TemplatedLink): ClientTemplatedLink   = platform.wrap[ClientTemplatedLink](from)
     override def asInternal(from: ClientTemplatedLink): TemplatedLink = from._internal
-  }
-}
-
-trait PayloadValidatorConverter {
-
-  implicit object PayloadValidatorMatcher
-      extends BidirectionalMatcher[PayloadValidator, ClientInternalPayloadValidator] {
-    override def asClient(from: PayloadValidator): ClientInternalPayloadValidator =
-      new ClientInternalPayloadValidator(from)
-
-    override def asInternal(from: ClientInternalPayloadValidator): PayloadValidator = from._internal
   }
 }

--- a/amf-webapi/shared/src/main/scala/amf/client/model/domain/AnyShape.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/model/domain/AnyShape.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 
 @JSExportAll
-class AnyShape(override private[amf] val _internal: InternalAnyShape) extends Shape with PlatformSecrets {
+class AnyShape(override private[amf] val _internal: InternalAnyShape) extends Shape with ValidatorAware with PlatformSecrets {
 
   @JSExportTopLevel("model.domain.AnyShape")
   def this() = this(InternalAnyShape())

--- a/amf-webapi/shared/src/main/scala/amf/plugins/domain/shapes/models/AnyShape.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/domain/shapes/models/AnyShape.scala
@@ -6,7 +6,7 @@ import amf.core.annotations.DeclaredElement
 import amf.core.emitter.ShapeRenderOptions
 import amf.core.model.StrField
 import amf.core.model.document.PayloadFragment
-import amf.core.model.domain.{DomainElement, ExternalSourceElement, Linkable, Shape}
+import amf.core.model.domain.{DomainElement, ExternalSourceElement, Linkable, Shape, ValidatorAware}
 import amf.core.parser.{Annotations, Fields}
 import amf.core.utils.AmfStrings
 import amf.core.validation.{AMFValidationReport, PayloadValidator, SeverityLevels}
@@ -91,7 +91,8 @@ class AnyShape(val fields: Fields, val annotations: Annotations = Annotations())
     with ExternalSourceElement
     with InheritanceChain
     with DocumentedElement
-    with ExemplifiedDomainElement {
+    with ExemplifiedDomainElement
+    with ValidatorAware {
 
   // TODO: should return Option has field can be null
   def documentation: CreativeWork     = fields.field(Documentation)


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-core/pull/146