### PR TITLE
APIMF-2814: maintain precision when validating large numbers

### DIFF
--- a/amf-client/shared/src/test/resources/org/raml/api/v10/error-path/model.json.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/api/v10/error-path/model.json.jvm
@@ -34,7 +34,7 @@ required key [family] not found
   Location: file://amf-client/shared/src/test/resources/org/raml/api/v10/error-path/input.raml
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /age expected type: Number, found: String
+  Message: /age expected type: Integer, found: String
 /name expected type: String, found: Integer
 
   Level: Violation
@@ -46,7 +46,7 @@ required key [family] not found
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: /users/1/family/1 expected type: String, found: Integer
 /users/1/family/2 expected type: String, found: Integer
-/users/2/age expected type: Number, found: String
+/users/2/age expected type: Integer, found: String
 
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/org/raml/api/v10/error-path/input.raml#/declarations/types/Book/example/one

--- a/amf-client/shared/src/test/resources/org/raml/parser/examples/builtin/number/output.txt.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/parser/examples/builtin/number/output.txt.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /age expected type: Integer, found: Double
+  Message: /age expected type: Integer, found: BigDecimal
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/org/raml/parser/examples/builtin/number/input.raml#/declarations/types/User/example/bad-int
   Property: file://amf-client/shared/src/test/resources/org/raml/parser/examples/builtin/number/input.raml#/declarations/types/User/example/bad-int

--- a/amf-client/shared/src/test/resources/org/raml/parser/examples/connect/output.txt.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/parser/examples/connect/output.txt.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /orders/1/items/0/quantity expected type: Number, found: String
+  Message: /orders/1/items/0/quantity expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/org/raml/parser/examples/connect/input.raml#/web-api/end-points/%2Forders/get/200/application%2Fjson/schema/example/multiple-orders
   Property: file://amf-client/shared/src/test/resources/org/raml/parser/examples/connect/input.raml#/web-api/end-points/%2Forders/get/200/application%2Fjson/schema/example/multiple-orders

--- a/amf-client/shared/src/test/resources/org/raml/parser/examples/include-json-schema-multiple-examples/output.txt.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/parser/examples/include-json-schema-multiple-examples/output.txt.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /age expected type: Number, found: String
+  Message: /age expected type: Integer, found: String
 /name expected type: String, found: Integer
 
   Level: Violation

--- a/amf-client/shared/src/test/resources/org/raml/parser/examples/include-json-schema-yaml-example/output.txt.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/parser/examples/include-json-schema-yaml-example/output.txt.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /age expected type: Number, found: String
+  Message: /age expected type: Integer, found: String
 /name expected type: String, found: Integer
 
   Level: Violation

--- a/amf-client/shared/src/test/resources/org/raml/parser/examples/include-json-schema/output.txt.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/parser/examples/include-json-schema/output.txt.jvm
@@ -6,7 +6,7 @@ Number of results: 2
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /age expected type: Number, found: String
+  Message: /age expected type: Integer, found: String
 /name expected type: String, found: Integer
 
   Level: Violation
@@ -16,7 +16,7 @@ Level: Violation
   Location: file://amf-client/shared/src/test/resources/org/raml/parser/examples/include-json-schema/input.raml
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /age expected type: Number, found: String
+  Message: /age expected type: Integer, found: String
 /name expected type: String, found: Integer
 
   Level: Violation

--- a/amf-client/shared/src/test/resources/org/raml/parser/examples/pattern-properties-bad/output.txt.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/parser/examples/pattern-properties-bad/output.txt.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /note1 expected type: String, found: Double
+  Message: /note1 expected type: String, found: BigDecimal
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/org/raml/parser/examples/pattern-properties-bad/input.raml#/declarations/types/Person/example/default-example
   Property: file://amf-client/shared/src/test/resources/org/raml/parser/examples/pattern-properties-bad/input.raml#/declarations/types/Person/example/default-example

--- a/amf-client/shared/src/test/resources/org/raml/parser/types/builtin/number-float/output.txt
+++ b/amf-client/shared/src/test/resources/org/raml/parser/types/builtin/number-float/output.txt
@@ -4,6 +4,6 @@ types:
   MyCustomType:
     type: number
     minimum: 2.5
