### PR TITLE
APIMF-2768: propagated implicit error handlers were there weren't for SYAML conversions. Most test cases are hard to reach so they aren't explicitly tested

### DIFF
--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-expanded-context-entry-id-format.jsonld
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-expanded-context-entry-id-format.jsonld
@@ -1,0 +1,23 @@
+{
+  "@graph": [
+    {
+      "@id": "#4",
+      "@type": [
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "name": "API",
+      "http://a.ml/vocabularies/document#root": true
+    }
+  ],
+  "@context": {
+    "@base": "amf://id",
+    "doc": "http://a.ml/vocabularies/document#",
+    "apiContract": "http://a.ml/vocabularies/apiContract#",
+    "strict": {
+      "@id": false
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-expanded-context-entry-type-format.jsonld
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-expanded-context-entry-type-format.jsonld
@@ -1,0 +1,26 @@
+{
+  "@graph": [
+    {
+      "@id": "#4",
+      "@type": [
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "name": "API",
+      "http://a.ml/vocabularies/document#root": true
+    }
+  ],
+  "@context": {
+    "@base": "amf://id",
+    "doc": "http://a.ml/vocabularies/document#",
+    "apiContract": "http://a.ml/vocabularies/apiContract#",
+    "strict": {
+      "@id": "something",
+      "@type": {
+        "a": ["an unexpected map", 5]
+      }
+    }
+  }
+}

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-graph-dependency-value.jsonld
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-graph-dependency-value.jsonld
@@ -1,0 +1,13 @@
+[
+  {
+    "@id": "file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-graph-dependency-value.jsonld",
+    "@type": [
+      "http://a.ml/vocabularies/document#Document"
+    ],
+    "http://a.ml/vocabularies/document#graphDependencies": [
+      {
+        "@id": ["an", "unexpected", "sequence", 5, true]
+      }
+    ]
+  }
+]

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-root-field-value.jsonld
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-root-field-value.jsonld
@@ -1,0 +1,20 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:root": [
+      {
+        "@value": 5
+      }
+    ],
+    "@context": {
+      "@base": "amf://id",
+      "doc": "http://a.ml/vocabularies/document#"
+    }
+  }
+]

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-type-array-is-not-all-string.jsonld
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-type-array-is-not-all-string.jsonld
@@ -1,0 +1,11 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      ["aSeq", "in", "the", "middle"],
+      "doc:Unit"
+    ]
+  }
+]

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-version-value.jsonld
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-version-value.jsonld
@@ -1,0 +1,23 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:version": [
+      {
+        "@value": ["a", "seq"]
+      }
+    ],
+    "@context": {
+      "@base": "amf://id",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#",
+      "sourcemaps": "http://a.ml/vocabularies/document-source-maps#"
+    }
+  }
+]

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-expanded-context-entry-id-format.report
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-expanded-context-entry-id-format.report
@@ -1,0 +1,14 @@
+Model: amf://id#4
+Profile: AMF Graph
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/core#syaml-error
+  Message: Expecting !!str, !!bool provided
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(20,13)-(20,18)]))
+  Location: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-expanded-context-entry-id-format.jsonld

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-expanded-context-entry-type-format.report
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-expanded-context-entry-type-format.report
@@ -1,0 +1,14 @@
+Model: amf://id#4
+Profile: AMF Graph
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/core#syaml-error
+  Message: Expecting !!str, !!map provided
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(21,15)-(23,7)]))
+  Location: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-expanded-context-entry-type-format.jsonld

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-graph-dependency-value.report.js
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-graph-dependency-value.report.js
@@ -1,0 +1,22 @@
+Model: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-graph-dependency-value.jsonld
+Profile: AMF Graph
+Conforms? false
+Number of results: 2
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/core#syaml-error
+  Message: Expecting !!str, !!seq provided
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(9,15)-(9,56)]))
+  Location: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-graph-dependency-value.jsonld
+
+- Source: http://a.ml/vocabularies/amf/core#unresolved-reference
+  Message: File Not Found: EISDIR: illegal operation on a directory, read
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(9,15)-(9,56)]))
+  Location: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-graph-dependency-value.jsonld

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-graph-dependency-value.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-graph-dependency-value.report.jvm
@@ -1,0 +1,22 @@
+Model: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-graph-dependency-value.jsonld
+Profile: AMF Graph
+Conforms? false
+Number of results: 2
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/core#syaml-error
+  Message: Expecting !!str, !!seq provided
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(9,15)-(9,56)]))
+  Location: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-graph-dependency-value.jsonld
+
+- Source: http://a.ml/vocabularies/amf/core#unresolved-reference
+  Message: File Not Found: amf-client/shared/src/test/resources/validations/conversion-exceptions (Is a directory)
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(9,15)-(9,56)]))
+  Location: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-graph-dependency-value.jsonld

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-root-field-value.report
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-root-field-value.report
@@ -1,0 +1,14 @@
+Model: amf://id
+Profile: AMF Graph
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/core#syaml-error
+  Message: Expecting !!bool, !!int provided
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(12,18)-(12,19)]))
+  Location: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-root-field-value.jsonld

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-type-array-is-not-all-string.report
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-type-array-is-not-all-string.report
@@ -1,0 +1,22 @@
+Model: null
+Profile: AMF Graph
+Conforms? false
+Number of results: 2
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/core#parse-document-fail
+  Message: Unable to parse Document: [{"@id": "", "@type": ["doc:Document", "doc:Fragment", ["aSeq", "in", "the", "middle"], "doc:Unit"]}]
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-type-array-is-not-all-string.jsonld
+  Property: 
+  Position: Some(LexicalInformation([(1,0)-(12,0)]))
+  Location: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-type-array-is-not-all-string.jsonld
+
+- Source: http://a.ml/vocabularies/amf/core#parse-node-fail
+  Message: Error parsing JSON-LD node, unknown @types ArrayBuffer(doc:Document, doc:Fragment, doc:Unit)
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(2,2)-(10,3)]))
+  Location: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-type-array-is-not-all-string.jsonld

