### PR TITLE
APIMF-2946: (MOD) return BaseUnit in parsing plugin parse method

### DIFF
--- a/amf-client/shared/src/test/scala/amf/cycle/JsonSchemaSuite.scala
+++ b/amf-client/shared/src/test/scala/amf/cycle/JsonSchemaSuite.scala
@@ -12,10 +12,13 @@ import org.yaml.parser.JsonParser
 
 trait JsonSchemaSuite {
 
-  protected def parseSchema(platform: Platform, path: String, mediatype: String, eh: ParserErrorHandler = UnhandledParserErrorHandler) = {
-    val content = platform.fs.syncFile(path).read().toString
+  protected def parseSchema(platform: Platform,
+                            path: String,
+                            mediatype: String,
+                            eh: ParserErrorHandler = UnhandledParserErrorHandler) = {
+    val content  = platform.fs.syncFile(path).read().toString
     val document = JsonParser.withSource(content, path).document()
-    val root =  Root(
+    val root = Root(
       SyamlParsedDocument(document),
       path,
       mediatype,
@@ -24,10 +27,11 @@ trait JsonSchemaSuite {
       content
     )
     val options = ParsingOptions()
-    val fragment = new JsonSchemaParser().parse(root, getBogusParserCtx(path, options, eh), options, None).get
-    fragment
+    new JsonSchemaParser().parse(root, getBogusParserCtx(path, options, eh), options, None)
   }
 
-  private def getBogusParserCtx(location: String, options: ParsingOptions, eh: ParserErrorHandler): JsonSchemaWebApiContext =
+  private def getBogusParserCtx(location: String,
+                                options: ParsingOptions,
+                                eh: ParserErrorHandler): JsonSchemaWebApiContext =
     new JsonSchemaWebApiContext(location, Seq(), ParserContext(eh = eh), None, options, JSONSchemaDraft7SchemaVersion)
 }

--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,4 +1,4 @@
 amf.webapi=4.8.0-SNAPSHOT
-amf.core=4.1.194
+amf.core=4.1.195
 amf.custom.validations=5.2.0-SNAPSHOT
 amf.model=3.0.0

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/ExternalJsonYamlRefsPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/ExternalJsonYamlRefsPlugin.scala
@@ -23,7 +23,7 @@ import amf.core.remote.Platform
 import amf.core.utils._
 import amf.plugins.features.validation.CoreValidations.UnresolvedReference
 import org.yaml.model._
-
+import amf.core.exception.UnsupportedParsedDocumentException
 import scala.concurrent.{ExecutionContext, Future}
 
 class JsonRefsReferenceHandler extends ReferenceHandler {
@@ -107,9 +107,8 @@ class ExternalJsonYamlRefsPlugin extends JsonSchemaPlugin {
   /**
     * Parses an accepted document returning an optional BaseUnit
     */
-  override def parse(document: Root, ctx: ParserContext, options: ParsingOptions): Option[BaseUnit] =
+  override def parse(document: Root, ctx: ParserContext, options: ParsingOptions): BaseUnit =
     document.parsed match {
-
       case parsed: SyamlParsedDocument =>
         val result =
           ExternalDomainElement(Annotations(parsed.document))
@@ -124,10 +123,8 @@ class ExternalJsonYamlRefsPlugin extends JsonSchemaPlugin {
           .withEncodes(result)
           .withLocation(document.location)
         if (references.nonEmpty) fragment.withReferences(references)
-        Some(fragment)
-
-      case _ =>
-        None
+        fragment
+      case _ => throw UnsupportedParsedDocumentException
     }
 
   private def docMediaType(doc: Root) = if (doc.raw.isJson) "application/json" else "application/yaml"

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/JsonSchemaPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/JsonSchemaPlugin.scala
@@ -51,7 +51,7 @@ class JsonSchemaPlugin extends AMFDocumentPlugin with PlatformSecrets {
   /**
     * Parses an accepted document returning an optional BaseUnit
     */
-  override def parse(document: Root, parentContext: ParserContext, options: ParsingOptions): Option[BaseUnit] = {
+  override def parse(document: Root, parentContext: ParserContext, options: ParsingOptions): BaseUnit = {
     val ctx = context(document.location, document.references, options, parentContext)
     new JsonSchemaParser().parse(document, ctx, options)
   }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/PayloadPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/PayloadPlugin.scala
@@ -6,6 +6,7 @@ import amf.core.Root
 import amf.core.client.ParsingOptions
 import amf.client.remod.amfcore.config.RenderOptions
 import amf.core.errorhandling.ErrorHandler
+import amf.core.exception.UnsupportedParsedDocumentException
 import amf.core.model.document.{BaseUnit, PayloadFragment}
 import amf.core.parser.{ParserContext, SimpleReferenceHandler, SyamlParsedDocument}
 import amf.core.remote.{Payload, Platform}
@@ -43,14 +44,13 @@ object PayloadPlugin extends AMFDocumentPlugin {
     "application/payload+yaml"
   )
 
-  override def parse(root: Root, parentContext: ParserContext, options: ParsingOptions): Option[PayloadFragment] = {
+  override def parse(root: Root, parentContext: ParserContext, options: ParsingOptions): PayloadFragment = {
     root.parsed match {
       case parsed: SyamlParsedDocument =>
         implicit val ctx: PayloadContext =
           new PayloadContext(root.location, parentContext.refs, parentContext, options = options)
-        Some(PayloadParser(parsed.document, root.location, root.mediatype).parseUnit())
-      case _ =>
-        None
+        PayloadParser(parsed.document, root.location, root.mediatype).parseUnit()
+      case _ => throw UnsupportedParsedDocumentException
     }
   }
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/RamlHeader.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/RamlHeader.scala
@@ -13,7 +13,7 @@ case class RamlHeader(text: String) {
   def asRegExp(): Regex = ("\\s*" + text.replaceAll(" ", "\\\\s*") + "\\s*").r
 }
 
-trait RamlFragment
+sealed trait RamlFragment
 
 object RamlHeader {
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/oas/OasFragmentParser.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/oas/OasFragmentParser.scala
@@ -46,9 +46,8 @@ case class OasFragmentParser(root: Root, fragment: Option[OasHeader] = None)(imp
       case Oas20AnnotationTypeDeclaration => Some(AnnotationFragmentParser(map).parse())
       case Oas20SecurityScheme            => Some(SecuritySchemeFragmentParser(map).parse())
       case Oas20NamedExample              => Some(NamedExampleFragmentParser(map).parse())
-      case Oas20Header | Oas30Header =>
-        new ExternalJsonYamlRefsPlugin().parse(root, ctx, ParsingOptions())
-      case _ => None
+      case Oas20Header | Oas30Header      => Some(new ExternalJsonYamlRefsPlugin().parse(root, ctx, ParsingOptions()))
+      case _                              => None
     }).getOrElse {
       val fragment = ExternalFragment()
         .withLocation(root.location)


### PR DESCRIPTION
Moved raml 08 specific logic of when to parse document from parse method to canParse.
The rest of the changes are straightforward using InvalidDocumentHeaderException and UnsupportedParsedDocumentException for cases which are unreachable.
depends on https://github.com/aml-org/amf-aml/pull/209 and https://github.com/aml-org/amf-core/pull/186.