-    maximum: 9.3
+    maximum: 9.30
     multipleOf: 3.4
     example: 6.8

--- a/amf-client/shared/src/test/resources/org/raml/parser/types/builtin/number-restricted-with-format/output.txt.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/parser/types/builtin/number-restricted-with-format/output.txt.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /Priority expected type: Integer, found: Double
+  Message: /Priority expected type: Integer, found: BigDecimal
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/org/raml/parser/types/builtin/number-restricted-with-format/input.raml#/web-api/end-points/%2Fresource/post/request/application%2Fjson/schema/example/default-example
   Property: file://amf-client/shared/src/test/resources/org/raml/parser/types/builtin/number-restricted-with-format/input.raml#/web-api/end-points/%2Fresource/post/request/application%2Fjson/schema/example/default-example

--- a/amf-client/shared/src/test/resources/org/raml/parser/types/multiple-inheritance-validation/output.txt.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/parser/types/multiple-inheritance-validation/output.txt.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /age expected type: Number, found: String
+  Message: /age expected type: Integer, found: String
 /id expected type: String, found: Integer
 
   Level: Violation

--- a/amf-client/shared/src/test/resources/org/raml/parser/types/simple-inheritance-validation/output.txt.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/parser/types/simple-inheritance-validation/output.txt.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /id expected type: Number, found: String
+  Message: /id expected type: Integer, found: String
 /name expected type: String, found: Integer
 
   Level: Violation

--- a/amf-client/shared/src/test/resources/org/raml/parser/types/sugar/object/output.txt.jvm
+++ b/amf-client/shared/src/test/resources/org/raml/parser/types/sugar/object/output.txt.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /name expected type: Number, found: String
+  Message: /name expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/org/raml/parser/types/sugar/object/input.raml#/declarations/types/Person/example/default-example
   Property: file://amf-client/shared/src/test/resources/org/raml/parser/types/sugar/object/input.raml#/declarations/types/Person/example/default-example

--- a/amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+++ b/amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
@@ -1,0 +1,40 @@
+#%RAML 1.0
+title: some title
+types:
+  BigNumberMax:
+    type: number
+    maximum: 9999999999999999
+    examples:
+      valid: 9999999999999999
+      wrong0: 10000000000000000
+      wrong1: 10000000000000001
+      wrong2: 10000000000000002
+      wrong3: 10000000000000003
+
+  BigNumberMin:
+    type: number
+    minimum: 10000000000000000
+    examples:
+      valid: 10000000000000000
+      wrong1: 9999999999999999
+
+  BigIntMax:
+    type: integer
+    maximum: 9999999999999999
+    examples:
+      valid: 9999999999999999
+      wrong0: 10000000000000000
+      wrong1: 10000000000000001
+      wrong2: 10000000000000002
+      wrong3: 10000000000000003
+
+  BigIntMin:
+    type: integer
+    minimum: 10000000000000000
+    examples:
+      valid: 10000000000000000
+      wrong1: 9999999999999999
+
+
+
+

--- a/amf-client/shared/src/test/resources/validations/raml/big-number-in-schema.raml
+++ b/amf-client/shared/src/test/resources/validations/raml/big-number-in-schema.raml
@@ -1,0 +1,28 @@
+#%RAML 1.0
+title: a title
+version: 1.0
+baseUri: http://someuri.com
+mediaType: application/json
+
+
+/subscription:
+  /usage:
+    displayName: name
+    description: lalal
+    post:
+      body:
+        application/json:
+          # define number with 21 digits (cannot be stored in long)
+          type: |
+            {
+              "type": "object",
+              "properties": {
+                "someNumber": {
+                  "type": "number",
+                  "maximum": 999999999999999999999
+                }
+              }
+            }
+          example: {
+            "someNumber": 0
+          }

--- a/amf-client/shared/src/test/resources/validations/reports/async20/draft-7-validations.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/async20/draft-7-validations.report.jvm
@@ -64,7 +64,7 @@ Level: Violation
   Location: file://amf-client/shared/src/test/resources/validations/async20/validations/draft-7-validations.yaml
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /a is not less than 100
+  Message: /a 100 is not less than 100
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/async20/validations/draft-7-validations.yaml#/declarations/types/exclusive-with-values/example/default-example_2
   Property: file://amf-client/shared/src/test/resources/validations/async20/validations/draft-7-validations.yaml#/declarations/types/exclusive-with-values/example/default-example_2