--- a/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-version-value.report
+++ b/amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/invalid-version-value.report
@@ -1,0 +1,14 @@
+Model: amf://id
+Profile: AMF Graph
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/core#syaml-error
+  Message: Expected scalar but found: ["a", "seq"]
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(12,18)-(12,30)]))
+  Location: file://amf-client/shared/src/test/resources/validations/conversion-exceptions/invalid-version-value.jsonld

--- a/amf-client/shared/src/test/scala/amf/parser/AmfGraphSyamlConversionExceptionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/parser/AmfGraphSyamlConversionExceptionTest.scala
@@ -1,0 +1,40 @@
+package amf.parser
+
+import amf.core.remote.{AmfJsonHint, Hint}
+import amf.validation.{MultiPlatformReportGenTest, UniquePlatformReportGenTest}
+
+class UniqueAmfGraphSyamlConversionExceptionTest extends UniquePlatformReportGenTest{
+  override val basePath: String = "file://amf-client/shared/src/test/resources/validations/conversion-exceptions/"
+  override val reportsPath: String = "amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/"
+  override val hint: Hint = AmfJsonHint
+
+  test("Invalid @type array is not all strings") {
+    validate("invalid-type-array-is-not-all-string.jsonld", Some("invalid-type-array-is-not-all-string.report"))
+  }
+
+  test("JSON-LD value conversion uses error handler 1") {
+    validate("invalid-root-field-value.jsonld", Some("invalid-root-field-value.report"))
+  }
+
+  test("JSON-LD value conversion uses error handler 2") {
+    validate("invalid-version-value.jsonld", Some("invalid-version-value.report"))
+  }
+
+  test("Invalid expanded context entry id format") {
+    validate("invalid-expanded-context-entry-id-format.jsonld", Some("invalid-expanded-context-entry-id-format.report"))
+  }
+
+  test("Invalid expanded context entry type format") {
+    validate("invalid-expanded-context-entry-type-format.jsonld", Some("invalid-expanded-context-entry-type-format.report"))
+  }
+}
+
+class MultiAmfGraphSyamlConversionExceptionTest extends MultiPlatformReportGenTest{
+  override val basePath: String = "file://amf-client/shared/src/test/resources/validations/conversion-exceptions/"
+  override val reportsPath: String = "amf-client/shared/src/test/resources/validations/conversion-exceptions/reports/"
+  override val hint: Hint = AmfJsonHint
+
+  test("Invalid graph dependency value") {
+    validate("invalid-graph-dependency-value.jsonld", Some("invalid-graph-dependency-value.report"))
+  }
+}

--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,4 +1,4 @@
 amf.webapi=4.6.0-SNAPSHOT
-amf.core=4.1.163
+amf.core=4.1.164
 amf.custom.validations=5.2.0-SNAPSHOT
 amf.model=2.3.0

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/contexts/parser/raml/RamlWebApiContext.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/contexts/parser/raml/RamlWebApiContext.scala
@@ -1,6 +1,7 @@
 package amf.plugins.document.webapi.contexts.parser.raml
 import amf.core.client.ParsingOptions
 import amf.core.model.domain.Shape
+import amf.core.parser.errorhandler.ParserErrorHandler
 import amf.core.parser.{ParsedReference, ParserContext}
 import amf.core.remote.{Payload, Vendor}
 import amf.plugins.document.webapi.contexts.WebApiContext
