### PR TITLE
APIMF-2607: Bump core to 4.1.169. Fix test

### DIFF
--- a/amf-client/shared/src/test/scala/amf/compiler/AnnotationInFieldTest.scala
+++ b/amf-client/shared/src/test/scala/amf/compiler/AnnotationInFieldTest.scala
@@ -218,7 +218,7 @@ class AnnotationInFieldTest extends AsyncFunSuite with CompilerTestBuilder {
 
       assert(targets.size == 1)
       assert(targets.head._1 == s"${uri}reference-1.yaml")
-      assert(targets.head._2 == List(Range(Position(6, 5), Position(6, 30))))
+      assert(targets.head._2 == List(Range(Position(6, 14), Position(6, 30))))
 
       assert(reftargets.size == 1)
       assert(reftargets.head._1 == s"${uri}reference.json")

--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,4 +1,4 @@
 amf.webapi=4.7.0-SNAPSHOT
-amf.core=4.1.168
+amf.core=4.1.169
 amf.custom.validations=5.2.0-SNAPSHOT
 amf.model=2.3.0


### PR DESCRIPTION
Related to https://github.com/aml-org/amf-core/pull/156