@@ -72,7 +72,7 @@ Level: Violation
   Location: file://amf-client/shared/src/test/resources/validations/async20/validations/draft-7-validations.yaml
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: subject must not be valid against schema {"type":"object","properties":{"a":{"type":"string"},"b":{"type":"number"}},"required":["a","b"]}
+  Message: subject must not be valid against schema {"type":"object","required":["a","b"],"properties":{"a":{"type":"string"},"b":{"type":"number"}}}
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/async20/validations/draft-7-validations.yaml#/declarations/types/any/notKeyword/example/default-example_2
   Property: file://amf-client/shared/src/test/resources/validations/async20/validations/draft-7-validations.yaml#/declarations/types/any/notKeyword/example/default-example_2

--- a/amf-client/shared/src/test/resources/validations/reports/examples/annotations.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/annotations.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: expected type: Number, found: String
+  Message: expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/annotations/annotations.raml#/web-api/b/scalar_1
   Property: file://amf-client/shared/src/test/resources/validations/annotations/annotations.raml#/web-api/b/scalar_1

--- a/amf-client/shared/src/test/resources/validations/reports/examples/big_nums.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/big_nums.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: 1000000000000 is not less or equal to 9.99999999999E11
+  Message: 1000000000000 is not less or equal to 999999999999
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/types/big_nums.raml#/declarations/types/scalar/LongNumber/example/three
   Property: file://amf-client/shared/src/test/resources/validations/types/big_nums.raml#/declarations/types/scalar/LongNumber/example/three

--- a/amf-client/shared/src/test/resources/validations/reports/examples/double-example-inttype.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/double-example-inttype.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: expected type: Integer, found: Double
+  Message: expected type: Integer, found: BigDecimal
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/examples/double-example-inttype.raml#/declarations/types/orders/property/Priority/scalar/Priority/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/examples/double-example-inttype.raml#/declarations/types/orders/property/Priority/scalar/Priority/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/examples/example-in-unions.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/example-in-unions.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: expected type: Number, found: JSONObject
+  Message: expected type: Integer, found: JSONObject
 expected type: String, found: JSONObject
 
   Level: Violation

--- a/amf-client/shared/src/test/resources/validations/reports/examples/examples-in-oas.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/examples-in-oas.report.jvm
@@ -7,7 +7,7 @@ Level: Warning
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: /dateOfBirth [bla bla] is not a valid date-time. Expected [yyyy-MM-dd'T'HH:mm:ssZ, yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,9}Z, yyyy-MM-dd'T'HH:mm:ss[+-]HH:mm, yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,9}[+-]HH:mm]
-/phoneNo expected type: Number, found: String
+/phoneNo expected type: Integer, found: String
 
   Level: Warning
   Target: file://amf-client/shared/src/test/resources/validations/examples/examples-in-oas.json#/declarations/types/User/example/default-example
@@ -17,9 +17,9 @@ Level: Warning
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: /application/user/dateOfBirth [bla bla] is not a valid date-time. Expected [yyyy-MM-dd'T'HH:mm:ssZ, yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,9}Z, yyyy-MM-dd'T'HH:mm:ss[+-]HH:mm, yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,9}[+-]HH:mm]
-/application/user/monthsAtCurrAdd expected type: Number, found: String
+/application/user/monthsAtCurrAdd expected type: Integer, found: String
 /user/dateOfBirth [bla bla bla] is not a valid date-time. Expected [yyyy-MM-dd'T'HH:mm:ssZ, yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,9}Z, yyyy-MM-dd'T'HH:mm:ss[+-]HH:mm, yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,9}[+-]HH:mm]
-/user/monthsAtCurrAdd expected type: Number, found: String
+/user/monthsAtCurrAdd expected type: Integer, found: String
 
   Level: Warning
   Target: file://amf-client/shared/src/test/resources/validations/examples/examples-in-oas.json#/declarations/types/LoanApplication/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/examples/examples_validation.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/examples_validation.report.jvm
