### PR TITLE
APIMF-2769: Added parsing and emission of custom domain properties to Module

### DIFF
--- a/amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml
+++ b/amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml
@@ -1,0 +1,14 @@
+#%RAML 1.0 Library
+
+(someVeryCoolAnnotation): io.test.lib
+
+types:
+  Test:
+    type: object
+    properties:
+      value: string
+
+annotationTypes:
+  someVeryCoolAnnotation:
+    type: string
+    allowedTargets: Library

--- a/amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.expanded.jsonld
+++ b/amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.expanded.jsonld
@@ -1,0 +1,491 @@
+[
+  {
+    "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml",
+    "@type": [
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/document#version": [
+      {
+        "@value": "2.3.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation": {
+      "http://a.ml/vocabularies/core#extensionName": [
+        {
+          "@value": "someVeryCoolAnnotation"
+        }
+      ],
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": [
+        {
+          "@value": "io.test.lib"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": [
+        {
+          "@value": "scalar_1"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1#/source-map",
+          "@type": [
+            "http://a.ml/vocabularies/document-source-maps#SourceMap"
+          ],
+          "http://a.ml/vocabularies/document-source-maps#lexical": [
+            {
+              "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1#/source-map/lexical/element_0",
+              "http://a.ml/vocabularies/document-source-maps#element": [
+                {
+                  "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1"
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#value": [
+                {
+                  "@value": "[(3,26)-(3,37)]"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "http://a.ml/vocabularies/document#customDomainProperties": [
+      {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation"
+      }
+    ],
+    "http://a.ml/vocabularies/document-source-maps#sources": [
+      {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/source-map",
+        "@type": [
+          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+        ],
+        "http://a.ml/vocabularies/document-source-maps#source-vendor": [
+          {
+            "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/source-map/source-vendor/element_0",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "RAML 1.0"
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#lexical": [
+          {
+            "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/source-map/lexical/element_0",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(1,0)-(15,0)]"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#declares": [
+      {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation",
+        "@type": [
+          "http://a.ml/vocabularies/document#DomainProperty",
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/2000/01/rdf-schema#domain": [
+          {
+            "@id": "http://a.ml/vocabularies/document#Module"
+          }
+        ],
+        "http://a.ml/vocabularies/shapes#schema": [
+          {
+            "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema",
+            "@type": [
+              "http://a.ml/vocabularies/shapes#ScalarShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#datatype": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#string"
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "schema"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+                  {
+                    "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map/type-property-lexical-info/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(13,4)-(13,8)]"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map/lexical/element_1",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(12,25)-(15,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://www.w3.org/ns/shacl#datatype"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(13,4)-(14,0)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "someVeryCoolAnnotation"
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#single-value-array": [
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/single-value-array/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://www.w3.org/2000/01/rdf-schema#domain"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": ""
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_3",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/shapes#schema"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(12,25)-(15,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_1",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://www.w3.org/2000/01/rdf-schema#domain"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(14,4)-(15,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(12,2)-(12,24)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(12,2)-(15,0)]"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#declared-element": [
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/declared-element/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#closed": [
+          {
+            "@value": false
+          }
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#value"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "value"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#lexical": [
+                      {
+                        "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(9,6)-(11,0)]"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "value"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(9,6)-(11,0)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": "Test"
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#declared-element": [
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/declared-element/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": ""
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://www.w3.org/ns/shacl#property"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(8,4)-(11,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://www.w3.org/ns/shacl#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(6,2)-(6,6)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/lexical/element_1",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(6,2)-(11,0)]"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+              {
+                "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/type-property-lexical-info/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(7,4)-(7,8)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.flattened.jsonld
+++ b/amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.flattened.jsonld
@@ -1,0 +1,419 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/extension/someVeryCoolAnnotation",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#DomainExtension",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#extensionName": "someVeryCoolAnnotation",
+      "http://a.ml/vocabularies/document#definedBy": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation"
+      },
+      "http://a.ml/vocabularies/document#extension": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1"
+      },
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/extension/someVeryCoolAnnotation#/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation",
+      "@type": [
+        "http://a.ml/vocabularies/document#DomainProperty",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#domain": [
+        {
+          "@id": "http://a.ml/vocabularies/document#Module"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#schema": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema"
+      },
+      "http://a.ml/vocabularies/core#name": "someVeryCoolAnnotation",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "io.test.lib",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "scalar_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1#/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/extension/someVeryCoolAnnotation#/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/extension/someVeryCoolAnnotation#/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "schema",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#single-value-array": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/single-value-array/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_2"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#declared-element": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/declared-element/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1#/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1#/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/extension/someVeryCoolAnnotation#/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/extension/someVeryCoolAnnotation",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(3,0)-(5,0)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map/type-property-lexical-info/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/single-value-array/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/2000/01/rdf-schema#domain",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#schema",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(12,25)-(15,0)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/2000/01/rdf-schema#domain",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(14,4)-(15,0)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(12,2)-(12,24)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(12,2)-(15,0)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/source-map/declared-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1#/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(3,26)-(3,37)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(13,4)-(13,8)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(12,25)-(15,0)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation/scalar/schema/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(13,4)-(14,0)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml",
+      "http://a.ml/vocabularies/document#declares": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test"
+        }
+      ],
+      "@type": [
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#version": "2.3.0",
+      "http://a.ml/vocabularies/document#root": true,
+      "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml/someVeryCoolAnnotation/scalar_1"
+      },
+      "http://a.ml/vocabularies/document#customDomainProperties": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/annotations/someVeryCoolAnnotation"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#closed": false,
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "Test",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#source-vendor": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/source-map/source-vendor/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#value"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value"
+      },
+      "http://www.w3.org/ns/shacl#minCount": 1,
+      "http://www.w3.org/ns/shacl#name": "value",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#declared-element": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/declared-element/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/lexical/element_1"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/type-property-lexical-info/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/source-map/source-vendor/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml",
+      "http://a.ml/vocabularies/document-source-maps#value": "RAML 1.0"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(15,0)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "value",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/declared-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#property",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(8,4)-(11,0)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(6,2)-(6,6)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(6,2)-(11,0)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(7,8)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(9,6)-(11,0)]"
+    },
+    {
+      "@id": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declarations/types/Test/property/value/scalar/value",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(9,6)-(11,0)]"
+    }
+  ]
+}

--- a/amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.jsonld.raml
+++ b/amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.jsonld.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0 Library
+types:
+  Test:
+    properties:
+      value:
+        type: string
+annotationTypes:
+  someVeryCoolAnnotation:
+    type: string
+    allowedTargets: Library

--- a/amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/dumped.raml
+++ b/amf-client/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/dumped.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0 Library
+(someVeryCoolAnnotation): io.test.lib
+types:
+  Test:
+    type: object
+    properties:
+      value:
+        type: string
+annotationTypes:
+  someVeryCoolAnnotation:
+    type: string
+    allowedTargets: Library

--- a/amf-client/shared/src/test/resources/validations/raml/library-annotations.raml
+++ b/amf-client/shared/src/test/resources/validations/raml/library-annotations.raml
@@ -1,0 +1,18 @@
+#%RAML 1.0 Library
+
+(someVeryCoolLibraryAnnotation): io.test.lib
+(aSuperCoolResourceAnnotation): uh oh this should be invalid
+
+types:
+  Test:
+    type: object
+    properties:
+      value: string
+
+annotationTypes:
+  someVeryCoolLibraryAnnotation:
+    type: string
+    allowedTargets: Library
+  aSuperCoolResourceAnnotation:
+    type: string
+    allowedTargets: Resource

--- a/amf-client/shared/src/test/resources/validations/reports/model/library-annotations.report
+++ b/amf-client/shared/src/test/resources/validations/reports/model/library-annotations.report
@@ -1,0 +1,14 @@
+Model: file://amf-client/shared/src/test/resources/validations/raml/library-annotations.raml
+Profile: RAML 1.0
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/parser#invalid-annotation-target
+  Message: Annotation aSuperCoolResourceAnnotation not allowed in target Library, allowed targets: Resource
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/raml/library-annotations.raml
+  Property: 
+  Position: Some(LexicalInformation([(4,0)-(6,0)]))
+  Location: file://amf-client/shared/src/test/resources/validations/raml/library-annotations.raml

--- a/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -568,4 +568,8 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
   test("valid example defined nested within external fragment") {
     validate("raml/nested-example-external-fragment/api.raml", None, Raml08Profile)
   }
+
+  test("RAML Library annotations") {
+    validate("raml/library-annotations.raml", Some("library-annotations.report"))
+  }
 }

--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,4 +1,4 @@
 amf.webapi=4.7.0-SNAPSHOT
-amf.core=4.1.170
+amf.core=4.1.174
 amf.custom.validations=5.2.0-SNAPSHOT
 amf.model=2.3.0

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/contexts/parser/raml/RamlWebApiContext.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/contexts/parser/raml/RamlWebApiContext.scala
@@ -187,5 +187,5 @@ class PayloadContext(loc: String,
 
 object RamlWebApiContextType extends Enumeration {
   type RamlWebApiContextType = Value
-  val DEFAULT, RESOURCE_TYPE, TRAIT, EXTENSION, OVERLAY = Value
+  val DEFAULT, RESOURCE_TYPE, TRAIT, EXTENSION, OVERLAY, LIBRARY = Value
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/emitters/annotations/AnnotationEmitter.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/emitters/annotations/AnnotationEmitter.scala
@@ -12,7 +12,7 @@ import org.yaml.model.YDocument.EntryBuilder
 /**
   *
   */
-case class AnnotationsEmitter(element: DomainElement, ordering: SpecOrdering)(implicit spec: SpecEmitterContext) {
+case class AnnotationsEmitter(element: CustomizableElement, ordering: SpecOrdering)(implicit spec: SpecEmitterContext) {
   def emitters: Seq[EntryEmitter] =
     element.customDomainProperties
       .filter(!isOrphanOasExtension(_))

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlAnnotationTargets.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlAnnotationTargets.scala
@@ -1,0 +1,16 @@
+package amf.plugins.document.webapi.parser.spec.raml
+
+import amf.plugins.document.webapi.contexts.parser.raml.RamlWebApiContextType
+import amf.plugins.document.webapi.contexts.parser.raml.RamlWebApiContextType.RamlWebApiContextType
+import amf.plugins.document.webapi.vocabulary.VocabularyMappings
+
+object RamlAnnotationTargets {
+
+  def targetsFor(contextType: RamlWebApiContextType): List[String] = contextType match {
+    case RamlWebApiContextType.DEFAULT   => List(VocabularyMappings.webapi)
+    case RamlWebApiContextType.LIBRARY   => List(VocabularyMappings.library)
+    case RamlWebApiContextType.OVERLAY   => List(VocabularyMappings.overlay)
+    case RamlWebApiContextType.EXTENSION => List(VocabularyMappings.extension)
+    case _                               => Nil
+  }
+}

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlDocumentParser.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlDocumentParser.scala
@@ -13,16 +13,13 @@ import amf.core.parser.{Annotations, _}
 import amf.core.utils._
 import amf.plugins.document.webapi.annotations.DeclarationKey
 import amf.plugins.document.webapi.contexts.parser.raml.RamlWebApiContextType.RamlWebApiContextType
-import amf.plugins.document.webapi.contexts.parser.raml.{
-  ExtensionLikeWebApiContext,
-  RamlWebApiContext,
-  RamlWebApiContextType
-}
+import amf.plugins.document.webapi.contexts.parser.raml.{ExtensionLikeWebApiContext, RamlWebApiContext, RamlWebApiContextType}
 import amf.plugins.document.webapi.model.{Extension, Overlay}
 import amf.plugins.document.webapi.parser.spec._
 import amf.plugins.document.webapi.parser.spec.common._
 import amf.plugins.document.webapi.parser.spec.declaration._
 import amf.plugins.document.webapi.parser.spec.domain._
+import amf.plugins.document.webapi.parser.spec.raml.RamlAnnotationTargets.targetsFor
 import amf.plugins.document.webapi.vocabulary.VocabularyMappings
 import amf.plugins.domain.shapes.models.CreativeWork
 import amf.plugins.domain.shapes.models.ExampleTracking.tracking
@@ -231,16 +228,9 @@ abstract class RamlDocumentParser(root: Root)(implicit val ctx: RamlWebApiContex
       }
     )
 
-    AnnotationParser(api, map, obtainTarget(ctx.contextType)).parse()
+    AnnotationParser(api, map, targetsFor(ctx.contextType)).parse()
 
     api
-  }
-
-  private def obtainTarget(contextType: RamlWebApiContextType): List[String] = contextType match {
-    case RamlWebApiContextType.DEFAULT   => List(VocabularyMappings.webapi)
-    case RamlWebApiContextType.OVERLAY   => List(VocabularyMappings.overlay)
-    case RamlWebApiContextType.EXTENSION => List(VocabularyMappings.extension)
-    case _                               => Nil
   }
 }
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlModuleEmitter.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlModuleEmitter.scala
@@ -11,7 +11,7 @@ import amf.core.remote.Raml
 import amf.plugins.document.webapi.contexts.emitter.raml.RamlSpecEmitterContext
 import amf.plugins.document.webapi.model._
 import amf.plugins.document.webapi.parser.spec.declaration._
-import amf.plugins.document.webapi.parser.spec.declaration.emitters.annotations.DataNodeEmitter
+import amf.plugins.document.webapi.parser.spec.declaration.emitters.annotations.{AnnotationsEmitter, DataNodeEmitter}
 import amf.plugins.document.webapi.parser.spec.declaration.emitters.raml
 import amf.plugins.document.webapi.parser.spec.declaration.emitters.raml.Raml10TypeEmitter
 import amf.plugins.document.webapi.parser.spec.domain.NamedExampleEmitter
@@ -31,7 +31,7 @@ case class RamlModuleEmitter(module: Module)(implicit val spec: RamlSpecEmitterC
     val ordering: SpecOrdering = SpecOrdering.ordering(Raml, module.annotations)
 
     // TODO ordering??
-    val emitters = spec.factory.rootLevelEmitters(module, ordering).emitters
+    val emitters = spec.factory.rootLevelEmitters(module, ordering).emitters ++ AnnotationsEmitter(module, ordering).emitters
 
     // TODO invoke traits end resource types
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlModuleParser.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/raml/RamlModuleParser.scala
@@ -5,7 +5,10 @@ import amf.core.annotations.SourceVendor
 import amf.core.model.document.Module
 import amf.core.parser.{Annotations, _}
 import amf.plugins.document.webapi.contexts.parser.raml.RamlWebApiContext
+import amf.plugins.document.webapi.contexts.parser.raml.RamlWebApiContextType.LIBRARY
+import amf.plugins.document.webapi.parser.spec.common.AnnotationParser
 import amf.plugins.document.webapi.parser.spec.declaration.ReferencesParser
+import amf.plugins.document.webapi.parser.spec.raml.RamlAnnotationTargets.targetsFor
 import org.yaml.model._
 
 /**
@@ -31,6 +34,8 @@ case class RamlModuleParser(root: Root)(implicit override val ctx: RamlWebApiCon
 
       addDeclarationsToModel(module)
       if (references.nonEmpty) module.withReferences(references.baseUnitReferences())
+
+      AnnotationParser(module, rootMap, targetsFor(LIBRARY)).parse()
     }
 
     ctx.futureDeclarations.resolve()


### PR DESCRIPTION
Linked to: https://github.com/aml-org/amf-core/pull/161

ScalaJS linker fixes: https://github.com/aml-org/amf-core/pull/164

Issue: https://github.com/aml-org/amf/issues/779