@@ -73,6 +74,8 @@ abstract class RamlWebApiContext(override val loc: String,
   }
 
   override def link(node: YNode): Either[String, YNode] = {
+    implicit val errorHandler: IllegalTypeHandler = eh
+
     node match {
       case _ if isInclude(node) => Left(node.as[YScalar].text)
       case _                    => Right(node)
@@ -114,6 +117,9 @@ abstract class RamlWebApiContext(override val loc: String,
     * can be defined in the AST node
     */
   def closedRamlTypeShape(shape: Shape, ast: YMap, shapeType: String, typeInfo: TypeInfo): Unit = {
+
+    implicit val errorHandler: IllegalTypeHandler = eh
+
     val node       = shape.id
     val facets     = shape.collectCustomShapePropertyDefinitions(onlyInherited = true)
     val shapeLabel = RamlShapeTypeBeautifier.beautify(shapeType)

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/LibraryLocationParser.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/LibraryLocationParser.scala
@@ -1,18 +1,13 @@
 package amf.plugins.document.webapi.parser.spec.declaration
 
-import amf.core.parser.ParserContext
+import amf.core.parser.errorhandler.ParserErrorHandler
 import org.yaml.model.{YMapEntry, YScalar, YType}
 
-case class LibraryLocationParser(e: YMapEntry) {
-
-  def parse()(implicit ctx: ParserContext): Option[String] = {
+object LibraryLocationParser {
+  def apply(e: YMapEntry)(implicit errorHandler: ParserErrorHandler): Option[String] = {
     e.value.tagType match {
       case YType.Null | YType.Map | YType.Seq => None
       case _                                  => Some(e.value.as[YScalar].text) // TODO should we validate the tag?
     }
   }
-}
-
-object LibraryLocationParser {
-  def apply(e: YMapEntry, ctx: ParserContext): Option[String] = new LibraryLocationParser(e).parse()(ctx)
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/ReferencesParsers.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/ReferencesParsers.scala
@@ -66,7 +66,7 @@ case class ReferencesParser(baseUnit: BaseUnit, id: String, key: String, map: YM
               .entries
               .foreach(e => {
                 val alias: String = e.key.as[YScalar].text
-                val urlOption     = LibraryLocationParser(e, ctx)
+                val urlOption     = LibraryLocationParser(e)(ctx.eh)
                 urlOption.foreach { url =>
                   target(url).foreach {
                     case module: DeclaresModel =>

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/external/raml/RamlJsonSchemaExpression.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/external/raml/RamlJsonSchemaExpression.scala
@@ -139,6 +139,9 @@ case class RamlJsonSchemaExpression(key: YNode,
   }
 
   case class RamlExternalOasLibParser(ctx: RamlWebApiContext, text: String, valueAST: YNode, path: String) {
+
+    private implicit val errorHandler: IllegalTypeHandler = ctx.eh
+
     def parse(): Unit = {
       // todo: should we add string begin position to each node position? in order to have the positions relatives to root api intead of absolut to text
       // todo: this should be migrated to JsonSchemaParser

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/domain/ExampleEmitters.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/domain/ExampleEmitters.scala
@@ -237,10 +237,7 @@ object RamlExampleValuesEmitter {
     val fs = example.fields
     // This should remove Strict if we auto-generated it when parsing the model
     val explicitMetaFields =
-      List(ExampleModel.Strict,
-           ExampleModel.Description,
-           ExampleModel.DisplayName,
-           ExampleModel.CustomDomainProperties)
+      List(ExampleModel.Strict, ExampleModel.Description, ExampleModel.DisplayName, ExampleModel.CustomDomainProperties)
         .filter { f =>
           fs.entry(f) match {
             case Some(entry) => !entry.value.annotations.contains(classOf[SynthesizedField])
@@ -356,16 +353,11 @@ case class StringToAstEmitter(value: String) extends PartEmitter {
   }
   private def emitNode(node: YNode, b: PartBuilder): Unit = {
 
-    node.tagType match {
-      case YType.Map =>
-        val map = node.as[YMap]
-        b.obj(e => map.entries.foreach(entry => e.entry(entry.key.as[String], p => emitNode(entry.value, p))))
-      case YType.Seq =>
-        val seq = node.as[Seq[YNode]]
-        b.list(p => seq.foreach(emitNode(_, p)))
-      case _ =>
-        val scalar = node.as[YScalar]
-        b += scalar.text
+    node.value match {
+      case map: YMap       => b.obj(e => map.entries.foreach(entry => e.entry(entry.key, p => emitNode(entry.value, p))))
+      case seq: YSequence  => b.list(p => seq.nodes.foreach(emitNode(_, p)))
+      case scalar: YScalar => b += scalar.text
+      case _               => // ignore
     }
   }
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/domain/ParameterParsers.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/domain/ParameterParsers.scala
@@ -640,7 +640,7 @@ object Oas3ParameterParser {
     "deepObject"     -> List("query")
   )
 
-  def parseExplodeField(map: YMap, result: Parameter): Unit = {
+  def parseExplodeField(map: YMap, result: Parameter)(implicit errorHandler: IllegalTypeHandler): Unit = {
     map.key("explode") match {
       case Some(entry) =>
         result.fields.setWithoutId(ParameterModel.Explode,


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-core/pull/150