@@ -6,7 +6,7 @@ Number of results: 4
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /b expected type: Number, found: String
+  Message: /b expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/examples/examples_validation.raml#/declarations/types/A/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/examples/examples_validation.raml#/declarations/types/A/example/default-example
@@ -14,7 +14,7 @@ Level: Violation
   Location: file://amf-client/shared/src/test/resources/validations/examples/examples_validation.raml
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: expected type: Number, found: String
+  Message: expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/examples/examples_validation.raml#/declarations/types/scalar/D/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/examples/examples_validation.raml#/declarations/types/scalar/D/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/examples/int-formats.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/int-formats.report.jvm
@@ -6,7 +6,7 @@ Number of results: 4
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: expected type: Integer, found: Double
+  Message: expected type: Integer, found: BigDecimal
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/types/int-formats.raml#/declarations/types/scalar/int/example/invalid
   Property: file://amf-client/shared/src/test/resources/validations/types/int-formats.raml#/declarations/types/scalar/int/example/invalid

--- a/amf-client/shared/src/test/resources/validations/reports/examples/invalid-property-in-array-items.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/invalid-property-in-array-items.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /orders/0/items/0/quantity expected type: Number, found: String
+  Message: /orders/0/items/0/quantity expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/examples/invalid-property-in-array-items.raml#/web-api/end-points/%2Forders/get/200/application%2Fjson/schema/example/single-order
   Property: file://amf-client/shared/src/test/resources/validations/examples/invalid-property-in-array-items.raml#/web-api/end-points/%2Forders/get/200/application%2Fjson/schema/example/single-order

--- a/amf-client/shared/src/test/resources/validations/reports/examples/named-examples-seq-invalid.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/named-examples-seq-invalid.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /1/age expected type: Number, found: String
+  Message: /1/age expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/examples/named-examples-seq-invalid/api.raml#/declarations/types/array/People/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/examples/named-examples-seq-invalid/api.raml#/declarations/types/array/People/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/examples/null-keys.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/null-keys.report.jvm
@@ -6,7 +6,7 @@ Number of results: 3
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /b expected type: Number, found: String
+  Message: /b expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/production/null-keys/api.raml#/web-api/end-points/%2FUsuario/delete/request/application%2Fjson/schema/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/production/null-keys/api.raml#/web-api/end-points/%2FUsuario/delete/request/application%2Fjson/schema/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/examples/pattern-properties/pattern_properties.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/pattern-properties/pattern_properties.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /note1 expected type: Number, found: String
+  Message: /note1 expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/examples/pattern-properties/pattern_properties.raml#/web-api/end-points/%2Ftest/get/200/application%2Fjson/schema/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/examples/pattern-properties/pattern_properties.raml#/web-api/end-points/%2Ftest/get/200/application%2Fjson/schema/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/examples/pattern-properties/pattern_properties2.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/pattern-properties/pattern_properties2.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /note1 expected type: Number, found: String
+  Message: /note1 expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/examples/pattern-properties/pattern_properties2.raml#/web-api/end-points/%2Ftest/get/200/application%2Fjson/schema/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/examples/pattern-properties/pattern_properties2.raml#/web-api/end-points/%2Ftest/get/200/application%2Fjson/schema/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/examples/pattern-properties/pattern_properties3.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/pattern-properties/pattern_properties3.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /note1 expected type: Number, found: String
+  Message: /note1 expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/examples/pattern-properties/pattern_properties3.raml#/web-api/end-points/%2Ftest/get/200/application%2Fjson/schema/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/examples/pattern-properties/pattern_properties3.raml#/web-api/end-points/%2Ftest/get/200/application%2Fjson/schema/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/examples/scalars-numbers-string.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/scalars-numbers-string.report.jvm
@@ -30,7 +30,7 @@ Level: Violation
   Location: file://amf-client/shared/src/test/resources/validations/examples/string-hierarchy.raml
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: expected type: String, found: Double
+  Message: expected type: String, found: BigDecimal
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/examples/string-hierarchy.raml#/declarations/types/scalar/SomeType/example/invalidNumber
   Property: file://amf-client/shared/src/test/resources/validations/examples/string-hierarchy.raml#/declarations/types/scalar/SomeType/example/invalidNumber

--- a/amf-client/shared/src/test/resources/validations/reports/examples/union1-invalid.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/examples/union1-invalid.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: expected type: Number, found: Boolean
+  Message: expected type: Integer, found: Boolean
 expected: null, found: Boolean
 
   Level: Violation

--- a/amf-client/shared/src/test/resources/validations/reports/extends/resource-types/parametrizedIncludesOfExamples.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/extends/resource-types/parametrizedIncludesOfExamples.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: expected type: Number, found: String
+  Message: expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/resource_types/parametrized-includes-of-examples/api.raml#/web-api/end-points/%2Fendpoint2/get/request/default/scalar/default/example/myExample
   Property: file://amf-client/shared/src/test/resources/validations/resource_types/parametrized-includes-of-examples/api.raml#/web-api/end-points/%2Fendpoint2/get/request/default/scalar/default/example/myExample

--- a/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/allOf-api1.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/allOf-api1.report.jvm
@@ -22,7 +22,7 @@ Level: Violation
   Location: file://amf-client/shared/src/test/resources/validations/jsonschema/allOf/api1.raml
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /bar expected type: Number, found: String
+  Message: /bar expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/jsonschema/allOf/api1.raml#/web-api/end-points/%2Fep4/get/200/application%2Fjson/any/schema/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/jsonschema/allOf/api1.raml#/web-api/end-points/%2Fep4/get/200/application%2Fjson/any/schema/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/anyOf-api1.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/anyOf-api1.report.jvm
@@ -7,7 +7,7 @@ Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: 1.5 is not greater or equal to 2
-expected type: Integer, found: Double
+expected type: Integer, found: BigDecimal
 
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/jsonschema/anyOf/api1.raml#/web-api/end-points/%2Fep4/get/200/application%2Fjson/any/schema/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/anyOf-api3.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/anyOf-api3.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /bar expected type: Number, found: String
+  Message: /bar expected type: Integer, found: String
 /foo expected type: String, found: Integer
 
   Level: Violation

--- a/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/jsonSchemaProperties.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/jsonSchemaProperties.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /I_4 expected type: Number, found: String
+  Message: /I_4 expected type: Integer, found: String
 /S_0 expected type: String, found: Integer
 /a expected type: String, found: Boolean
 

--- a/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/max-exclusive-schema.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/max-exclusive-schema.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: is not less than 180
+  Message: 180 is not less than 180
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/jsonschema/max-exclusive-schema.raml#/declarations/schemas/invalidExample/property/prop1/scalar/prop1/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/jsonschema/max-exclusive-schema.raml#/declarations/schemas/invalidExample/property/prop1/scalar/prop1/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/oneOf-api1.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/oneOf-api1.report.jvm
@@ -15,7 +15,7 @@ Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: 1.5 is not greater or equal to 2
-expected type: Integer, found: Double
+expected type: Integer, found: BigDecimal
 
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/jsonschema/oneOf/api1.raml#/web-api/end-points/%2Fep4/get/200/application%2Fjson/any/schema/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/oneOf-api3.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/oneOf-api3.report.jvm
@@ -14,7 +14,7 @@ Level: Violation
   Location: file://amf-client/shared/src/test/resources/validations/jsonschema/oneOf/api3.raml
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /bar expected type: Number, found: String
+  Message: /bar expected type: Integer, found: String
 /foo expected type: String, found: Integer
 
   Level: Violation

--- a/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/ref-api2.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/ref-api2.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /bar expected type: Number, found: Boolean
+  Message: /bar expected type: Integer, found: Boolean
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/jsonschema/ref/api2.raml#/web-api/end-points/%2Fep2/get/200/application%2Fjson/schema/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/jsonschema/ref/api2.raml#/web-api/end-points/%2Fep2/get/200/application%2Fjson/schema/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/ref-api3.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/ref-api3.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /1 expected type: Number, found: String
+  Message: /1 expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/jsonschema/ref/api3.raml#/web-api/end-points/%2Fep2/get/200/application%2Fjson/any/schema/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/jsonschema/ref/api3.raml#/web-api/end-points/%2Fep2/get/200/application%2Fjson/any/schema/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/ref-api4.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/jsonschema-examples/ref-api4.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: expected type: Number, found: String
+  Message: expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/jsonschema/ref/api4.raml#/web-api/end-points/%2Fep2/get/200/application%2Fjson/scalar/schema/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/jsonschema/ref/api4.raml#/web-api/end-points/%2Fep2/get/200/application%2Fjson/scalar/schema/example/default-example

--- a/amf-client/shared/src/test/resources/validations/reports/multi-plat-model/invalid-big-numbers.report.js
+++ b/amf-client/shared/src/test/resources/validations/reports/multi-plat-model/invalid-big-numbers.report.js
@@ -1,0 +1,38 @@
+Model: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+Profile: RAML 1.0
+Conforms? false
+Number of results: 4
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: should be <= 10000000000000000
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong2
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong2
+  Position: Some(LexicalInformation([(11,14)-(11,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: should be <= 10000000000000000
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong3
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong3
+  Position: Some(LexicalInformation([(12,14)-(12,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: should be <= 10000000000000000
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong2
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong2
+  Position: Some(LexicalInformation([(28,14)-(28,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: should be <= 10000000000000000
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong3
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong3
+  Position: Some(LexicalInformation([(29,14)-(29,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml

--- a/amf-client/shared/src/test/resources/validations/reports/multi-plat-model/invalid-big-numbers.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/multi-plat-model/invalid-big-numbers.report.jvm
@@ -1,0 +1,86 @@
+Model: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+Profile: RAML 1.0
+Conforms? false
+Number of results: 10
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: 10000000000000000 is not less or equal to 9999999999999999
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong0
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong0
+  Position: Some(LexicalInformation([(9,14)-(9,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: 10000000000000001 is not less or equal to 9999999999999999
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong1
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong1
+  Position: Some(LexicalInformation([(10,14)-(10,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: 10000000000000002 is not less or equal to 9999999999999999
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong2
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong2
+  Position: Some(LexicalInformation([(11,14)-(11,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: 10000000000000003 is not less or equal to 9999999999999999
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong3
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMax/example/wrong3
+  Position: Some(LexicalInformation([(12,14)-(12,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: 9999999999999999 is not greater or equal to 10000000000000000
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMin/example/wrong1
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigNumberMin/example/wrong1
+  Position: Some(LexicalInformation([(19,14)-(19,30)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: 10000000000000000 is not less or equal to 9999999999999999
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong0
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong0
+  Position: Some(LexicalInformation([(26,14)-(26,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: 10000000000000001 is not less or equal to 9999999999999999
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong1
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong1
+  Position: Some(LexicalInformation([(27,14)-(27,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: 10000000000000002 is not less or equal to 9999999999999999
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong2
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong2
+  Position: Some(LexicalInformation([(28,14)-(28,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: 10000000000000003 is not less or equal to 9999999999999999
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong3
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMax/example/wrong3
+  Position: Some(LexicalInformation([(29,14)-(29,31)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: 9999999999999999 is not greater or equal to 10000000000000000
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMin/example/wrong1
+  Property: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml#/declarations/types/scalar/BigIntMin/example/wrong1
+  Position: Some(LexicalInformation([(36,14)-(36,30)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/big-number-examples.raml

--- a/amf-client/shared/src/test/resources/validations/reports/multi-plat-model/invalid-example-result.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/multi-plat-model/invalid-example-result.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /A expected type: Number, found: String
+  Message: /A expected type: Integer, found: String
 required key [B] not found
 
   Level: Violation

--- a/amf-client/shared/src/test/resources/validations/reports/multi-plat-model/invalid-facet-value-type.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/multi-plat-model/invalid-facet-value-type.report.jvm
@@ -14,7 +14,7 @@ Level: Violation
   Location: file://amf-client/shared/src/test/resources/validations/facets/invalid-facet-value-type.raml
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /age expected type: Number, found: String
+  Message: /age expected type: Integer, found: String
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/facets/invalid-facet-value-type.raml#/declarations/types/any/defining-incorrect-facet-type/extension/object-facet/object_1
   Property: file://amf-client/shared/src/test/resources/validations/facets/invalid-facet-value-type.raml#/declarations/types/any/defining-incorrect-facet-type/extension/object-facet/object_1

--- a/amf-client/shared/src/test/resources/validations/reports/recursives/response-without-mediatype.report.jvm
+++ b/amf-client/shared/src/test/resources/validations/reports/recursives/response-without-mediatype.report.jvm
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Source: http://a.ml/vocabularies/amf/validation#example-validation-error
-  Message: /prop expected type: JSONArray, found: Double
+  Message: /prop expected type: JSONArray, found: BigDecimal
   Level: Violation
   Target: file://amf-client/shared/src/test/resources/validations/recursives/response-without-mediatype.raml#/web-api/end-points/%2Fendpoint/get/200/default/default/example/default-example
   Property: file://amf-client/shared/src/test/resources/validations/recursives/response-without-mediatype.raml#/web-api/end-points/%2Fendpoint/get/200/default/default/example/default-example

--- a/amf-client/shared/src/test/scala/amf/validation/RamlModelMultiPlatformReportTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/RamlModelMultiPlatformReportTest.scala
@@ -60,6 +60,10 @@ class RamlModelMultiPlatformReportTest extends MultiPlatformReportGenTest {
              Raml08Profile)
   }
 
+  test("maximum/minimum validation with 17 digit numbers") {
+    validate("raml/big-number-examples.raml", Some("invalid-big-numbers.report"), Raml10Profile)
+  }
+
   override val basePath    = "file://amf-client/shared/src/test/resources/validations/"
   override val reportsPath = "amf-client/shared/src/test/resources/validations/reports/multi-plat-model/"
   override val hint: Hint  = RamlYamlHint

--- a/amf-client/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
@@ -267,5 +267,9 @@ class ValidRamlModelParserTest extends ValidModelTest {
     checkValid("/raml/examples/same-filename-example.raml")
   }
 
+  test("using number larger than long in schema definition") {
+    checkValid("/raml/big-number-in-schema.raml")
+  }
+
   override val hint: Hint = RamlYamlHint
 }

--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,4 +1,4 @@
 amf.webapi=4.7.0-SNAPSHOT
-amf.core=4.1.169
+amf.core=4.1.170
 amf.custom.validations=5.2.0-SNAPSHOT
 amf.model=2.3.0

--- a/amf-webapi/jvm/src/main/scala/amf/plugins/document/webapi/validation/json/JSONObject.java
+++ b/amf-webapi/jvm/src/main/scala/amf/plugins/document/webapi/validation/json/JSONObject.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 /**
   * Custom JSON Object which overrides org.json implementation to add a validation for trailing commas
+  * and stringToValue static method implementation.
   */
 public class JSONObject extends org.json.JSONObject {
 
@@ -74,6 +75,44 @@ public class JSONObject extends org.json.JSONObject {
                 default:
                     throw x.syntaxError("Expected a ',' or '}'");
             }
+        }
+    }
+
+    /**
+     * This redefines JSONObject.stringToValue method so that we can fail when an unquoted value is processed (as all the other json parsers).
+     * Method is called from JSONTokenerHack.
+     */
+    public static Object stringToValue(String string) {
+        if ("".equals(string)) {
+            return string;
+        }
+
+        // check JSON key words true/false/null
+        if ("true".equalsIgnoreCase(string)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equalsIgnoreCase(string)) {
+            return Boolean.FALSE;
+        }
+        if ("null".equalsIgnoreCase(string)) {
+            return org.json.JSONObject.NULL;
+        }
+
+        /*
+         * If it might be a number, try converting it. If a number cannot be
+         * produced, then the value will just be a string.
+         */
+
+        char initial = string.charAt(0);
+        if ((initial >= '0' && initial <= '9') || initial == '-') {
+            try {
+                return stringToNumber(string);
+            } catch (Exception ignore) {
+                throw new InvalidJSONValueException("Unquoted string value");
+            }
+        }
+        else {
+            throw new InvalidJSONValueException("Unquoted string value");
         }
     }
 

--- a/amf-webapi/jvm/src/main/scala/amf/plugins/document/webapi/validation/json/JSONTokenerHack.scala
+++ b/amf-webapi/jvm/src/main/scala/amf/plugins/document/webapi/validation/json/JSONTokenerHack.scala
@@ -1,8 +1,7 @@
 package amf.plugins.document.webapi.validation.json
 
 import java.lang
-
-import org.json.JSONTokener
+import org.json.{JSONTokener}
 
 import scala.util.matching.Regex
 
@@ -34,66 +33,28 @@ class JSONTokenerHack(text: String) extends JSONTokener(text) {
 
         val string = sb.toString.trim()
         if ("" == string) throw this.syntaxError("Missing value")
-        stringToValue(string)
+        JSONObject.stringToValue(string)
     }
   }
 
   protected def shouldContinueParsing(newChar: Char) = newChar >= ' ' && ",:]}/\\\"[{;=#".indexOf(newChar) < 0
 
-  private def checkNumber(s: String): Option[Object] =
-    try {
-      if (isDecimalNotation(s) || isBiggerThanLong(s)) checkDouble(s) else checkLong(s)
-    } catch {
-      case _: Exception => None
+  private def hack(value: Object) =
+    value match {
+      case double: lang.Double      => hackDecimal(double.toString, double)
+      case bd: java.math.BigDecimal => hackDecimal(bd.toString, bd)
+      case _                        => value
     }
 
-  private def isBiggerThanLong(s: String): Boolean = java.lang.Double.valueOf(s) match {
-    case num if num < Long.MinValue || Long.MaxValue < num => true
-    case _                                                 => false
-  }
-
-  private def checkLong(s: String) = java.lang.Long.valueOf(s) match {
-    case l if s == l.toString => Some(if (l.longValue == l.intValue) Integer.valueOf(l.intValue) else l)
-    case _                    => None
-  }
-
-  private def checkDouble(s: String) = java.lang.Double.valueOf(s) match {
-    case d if !d.isInfinite && !d.isNaN => Some(d)
-    case d if d.isInfinite              => Some(new java.math.BigDecimal(s))
-    case _                              => None
-  }
-
-  private def numberOption(s: String): Option[Object] = s.charAt(0) match {
-    case i if (i >= '0' && i <= '9') || i == '-' => checkNumber(s)
-    case _                                       => None
-  }
-
-  private def stringToValue(string: String): Object = string match {
-    case ci"true"  => java.lang.Boolean.TRUE
-    case ci"false" => java.lang.Boolean.FALSE
-    case ci"null"  => org.json.JSONObject.NULL
-    case _ =>
-      numberOption(string) match {
-        case Some(o) => o
-        case _       => throw new InvalidJSONValueException("Unquoted string value")
-      }
-  }
-
-  private def isDecimalNotation(s: String): Boolean =
-    s.indexOf('.') > -1 || s.indexOf('e') > -1 || s.indexOf('E') > -1 || "-0" == s
-
-  private def hack(value: Object) = value match {
-    case double: lang.Double => hackDouble(double)
-    case _                   => value
-  }
-
-  private def hackDouble(d: java.lang.Double): Object = {
+  /**
+    * numbers ending with .0 are converted to longs
+    * */
+  private def hackDecimal(str: String, value: Object): Object = {
     val pattern = "[0-9]+(\\.0+)".r
-    val str     = d.toString
 
     str match {
-      case pattern(group) => Integer.valueOf(str.stripSuffix(group))
-      case _              => d
+      case pattern(group) => java.lang.Long.valueOf(str.stripSuffix(group))
+      case _              => value
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -84,8 +84,8 @@ lazy val webapi = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .jvmSettings(
     libraryDependencies += "org.scala-js"                      %% "scalajs-stubs"          % scalaJSVersion % "provided",
-    libraryDependencies += "com.github.everit-org.json-schema" % "org.everit.json.schema"  % "1.9.2",
-    libraryDependencies += "org.json" % "json" % "20180130",
+    libraryDependencies += "com.github.everit-org.json-schema" % "org.everit.json.schema"  % "1.12.2",
+    libraryDependencies += "org.json" % "json" % "20201115",
     artifactPath in (Compile, packageDoc) := baseDirectory.value / "target" / "artifact" / "amf-webapi-javadoc.jar",
     mappings in (Compile, packageBin) += file("amf-webapi.versions") -> "amf-webapi.versions"
   )


### PR DESCRIPTION
 - update everit version to 1.12.2, and org.json to 20201115
 - adjust JSONTokenerHack and JSONObject to new changes in the json library
 - requires changes in ValueEmitter https://github.com/aml-org/amf-core/pull/158