### PR TITLE
APIMF-2963: define validVendorsToReference in plugins, adjust some tests

### DIFF
--- a/amf-client/shared/src/test/resources/production/inter-spec-refs/reports/oas-raml-datatype.report
+++ b/amf-client/shared/src/test/resources/production/inter-spec-refs/reports/oas-raml-datatype.report
@@ -1,14 +1,23 @@
 Model: file://amf-client/shared/src/test/resources/production/inter-spec-refs/oas-raml-datatype/api.json
 Profile: OAS 2.0
 Conforms? false
-Number of results: 1
+Number of results: 2
 
 Level: Violation
 
-- Source: http://a.ml/vocabularies/amf/core#invalid-cross-spec
-  Message: Cannot reference fragments of another spec
+- Source: http://a.ml/vocabularies/amf/core#syaml-error
+  Message: YAML map expected
   Level: Violation
   Target: 
   Property: 
-  Position: Some(LexicalInformation([(14,22)-(14,37)]))
-  Location: file://amf-client/shared/src/test/resources/production/inter-spec-refs/oas-raml-datatype/api.json
+  Position: None
+  Location: 
+
+- Source: http://a.ml/vocabularies/amf/core#syaml-error
+  Message: Syntax error : Unexpected '#%RAML 1.0 DataType
+type'
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(1,0)-(2,4)]))
+  Location: file://amf-client/shared/src/test/resources/production/inter-spec-refs/oas-raml-datatype/datatype.raml

--- a/amf-client/shared/src/test/resources/production/inter-spec-refs/reports/oas-raml-securityScheme.report
+++ b/amf-client/shared/src/test/resources/production/inter-spec-refs/reports/oas-raml-securityScheme.report
@@ -1,14 +1,23 @@
 Model: file://amf-client/shared/src/test/resources/production/inter-spec-refs/oas-raml-securityScheme/api.json
 Profile: OAS 2.0
 Conforms? false
-Number of results: 1
+Number of results: 2
 
 Level: Violation
 
-- Source: http://a.ml/vocabularies/amf/core#invalid-cross-spec
-  Message: Cannot reference fragments of another spec
+- Source: http://a.ml/vocabularies/amf/core#syaml-error
+  Message: YAML map expected
   Level: Violation
   Target: 
   Property: 
-  Position: Some(LexicalInformation([(23,14)-(23,35)]))
-  Location: file://amf-client/shared/src/test/resources/production/inter-spec-refs/oas-raml-securityScheme/api.json
+  Position: None
+  Location: 
+
+- Source: http://a.ml/vocabularies/amf/core#syaml-error
+  Message: Syntax error : Unexpected '#%RAML 1.0 SecurityScheme
+type'
+  Level: Violation
+  Target: 
+  Property: 
+  Position: Some(LexicalInformation([(1,0)-(2,4)]))
+  Location: file://amf-client/shared/src/test/resources/production/inter-spec-refs/oas-raml-securityScheme/securityScheme.raml

--- a/amf-client/shared/src/test/resources/production/knowledge-graph-reduced/api.jsonld
+++ b/amf-client/shared/src/test/resources/production/knowledge-graph-reduced/api.jsonld
@@ -1,0 +1,2281 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#3",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "ANG Service"
+          }
+        ],
+        "apiContract:server": [
+          {
+            "@id": "#84",
+            "@type": [
+              "apiContract:Server",
+              "doc:DomainElement"
+            ],
+            "core:urlTemplate": [
+              {
+                "@value": "http://ang-service.kqa.msap.io/v1"
+              }
+            ],
+            "smaps": {
+              "lexical": {
+                "core:urlTemplate": "[(2,0)-(4,0)]"
+              },
+              "synthesized-field": {
+                "#84": "true"
+              }
+            }
+          }
+        ],
+        "core:version": [
+          {
+            "@value": "v1"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#4",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/vocabulary"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#5",
+                "@type": [
+                  "apiContract:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "post"
+                  }
+                ],
+                "core:description": [
+                  {
+                    "@value": "Stores the triples for the parsed, and validated Vocabulary and returns the URI for the newly created graph"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#6",
+                    "@type": [
+                      "apiContract:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#7",
+                        "@type": [
+                          "apiContract:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "core:mediaType": [
+                          {
+                            "@value": "application/ld+json"
+                          }
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#8",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "shacl:name": [
+                              {
+                                "@value": "schema"
+                              }
+                            ],
+                            "apiContract:examples": [
+                              {
+                                "@id": "#9",
+                                "@type": [
+                                  "apiContract:Example",
+                                  "doc:DomainElement"
+                                ],
+                                "doc:strict": [
+                                  {
+                                    "@value": true
+                                  }
+                                ],
+                                "doc:structuredValue": [
+                                  {
+                                    "@id": "#10",
+                                    "@type": [
+                                      "data:Object",
+                                      "data:Node",
+                                      "doc:DomainElement"
+                                    ],
+                                    "data:dialect": [
+                                      {
+                                        "@id": "#11",
+                                        "@type": [
+                                          "data:Scalar",
+                                          "data:Node",
+                                          "doc:DomainElement"
+                                        ],
+                                        "data:value": [
+                                          {
+                                            "@value": "Tech Talks"
+                                          }
+                                        ],
+                                        "shacl:datatype": [
+                                          {
+                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                          }
+                                        ],
+                                        "core:name": [
+                                          {
+                                            "@value": "dialect"
+                                          }
+                                        ],
+                                        "smaps": {
+                                          "lexical": {
+                                            "#11": "[(4,9)-(4,19)]"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "data:version": [
+                                      {
+                                        "@id": "#12",
+                                        "@type": [
+                                          "data:Scalar",
+                                          "data:Node",
+                                          "doc:DomainElement"
+                                        ],
+                                        "data:value": [
+                                          {
+                                            "@value": "0.1"
+                                          }
+                                        ],
+                                        "shacl:datatype": [
+                                          {
+                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                          }
+                                        ],
+                                        "core:name": [
+                                          {
+                                            "@value": "version"
+                                          }
+                                        ],
+                                        "smaps": {
+                                          "lexical": {
+                                            "#12": "[(5,9)-(5,14)]"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "data:uses": [
+                                      {
+                                        "@id": "#13",
+                                        "@type": [
+                                          "data:Object",
+                                          "data:Node",
+                                          "doc:DomainElement"
+                                        ],
+                                        "data:demos": [
+                                          {
+                                            "@id": "#14",
+                                            "@type": [
+                                              "data:Scalar",
+                                              "data:Node",
+                                              "doc:DomainElement"
+                                            ],
+                                            "data:value": [
+                                              {
+                                                "@value": "http://mulesoft.com/v1/vocabulary/9758c8aa-18d0-484f-905c-a715c279b195/7574a3a021fc0ad2a2bae65136bea7ab"
+                                              }
+                                            ],
+                                            "shacl:datatype": [
+                                              {
+                                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                              }
+                                            ],
+                                            "core:name": [
+                                              {
+                                                "@value": "demos"
+                                              }
+                                            ],
+                                            "smaps": {
+                                              "lexical": {
+                                                "#14": "[(9,9)-(9,112)]"
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "core:name": [
+                                          {
+                                            "@value": "uses"
+                                          }
+                                        ],
+                                        "smaps": {
+                                          "lexical": {
+                                            "data:demos": "[(9,2)-(11,0)]",
+                                            "#13": "[(9,0)-(11,0)]"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "data:external": [
+                                      {
+                                        "@id": "#15",
+                                        "@type": [
+                                          "data:Object",
+                                          "data:Node",
+                                          "doc:DomainElement"
+                                        ],
+                                        "data:schema-org": [
+                                          {
+                                            "@id": "#16",
+                                            "@type": [
+                                              "data:Scalar",
+                                              "data:Node",
+                                              "doc:DomainElement"
+                                            ],
+                                            "data:value": [
+                                              {
+                                                "@value": "http://schema.org/"
+                                              }
+                                            ],
+                                            "shacl:datatype": [
+                                              {
+                                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                              }
+                                            ],
+                                            "core:name": [
+                                              {
+                                                "@value": "schema-org"
+                                              }
+                                            ],
+                                            "smaps": {
+                                              "lexical": {
+                                                "#16": "[(12,14)-(12,32)]"
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "core:name": [
+                                          {
+                                            "@value": "external"
+                                          }
+                                        ],
+                                        "smaps": {
+                                          "lexical": {
+                                            "data:schema-org": "[(12,2)-(14,0)]",
+                                            "#15": "[(12,0)-(14,0)]"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "data:documents": [
+                                      {
+                                        "@id": "#17",
+                                        "@type": [
+                                          "data:Object",
+                                          "data:Node",
+                                          "doc:DomainElement"
+                                        ],
+                                        "data:library": [
+                                          {
+                                            "@id": "#18",
+                                            "@type": [
+                                              "data:Object",
+                                              "data:Node",
+                                              "doc:DomainElement"
+                                            ],
+                                            "data:declares": [
+                                              {
+                                                "@id": "#19",
+                                                "@type": [
+                                                  "data:Object",
+                                                  "data:Node",
+                                                  "doc:DomainElement"
+                                                ],
+                                                "data:products": [
+                                                  {
+                                                    "@id": "#20",
+                                                    "@type": [
+                                                      "data:Scalar",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:value": [
+                                                      {
+                                                        "@value": "ProductNode"
+                                                      }
+                                                    ],
+                                                    "shacl:datatype": [
+                                                      {
+                                                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "products"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "#20": "[(17,16)-(17,27)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "core:name": [
+                                                  {
+                                                    "@value": "declares"
+                                                  }
+                                                ],
+                                                "smaps": {
+                                                  "lexical": {
+                                                    "data:products": "[(17,6)-(18,0)]",
+                                                    "#19": "[(17,0)-(18,0)]"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "core:name": [
+                                              {
+                                                "@value": "library"
+                                              }
+                                            ],
+                                            "smaps": {
+                                              "lexical": {
+                                                "data:declares": "[(16,4)-(18,0)]",
+                                                "#18": "[(16,0)-(18,0)]"
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "data:root": [
+                                          {
+                                            "@id": "#21",
+                                            "@type": [
+                                              "data:Object",
+                                              "data:Node",
+                                              "doc:DomainElement"
+                                            ],
+                                            "data:encodes": [
+                                              {
+                                                "@id": "#22",
+                                                "@type": [
+                                                  "data:Scalar",
+                                                  "data:Node",
+                                                  "doc:DomainElement"
+                                                ],
+                                                "data:value": [
+                                                  {
+                                                    "@value": "PresentationNode"
+                                                  }
+                                                ],
+                                                "shacl:datatype": [
+                                                  {
+                                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                  }
+                                                ],
+                                                "core:name": [
+                                                  {
+                                                    "@value": "encodes"
+                                                  }
+                                                ],
+                                                "smaps": {
+                                                  "lexical": {
+                                                    "#22": "[(19,13)-(19,29)]"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "core:name": [
+                                              {
+                                                "@value": "root"
+                                              }
+                                            ],
+                                            "smaps": {
+                                              "lexical": {
+                                                "data:encodes": "[(19,4)-(21,0)]",
+                                                "#21": "[(19,0)-(21,0)]"
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "core:name": [
+                                          {
+                                            "@value": "documents"
+                                          }
+                                        ],
+                                        "smaps": {
+                                          "lexical": {
+                                            "data:root": "[(18,2)-(21,0)]",
+                                            "#17": "[(15,0)-(21,0)]",
+                                            "data:library": "[(15,2)-(18,0)]"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "data:nodeMappings": [
+                                      {
+                                        "@id": "#23",
+                                        "@type": [
+                                          "data:Object",
+                                          "data:Node",
+                                          "doc:DomainElement"
+                                        ],
+                                        "data:PresentationNode": [
+                                          {
+                                            "@id": "#24",
+                                            "@type": [
+                                              "data:Object",
+                                              "data:Node",
+                                              "doc:DomainElement"
+                                            ],
+                                            "data:classTerm": [
+                                              {
+                                                "@id": "#25",
+                                                "@type": [
+                                                  "data:Scalar",
+                                                  "data:Node",
+                                                  "doc:DomainElement"
+                                                ],
+                                                "data:value": [
+                                                  {
+                                                    "@value": "demos.Presentation"
+                                                  }
+                                                ],
+                                                "shacl:datatype": [
+                                                  {
+                                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                  }
+                                                ],
+                                                "core:name": [
+                                                  {
+                                                    "@value": "classTerm"
+                                                  }
+                                                ],
+                                                "smaps": {
+                                                  "lexical": {
+                                                    "#25": "[(24,15)-(24,33)]"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "data:mapping": [
+                                              {
+                                                "@id": "#26",
+                                                "@type": [
+                                                  "data:Object",
+                                                  "data:Node",
+                                                  "doc:DomainElement"
+                                                ],
+                                                "data:title": [
+                                                  {
+                                                    "@id": "#27",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#28",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "schema-org.name"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#28": "[(27,22)-(27,37)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:mandatory": [
+                                                      {
+                                                        "@id": "#29",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "true"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "mandatory"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#29": "[(28,19)-(28,23)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#30",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "string"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#30": "[(29,15)-(29,21)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "title"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:range": "[(29,8)-(30,0)]",
+                                                        "data:propertyTerm": "[(27,8)-(28,0)]",
+                                                        "#27": "[(27,0)-(30,0)]",
+                                                        "data:mandatory": "[(28,8)-(29,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "data:about": [
+                                                  {
+                                                    "@id": "#31",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#32",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "schema-org.description"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#32": "[(31,22)-(31,44)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:mandatory": [
+                                                      {
+                                                        "@id": "#33",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "true"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "mandatory"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#33": "[(32,19)-(32,23)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#34",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "string"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#34": "[(33,15)-(33,21)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "about"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:range": "[(33,8)-(34,0)]",
+                                                        "data:propertyTerm": "[(31,8)-(32,0)]",
+                                                        "#31": "[(31,0)-(34,0)]",
+                                                        "data:mandatory": "[(32,8)-(33,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "data:date": [
+                                                  {
+                                                    "@id": "#35",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#36",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "demos.demoDate"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#36": "[(35,22)-(35,36)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:mandatory": [
+                                                      {
+                                                        "@id": "#37",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "true"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "mandatory"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#37": "[(36,19)-(36,23)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#38",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "date"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#38": "[(37,15)-(37,19)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "date"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:range": "[(37,8)-(38,0)]",
+                                                        "data:propertyTerm": "[(35,8)-(36,0)]",
+                                                        "#35": "[(35,0)-(38,0)]",
+                                                        "data:mandatory": "[(36,8)-(37,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "data:recorded": [
+                                                  {
+                                                    "@id": "#39",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#40",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "demos.isRecorded"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#40": "[(39,22)-(39,38)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#41",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "boolean"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#41": "[(40,15)-(40,22)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "recorded"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:range": "[(40,8)-(41,0)]",
+                                                        "#39": "[(39,0)-(41,0)]",
+                                                        "data:propertyTerm": "[(39,8)-(40,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "data:product": [
+                                                  {
+                                                    "@id": "#42",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#43",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "demos.showcases"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#43": "[(42,22)-(42,37)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#44",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "ProductNode"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#44": "[(43,15)-(43,26)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:mandatory": [
+                                                      {
+                                                        "@id": "#45",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "true"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "mandatory"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#45": "[(44,19)-(44,23)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "product"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:mandatory": "[(44,8)-(45,0)]",
+                                                        "data:propertyTerm": "[(42,8)-(43,0)]",
+                                                        "#42": "[(42,0)-(45,0)]",
+                                                        "data:range": "[(43,8)-(44,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "data:speakers": [
+                                                  {
+                                                    "@id": "#46",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#47",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "demos.speakers"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#47": "[(46,22)-(46,36)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:mandatory": [
+                                                      {
+                                                        "@id": "#48",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "true"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "mandatory"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#48": "[(47,19)-(47,23)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:mapKey": [
+                                                      {
+                                                        "@id": "#49",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "demos.nickName"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "mapKey"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#49": "[(48,16)-(48,30)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#50",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "SpeakerNode"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#50": "[(49,15)-(49,26)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "speakers"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:range": "[(49,8)-(51,0)]",
+                                                        "data:mandatory": "[(47,8)-(48,0)]",
+                                                        "#46": "[(46,0)-(51,0)]",
+                                                        "data:propertyTerm": "[(46,8)-(47,0)]",
+                                                        "data:mapKey": "[(48,8)-(49,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "core:name": [
+                                                  {
+                                                    "@value": "mapping"
+                                                  }
+                                                ],
+                                                "smaps": {
+                                                  "lexical": {
+                                                    "data:speakers": "[(45,6)-(51,0)]",
+                                                    "data:recorded": "[(38,6)-(41,0)]",
+                                                    "data:about": "[(30,6)-(34,0)]",
+                                                    "#26": "[(26,0)-(51,0)]",
+                                                    "data:title": "[(26,6)-(30,0)]",
+                                                    "data:date": "[(34,6)-(38,0)]",
+                                                    "data:product": "[(41,6)-(45,0)]"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "core:name": [
+                                              {
+                                                "@value": "PresentationNode"
+                                              }
+                                            ],
+                                            "smaps": {
+                                              "lexical": {
+                                                "data:mapping": "[(25,4)-(51,0)]",
+                                                "#24": "[(24,0)-(51,0)]",
+                                                "data:classTerm": "[(24,4)-(25,0)]"
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "data:SpeakerNode": [
+                                          {
+                                            "@id": "#51",
+                                            "@type": [
+                                              "data:Object",
+                                              "data:Node",
+                                              "doc:DomainElement"
+                                            ],
+                                            "data:classTerm": [
+                                              {
+                                                "@id": "#52",
+                                                "@type": [
+                                                  "data:Scalar",
+                                                  "data:Node",
+                                                  "doc:DomainElement"
+                                                ],
+                                                "data:value": [
+                                                  {
+                                                    "@value": "demos.Speaker"
+                                                  }
+                                                ],
+                                                "shacl:datatype": [
+                                                  {
+                                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                  }
+                                                ],
+                                                "core:name": [
+                                                  {
+                                                    "@value": "classTerm"
+                                                  }
+                                                ],
+                                                "smaps": {
+                                                  "lexical": {
+                                                    "#52": "[(52,15)-(52,28)]"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "data:mapping": [
+                                              {
+                                                "@id": "#53",
+                                                "@type": [
+                                                  "data:Object",
+                                                  "data:Node",
+                                                  "doc:DomainElement"
+                                                ],
+                                                "data:age": [
+                                                  {
+                                                    "@id": "#54",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#55",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "schema-org.age"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#55": "[(55,22)-(55,36)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#56",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "integer"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#56": "[(56,15)-(56,22)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "age"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:range": "[(56,8)-(57,0)]",
+                                                        "#54": "[(55,0)-(57,0)]",
+                                                        "data:propertyTerm": "[(55,8)-(56,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "data:email": [
+                                                  {
+                                                    "@id": "#57",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#58",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "schema-org.email"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#58": "[(58,22)-(58,38)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#59",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "string"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#59": "[(59,15)-(59,21)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "email"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:range": "[(59,8)-(60,0)]",
+                                                        "#57": "[(58,0)-(60,0)]",
+                                                        "data:propertyTerm": "[(58,8)-(59,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "data:nick": [
+                                                  {
+                                                    "@id": "#60",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#61",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "demos.nickName"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#61": "[(61,22)-(61,36)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:mandatory": [
+                                                      {
+                                                        "@id": "#62",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "true"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "mandatory"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#62": "[(62,19)-(62,23)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#63",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "string"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#63": "[(63,15)-(63,21)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "nick"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:range": "[(63,8)-(65,0)]",
+                                                        "data:propertyTerm": "[(61,8)-(62,0)]",
+                                                        "#60": "[(61,0)-(65,0)]",
+                                                        "data:mandatory": "[(62,8)-(63,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "core:name": [
+                                                  {
+                                                    "@value": "mapping"
+                                                  }
+                                                ],
+                                                "smaps": {
+                                                  "lexical": {
+                                                    "data:nick": "[(60,6)-(65,0)]",
+                                                    "data:age": "[(54,6)-(57,0)]",
+                                                    "#53": "[(54,0)-(65,0)]",
+                                                    "data:email": "[(57,6)-(60,0)]"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "core:name": [
+                                              {
+                                                "@value": "SpeakerNode"
+                                              }
+                                            ],
+                                            "smaps": {
+                                              "lexical": {
+                                                "data:mapping": "[(53,4)-(65,0)]",
+                                                "#51": "[(52,0)-(65,0)]",
+                                                "data:classTerm": "[(52,4)-(53,0)]"
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "data:ProductNode": [
+                                          {
+                                            "@id": "#64",
+                                            "@type": [
+                                              "data:Object",
+                                              "data:Node",
+                                              "doc:DomainElement"
+                                            ],
+                                            "data:classTerm": [
+                                              {
+                                                "@id": "#65",
+                                                "@type": [
+                                                  "data:Scalar",
+                                                  "data:Node",
+                                                  "doc:DomainElement"
+                                                ],
+                                                "data:value": [
+                                                  {
+                                                    "@value": "schema-org.Product"
+                                                  }
+                                                ],
+                                                "shacl:datatype": [
+                                                  {
+                                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                  }
+                                                ],
+                                                "core:name": [
+                                                  {
+                                                    "@value": "classTerm"
+                                                  }
+                                                ],
+                                                "smaps": {
+                                                  "lexical": {
+                                                    "#65": "[(66,15)-(66,33)]"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "data:mapping": [
+                                              {
+                                                "@id": "#66",
+                                                "@type": [
+                                                  "data:Object",
+                                                  "data:Node",
+                                                  "doc:DomainElement"
+                                                ],
+                                                "data:code": [
+                                                  {
+                                                    "@id": "#67",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#68",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "demos.code"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#68": "[(69,22)-(69,32)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#69",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "string"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#69": "[(70,15)-(70,21)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:mandatory": [
+                                                      {
+                                                        "@id": "#70",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "true"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "mandatory"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#70": "[(71,19)-(71,23)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "code"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:mandatory": "[(71,8)-(72,0)]",
+                                                        "data:propertyTerm": "[(69,8)-(70,0)]",
+                                                        "#67": "[(69,0)-(72,0)]",
+                                                        "data:range": "[(70,8)-(71,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "data:description": [
+                                                  {
+                                                    "@id": "#71",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#72",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "schema-org.description"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#72": "[(73,22)-(73,44)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#73",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "string"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#73": "[(74,15)-(74,21)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "description"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:range": "[(74,8)-(75,0)]",
+                                                        "#71": "[(73,0)-(75,0)]",
+                                                        "data:propertyTerm": "[(73,8)-(74,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "data:version": [
+                                                  {
+                                                    "@id": "#74",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#75",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "demos.semantic-version"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#75": "[(76,22)-(76,44)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#76",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "string"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#76": "[(77,15)-(77,21)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "version"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:range": "[(77,8)-(78,0)]",
+                                                        "#74": "[(76,0)-(78,0)]",
+                                                        "data:propertyTerm": "[(76,8)-(77,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "data:resources": [
+                                                  {
+                                                    "@id": "#77",
+                                                    "@type": [
+                                                      "data:Object",
+                                                      "data:Node",
+                                                      "doc:DomainElement"
+                                                    ],
+                                                    "data:propertyTerm": [
+                                                      {
+                                                        "@id": "#78",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "demos.resources"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "propertyTerm"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#78": "[(79,22)-(79,37)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:range": [
+                                                      {
+                                                        "@id": "#79",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "string"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "range"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#79": "[(80,15)-(80,21)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "data:allowMultiple": [
+                                                      {
+                                                        "@id": "#80",
+                                                        "@type": [
+                                                          "data:Scalar",
+                                                          "data:Node",
+                                                          "doc:DomainElement"
+                                                        ],
+                                                        "data:value": [
+                                                          {
+                                                            "@value": "true"
+                                                          }
+                                                        ],
+                                                        "shacl:datatype": [
+                                                          {
+                                                            "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                                                          }
+                                                        ],
+                                                        "core:name": [
+                                                          {
+                                                            "@value": "allowMultiple"
+                                                          }
+                                                        ],
+                                                        "smaps": {
+                                                          "lexical": {
+                                                            "#80": "[(81,23)-(81,27)]"
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "core:name": [
+                                                      {
+                                                        "@value": "resources"
+                                                      }
+                                                    ],
+                                                    "smaps": {
+                                                      "lexical": {
+                                                        "data:allowMultiple": "[(81,8)-(81,27)]",
+                                                        "data:propertyTerm": "[(79,8)-(80,0)]",
+                                                        "#77": "[(79,0)-(81,27)]",
+                                                        "data:range": "[(80,8)-(81,0)]"
+                                                      }
+                                                    }
+                                                  }
+                                                ],
+                                                "core:name": [
+                                                  {
+                                                    "@value": "mapping"
+                                                  }
+                                                ],
+                                                "smaps": {
+                                                  "lexical": {
+                                                    "data:resources": "[(78,6)-(81,27)]",
+                                                    "data:description": "[(72,6)-(75,0)]",
+                                                    "#66": "[(68,0)-(81,27)]",
+                                                    "data:code": "[(68,6)-(72,0)]",
+                                                    "data:version": "[(75,6)-(78,0)]"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "core:name": [
+                                              {
+                                                "@value": "ProductNode"
+                                              }
+                                            ],
+                                            "smaps": {
+                                              "lexical": {
+                                                "data:mapping": "[(67,4)-(81,27)]",
+                                                "#64": "[(66,0)-(81,27)]",
+                                                "data:classTerm": "[(66,4)-(67,0)]"
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "core:name": [
+                                          {
+                                            "@value": "nodeMappings"
+                                          }
+                                        ],
+                                        "smaps": {
+                                          "lexical": {
+                                            "data:ProductNode": "[(65,2)-(81,27)]",
+                                            "data:PresentationNode": "[(23,2)-(51,0)]",
+                                            "#23": "[(23,0)-(81,27)]",
+                                            "data:SpeakerNode": "[(51,2)-(65,0)]"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "core:name": [
+                                      {
+                                        "@value": "object_1"
+                                      }
+                                    ],
+                                    "smaps": {
+                                      "lexical": {
+                                        "data:nodeMappings": "[(21,0)-(81,27)]",
+                                        "data:external": "[(11,0)-(14,0)]",
+                                        "data:version": "[(5,0)-(8,0)]",
+                                        "#10": "[(4,0)-(81,27)]",
+                                        "data:dialect": "[(4,0)-(5,0)]",
+                                        "data:uses": "[(8,0)-(11,0)]",
+                                        "data:documents": "[(14,0)-(21,0)]"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "doc:reference-id": [
+                                  {
+                                    "@id": "#2"
+                                  }
+                                ],
+                                "doc:location": [
+                                  {
+                                    "@value": "file://amf-client/shared/src/test/resources/production/knowledge-graph-service-api-1.0.13-raml/examples/post/dialect.yaml"
+                                  }
+                                ],
+                                "smaps": {
+                                  "synthesized-field": {
+                                    "doc:strict": "true"
+                                  },
+                                  "lexical": {
+                                    "doc:structuredValue": "[(17,17)-(17,95)]",
+                                    "#9": "[(17,8)-(19,0)]"
+                                  },
+                                  "tracked-element": {
+                                    "#9": "amf://id#7"
+                                  }
+                                }
+                              }
+                            ],
+                            "smaps": {
+                              "auto-generated-name": {
+                                "#8": ""
+                              },
+                              "lexical": {
+                                "apiContract:examples": "[(17,8)-(19,0)]",
+                                "#8": "[(16,6)-(19,0)]"
+                              }
+                            }
+                          }
+                        ],
+                        "smaps": {
+                          "lexical": {
+                            "#7": "[(16,6)-(19,0)]"
+                          }
+                        }
+                      }
+                    ],
+                    "smaps": {
+                      "lexical": {
+                        "apiContract:payload": "[(15,4)-(19,0)]",
+                        "#6": "[(9,0)-(19,0)]"
+                      }
+                    }
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#81",
+                    "@type": [
+                      "apiContract:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#82",
+                        "@type": [
+                          "apiContract:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "core:mediaType": [
+                          {
+                            "@value": "application/json"
+                          }
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#83",
+                            "@type": [
+                              "raml-shapes:ScalarShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "shacl:datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ],
+                            "shacl:name": [
+                              {
+                                "@value": "schema"
+                              }
+                            ],
+                            "smaps": {
+                              "auto-generated-name": {
+                                "#83": ""
+                              },
+                              "lexical": {
+                                "shacl:datatype": "[(14,12)-(15,0)]",
+                                "#83": "[(13,10)-(15,0)]"
+                              },
+                              "type-property-lexical-info": {
+                                "#83": "[(14,12)-(14,16)]"
+                              }
+                            }
+                          }
+                        ],
+                        "smaps": {
+                          "lexical": {
+                            "#82": "[(13,10)-(15,0)]"
+                          }
+                        }
+                      }
+                    ],
+                    "smaps": {
+                      "lexical": {
+                        "apiContract:payload": "[(12,8)-(15,0)]",
+                        "#81": "[(11,6)-(15,0)]"
+                      }
+                    }
+                  }
+                ],
+                "smaps": {
+                  "synthesized-field": {
+                    "apiContract:expects": "true"
+                  },
+                  "lexical": {
+                    "apiContract:returns": "[(10,4)-(15,0)]",
+                    "#5": "[(8,2)-(19,0)]",
+                    "core:description": "[(9,4)-(10,0)]"
+                  }
+                }
+              }
+            ],
+            "smaps": {
+              "lexical": {
+                "#4": "[(7,0)-(19,0)]"
+              }
+            }
+          }
+        ],
+        "smaps": {
+          "source-vendor": {
+            "#3": "RAML 1.0"
+          },
+          "lexical": {
+            "core:version": "[(5,0)-(7,0)]",
+            "core:name": "[(4,0)-(5,0)]",
+            "#3": "[(2,0)-(19,0)]",
+            "apiContract:server": "[(2,0)-(4,0)]"
+          }
+        }
+      }
+    ],
+    "doc:version": [
+      {
+        "@value": "3.0.0"
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:references": [
+      {
+        "@id": "#1",
+        "@type": [
+          "doc:ExternalFragment",
+          "doc:Fragment",
+          "doc:Unit"
+        ],
+        "doc:encodes": [
+          {
+            "@id": "#2",
+            "@type": [
+              "doc:ExternalDomainElement",
+              "doc:DomainElement"
+            ],
+            "doc:raw": [
+              {
+                "@value": "#%Dialect 1.0\n\n# Name of the dialect, this will define the header of the dialect documents\ndialect: Tech Talks\nversion: \"0.1\"\n\n# Vocabularies and externals can be referenced to use those terms in the dialect nodess\nuses:\n  demos: http://mulesoft.com/v1/vocabulary/9758c8aa-18d0-484f-905c-a715c279b195/7574a3a021fc0ad2a2bae65136bea7ab\n\nexternal:\n  schema-org: http://schema.org/\n\ndocuments:\n  library:\n    declares:\n      products: ProductNode\n  root:\n    encodes: PresentationNode\n\nnodeMappings:\n\n  PresentationNode:\n    classTerm: demos.Presentation\n    mapping:\n      title:\n        propertyTerm: schema-org.name\n        mandatory: true\n        range: string\n      about:\n        propertyTerm: schema-org.description\n        mandatory: true\n        range: string\n      date:\n        propertyTerm: demos.demoDate\n        mandatory: true\n        range: date\n      recorded:\n        propertyTerm: demos.isRecorded\n        range: boolean\n      product:\n        propertyTerm: demos.showcases\n        range: ProductNode\n        mandatory: true\n      speakers:\n        propertyTerm: demos.speakers\n        mandatory: true\n        mapKey: demos.nickName\n        range: SpeakerNode\n\n  SpeakerNode:\n    classTerm: demos.Speaker\n    mapping:\n      age:\n        propertyTerm: schema-org.age\n        range: integer\n      email:\n        propertyTerm: schema-org.email\n        range: string\n      nick:\n        propertyTerm: demos.nickName\n        mandatory: true\n        range: string\n\n  ProductNode:\n    classTerm: schema-org.Product\n    mapping:\n      code:\n        propertyTerm: demos.code\n        range: string\n        mandatory: true\n      description:\n        propertyTerm: schema-org.description\n        range: string\n      version:\n        propertyTerm: demos.semantic-version\n        range: string\n      resources:\n        propertyTerm: demos.resources\n        range: string\n        allowMultiple: true"
+              }
+            ],
+            "core:mediaType": [
+              {
+                "@value": "application/yaml"
+              }
+            ],
+            "smaps": {
+              "lexical": {
+                "#2": "[(1,0)-(81,27)]"
+              }
+            }
+          }
+        ],
+        "doc:version": [
+          {
+            "@value": "3.0.0"
+          }
+        ],
+        "doc:root": [
+          {
+            "@value": false
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "amf://id",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "data": "http://a.ml/vocabularies/data#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-client/shared/src/test/resources/production/knowledge-graph-reduced/api.raml
+++ b/amf-client/shared/src/test/resources/production/knowledge-graph-reduced/api.raml
@@ -1,0 +1,18 @@
+#%RAML 1.0
+baseUri: http://ang-service.kqa.msap.io/v1
+#baseUri: https://mocksvc.mulesoft.com/mocks/515b37d9-b7af-4c6a-9a3c-052bced57e5b #
+title: ANG Service
+version: v1
+
+/vocabulary:
+  post:
+    description: Stores the triples for the parsed, and validated Vocabulary and returns the URI for the newly created graph
+    responses:
+      200:
+        body:
+          application/json:
+            type: string
+    body:
+      application/ld+json:
+        example: !include ../knowledge-graph-service-api-1.0.13-raml/examples/post/dialect.yaml
+

--- a/amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-ref.jsonld
+++ b/amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-ref.jsonld
@@ -62,415 +62,44 @@
       {
         "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml",
         "@type": [
-          "http://a.ml/vocabularies/document#Document",
+          "http://a.ml/vocabularies/document#ExternalFragment",
           "http://a.ml/vocabularies/document#Fragment",
-          "http://a.ml/vocabularies/document#Module",
           "http://a.ml/vocabularies/document#Unit"
         ],
         "http://a.ml/vocabularies/document#encodes": [
           {
-            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/web-api",
+            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/external",
             "@type": [
-              "http://a.ml/vocabularies/apiContract#WebAPI",
-              "http://a.ml/vocabularies/apiContract#API",
-              "http://a.ml/vocabularies/document#RootDomainElement",
+              "http://a.ml/vocabularies/document#ExternalDomainElement",
               "http://a.ml/vocabularies/document#DomainElement"
             ],
-            "http://a.ml/vocabularies/core#name": [
+            "http://a.ml/vocabularies/document#raw": [
               {
-                "@value": "test-circular-references"
+                "@value": "swagger: '2.0'\ninfo:\n  title: test-circular-references\n  version: 1.1.0\ndefinitions:\n  pet:\n    type: object\n    properties:\n      animalRef:\n        $ref: 'oas-2-ref.yaml#/definitions/animal'\npaths: {}"
               }
             ],
-            "http://a.ml/vocabularies/core#version": [
+            "http://a.ml/vocabularies/core#mediaType": [
               {
-                "@value": "1.1.0"
+                "@value": "application/yaml"
               }
             ],
             "http://a.ml/vocabularies/document-source-maps#sources": [
               {
-                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/web-api/source-map",
+                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/external/source-map",
                 "@type": [
                   "http://a.ml/vocabularies/document-source-maps#SourceMap"
                 ],
-                "http://a.ml/vocabularies/document-source-maps#source-vendor": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/web-api/source-map/source-vendor/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/web-api"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "OAS 2.0"
-                      }
-                    ]
-                  }
-                ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/web-api/source-map/lexical/element_2",
+                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/external/source-map/lexical/element_0",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "http://a.ml/vocabularies/core#name"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(3,2)-(4,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/web-api/source-map/lexical/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://a.ml/vocabularies/core#version"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(4,2)-(5,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/web-api/source-map/lexical/element_1",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/web-api"
+                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/external"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(1,0)-(11,9)]"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        "http://a.ml/vocabularies/document#declares": [
-          {
-            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet",
-            "@type": [
-              "http://www.w3.org/ns/shacl#NodeShape",
-              "http://a.ml/vocabularies/shapes#AnyShape",
-              "http://www.w3.org/ns/shacl#Shape",
-              "http://a.ml/vocabularies/shapes#Shape",
-              "http://a.ml/vocabularies/document#DomainElement"
-            ],
-            "http://www.w3.org/ns/shacl#closed": [
-              {
-                "@value": false
-              }
-            ],
-            "http://www.w3.org/ns/shacl#property": [
-              {
-                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef",
-                "@type": [
-                  "http://www.w3.org/ns/shacl#PropertyShape",
-                  "http://www.w3.org/ns/shacl#Shape",
-                  "http://a.ml/vocabularies/shapes#Shape",
-                  "http://a.ml/vocabularies/document#DomainElement"
-                ],
-                "http://www.w3.org/ns/shacl#path": [
-                  {
-                    "@id": "http://a.ml/vocabularies/data#animalRef"
-                  }
-                ],
-                "http://a.ml/vocabularies/shapes#range": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal",
-                    "@type": [
-                      "http://www.w3.org/ns/shacl#NodeShape",
-                      "http://a.ml/vocabularies/shapes#AnyShape",
-                      "http://www.w3.org/ns/shacl#Shape",
-                      "http://a.ml/vocabularies/shapes#Shape",
-                      "http://a.ml/vocabularies/document#DomainElement"
-                    ],
-                    "http://www.w3.org/ns/shacl#closed": [
-                      {
-                        "@value": false
-                      }
-                    ],
-                    "http://www.w3.org/ns/shacl#property": [
-                      {
-                        "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef",
-                        "@type": [
-                          "http://www.w3.org/ns/shacl#PropertyShape",
-                          "http://www.w3.org/ns/shacl#Shape",
-                          "http://a.ml/vocabularies/shapes#Shape",
-                          "http://a.ml/vocabularies/document#DomainElement"
-                        ],
-                        "http://www.w3.org/ns/shacl#path": [
-                          {
-                            "@id": "http://a.ml/vocabularies/data#petRef"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/shapes#range": [
-                          {
-                            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/petRef",
-                            "@type": [
-                              "http://www.w3.org/ns/shacl#NodeShape",
-                              "http://a.ml/vocabularies/shapes#AnyShape",
-                              "http://www.w3.org/ns/shacl#Shape",
-                              "http://a.ml/vocabularies/shapes#Shape",
-                              "http://a.ml/vocabularies/document#DomainElement"
-                            ],
-                            "http://a.ml/vocabularies/document#link-target": [
-                              {
-                                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document#link-label": [
-                              {
-                                "@value": "oas-2-root.yaml#/definitions/pet"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document#recursive": [
-                              {
-                                "@value": true
-                              }
-                            ],
-                            "http://www.w3.org/ns/shacl#name": [
-                              {
-                                "@value": "petRef"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#sources": [
-                              {
-                                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/petRef/source-map",
-                                "@type": [
-                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                                ],
-                                "http://a.ml/vocabularies/document-source-maps#lexical": [
-                                  {
-                                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/petRef/source-map/lexical/element_0",
-                                    "http://a.ml/vocabularies/document-source-maps#element": [
-                                      {
-                                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/petRef"
-                                      }
-                                    ],
-                                    "http://a.ml/vocabularies/document-source-maps#value": [
-                                      {
-                                        "@value": "[(5,6)-(6,48)]"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ],
-                        "http://www.w3.org/ns/shacl#minCount": [
-                          {
-                            "@value": 0
-                          }
-                        ],
-                        "http://www.w3.org/ns/shacl#name": [
-                          {
-                            "@value": "petRef"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#sources": [
-                          {
-                            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/source-map",
-                            "@type": [
-                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#lexical": [
-                              {
-                                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/source-map/lexical/element_0",
-                                "http://a.ml/vocabularies/document-source-maps#element": [
-                                  {
-                                    "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef"
-                                  }
-                                ],
-                                "http://a.ml/vocabularies/document-source-maps#value": [
-                                  {
-                                    "@value": "[(5,6)-(6,48)]"
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ],
-                    "http://www.w3.org/ns/shacl#name": [
-                      {
-                        "@value": "animal"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#sources": [
-                      {
-                        "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/source-map",
-                        "@type": [
-                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-                          {
-                            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/source-map/type-property-lexical-info/element_0",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(3,4)-(3,8)]"
-                              }
-                            ]
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#lexical": [
-                          {
-                            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/source-map/lexical/element_1",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(2,2)-(6,48)]"
-                              }
-                            ]
-                          },
-                          {
-                            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/animal/source-map/lexical/element_0",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "http://www.w3.org/ns/shacl#property"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(4,4)-(6,48)]"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ],
-                "http://www.w3.org/ns/shacl#minCount": [
-                  {
-                    "@value": 0
-                  }
-                ],
-                "http://www.w3.org/ns/shacl#name": [
-                  {
-                    "@value": "animalRef"
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#sources": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/source-map",
-                    "@type": [
-                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#lexical": [
-                      {
-                        "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef/source-map/lexical/element_0",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/property/animalRef"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(9,6)-(11,0)]"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "http://www.w3.org/ns/shacl#name": [
-              {
-                "@value": "pet"
-              }
-            ],
-            "http://a.ml/vocabularies/document-source-maps#sources": [
-              {
-                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/source-map",
-                "@type": [
-                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                ],
-                "http://a.ml/vocabularies/document-source-maps#declared-element": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/source-map/declared-element/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": ""
-                      }
-                    ]
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#lexical": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/source-map/lexical/element_2",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://www.w3.org/ns/shacl#property"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(8,4)-(11,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/source-map/lexical/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://www.w3.org/ns/shacl#name"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(6,2)-(6,5)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/source-map/lexical/element_1",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(6,2)-(11,0)]"
-                      }
-                    ]
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet/source-map/type-property-lexical-info/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-2-root.yaml#/declarations/types/pet"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(7,4)-(7,8)]"
                       }
                     ]
                   }

--- a/amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-ref.jsonld
+++ b/amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-ref.jsonld
@@ -62,415 +62,44 @@
       {
         "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml",
         "@type": [
-          "http://a.ml/vocabularies/document#Document",
+          "http://a.ml/vocabularies/document#ExternalFragment",
           "http://a.ml/vocabularies/document#Fragment",
-          "http://a.ml/vocabularies/document#Module",
           "http://a.ml/vocabularies/document#Unit"
         ],
         "http://a.ml/vocabularies/document#encodes": [
           {
-            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/web-api",
+            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/external",
             "@type": [
-              "http://a.ml/vocabularies/apiContract#WebAPI",
-              "http://a.ml/vocabularies/apiContract#API",
-              "http://a.ml/vocabularies/document#RootDomainElement",
+              "http://a.ml/vocabularies/document#ExternalDomainElement",
               "http://a.ml/vocabularies/document#DomainElement"
             ],
-            "http://a.ml/vocabularies/core#name": [
+            "http://a.ml/vocabularies/document#raw": [
               {
-                "@value": "test-circular-references"
+                "@value": "openapi: '3.0.0'\ninfo:\n  title: test-circular-references\n  version: 1.1.0\ncomponents:\n  schemas:\n    pet:\n      type: object\n      properties:\n        animalRef:\n          $ref: 'oas-3-ref.yaml#/definitions/animal'\npaths: {}"
               }
             ],
-            "http://a.ml/vocabularies/core#version": [
+            "http://a.ml/vocabularies/core#mediaType": [
               {
-                "@value": "1.1.0"
+                "@value": "application/yaml"
               }
             ],
             "http://a.ml/vocabularies/document-source-maps#sources": [
               {
-                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/web-api/source-map",
+                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/external/source-map",
                 "@type": [
                   "http://a.ml/vocabularies/document-source-maps#SourceMap"
                 ],
-                "http://a.ml/vocabularies/document-source-maps#source-vendor": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/web-api/source-map/source-vendor/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/web-api"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "OAS 3.0"
-                      }
-                    ]
-                  }
-                ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/web-api/source-map/lexical/element_2",
+                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/external/source-map/lexical/element_0",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "http://a.ml/vocabularies/core#name"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(3,2)-(4,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/web-api/source-map/lexical/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://a.ml/vocabularies/core#version"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(4,2)-(5,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/web-api/source-map/lexical/element_1",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/web-api"
+                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/external"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(1,0)-(12,9)]"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        "http://a.ml/vocabularies/document#declares": [
-          {
-            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet",
-            "@type": [
-              "http://www.w3.org/ns/shacl#NodeShape",
-              "http://a.ml/vocabularies/shapes#AnyShape",
-              "http://www.w3.org/ns/shacl#Shape",
-              "http://a.ml/vocabularies/shapes#Shape",
-              "http://a.ml/vocabularies/document#DomainElement"
-            ],
-            "http://www.w3.org/ns/shacl#closed": [
-              {
-                "@value": false
-              }
-            ],
-            "http://www.w3.org/ns/shacl#property": [
-              {
-                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef",
-                "@type": [
-                  "http://www.w3.org/ns/shacl#PropertyShape",
-                  "http://www.w3.org/ns/shacl#Shape",
-                  "http://a.ml/vocabularies/shapes#Shape",
-                  "http://a.ml/vocabularies/document#DomainElement"
-                ],
-                "http://www.w3.org/ns/shacl#path": [
-                  {
-                    "@id": "http://a.ml/vocabularies/data#animalRef"
-                  }
-                ],
-                "http://a.ml/vocabularies/shapes#range": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal",
-                    "@type": [
-                      "http://www.w3.org/ns/shacl#NodeShape",
-                      "http://a.ml/vocabularies/shapes#AnyShape",
-                      "http://www.w3.org/ns/shacl#Shape",
-                      "http://a.ml/vocabularies/shapes#Shape",
-                      "http://a.ml/vocabularies/document#DomainElement"
-                    ],
-                    "http://www.w3.org/ns/shacl#closed": [
-                      {
-                        "@value": false
-                      }
-                    ],
-                    "http://www.w3.org/ns/shacl#property": [
-                      {
-                        "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef",
-                        "@type": [
-                          "http://www.w3.org/ns/shacl#PropertyShape",
-                          "http://www.w3.org/ns/shacl#Shape",
-                          "http://a.ml/vocabularies/shapes#Shape",
-                          "http://a.ml/vocabularies/document#DomainElement"
-                        ],
-                        "http://www.w3.org/ns/shacl#path": [
-                          {
-                            "@id": "http://a.ml/vocabularies/data#petRef"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/shapes#range": [
-                          {
-                            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/petRef",
-                            "@type": [
-                              "http://www.w3.org/ns/shacl#NodeShape",
-                              "http://a.ml/vocabularies/shapes#AnyShape",
-                              "http://www.w3.org/ns/shacl#Shape",
-                              "http://a.ml/vocabularies/shapes#Shape",
-                              "http://a.ml/vocabularies/document#DomainElement"
-                            ],
-                            "http://a.ml/vocabularies/document#link-target": [
-                              {
-                                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document#link-label": [
-                              {
-                                "@value": "oas-3-root.yaml#/components/schemas/pet"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document#recursive": [
-                              {
-                                "@value": true
-                              }
-                            ],
-                            "http://www.w3.org/ns/shacl#name": [
-                              {
-                                "@value": "petRef"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#sources": [
-                              {
-                                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/petRef/source-map",
-                                "@type": [
-                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                                ],
-                                "http://a.ml/vocabularies/document-source-maps#lexical": [
-                                  {
-                                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/petRef/source-map/lexical/element_0",
-                                    "http://a.ml/vocabularies/document-source-maps#element": [
-                                      {
-                                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/petRef"
-                                      }
-                                    ],
-                                    "http://a.ml/vocabularies/document-source-maps#value": [
-                                      {
-                                        "@value": "[(5,6)-(6,55)]"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ],
-                        "http://www.w3.org/ns/shacl#minCount": [
-                          {
-                            "@value": 0
-                          }
-                        ],
-                        "http://www.w3.org/ns/shacl#name": [
-                          {
-                            "@value": "petRef"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#sources": [
-                          {
-                            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/source-map",
-                            "@type": [
-                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#lexical": [
-                              {
-                                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef/source-map/lexical/element_0",
-                                "http://a.ml/vocabularies/document-source-maps#element": [
-                                  {
-                                    "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/property/petRef"
-                                  }
-                                ],
-                                "http://a.ml/vocabularies/document-source-maps#value": [
-                                  {
-                                    "@value": "[(5,6)-(6,55)]"
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ],
-                    "http://www.w3.org/ns/shacl#name": [
-                      {
-                        "@value": "animal"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#sources": [
-                      {
-                        "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/source-map",
-                        "@type": [
-                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-                          {
-                            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/source-map/type-property-lexical-info/element_0",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(3,4)-(3,8)]"
-                              }
-                            ]
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#lexical": [
-                          {
-                            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/source-map/lexical/element_1",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(2,2)-(6,55)]"
-                              }
-                            ]
-                          },
-                          {
-                            "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/animal/source-map/lexical/element_0",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "http://www.w3.org/ns/shacl#property"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(4,4)-(6,55)]"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ],
-                "http://www.w3.org/ns/shacl#minCount": [
-                  {
-                    "@value": 0
-                  }
-                ],
-                "http://www.w3.org/ns/shacl#name": [
-                  {
-                    "@value": "animalRef"
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#sources": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/source-map",
-                    "@type": [
-                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#lexical": [
-                      {
-                        "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef/source-map/lexical/element_0",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/property/animalRef"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(10,8)-(12,0)]"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "http://www.w3.org/ns/shacl#name": [
-              {
-                "@value": "pet"
-              }
-            ],
-            "http://a.ml/vocabularies/document-source-maps#sources": [
-              {
-                "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/source-map",
-                "@type": [
-                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                ],
-                "http://a.ml/vocabularies/document-source-maps#declared-element": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/source-map/declared-element/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": ""
-                      }
-                    ]
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#lexical": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/source-map/lexical/element_2",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://www.w3.org/ns/shacl#property"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(9,6)-(12,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/source-map/lexical/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://www.w3.org/ns/shacl#name"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(7,4)-(7,7)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/source-map/lexical/element_1",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(7,4)-(12,0)]"
-                      }
-                    ]
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-                  {
-                    "@id": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet/source-map/type-property-lexical-info/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "file://amf-client/shared/src/test/resources/references/oas/oas-references/oas-3-root.yaml#/declarations/types/pet"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(8,6)-(8,10)]"
                       }
                     ]
                   }

--- a/amf-client/shared/src/test/resources/validations/reports/model/invalid-cross-overlay.report
+++ b/amf-client/shared/src/test/resources/validations/reports/model/invalid-cross-overlay.report
@@ -5,10 +5,10 @@ Number of results: 1
 
 Level: Violation
 
-- Source: http://a.ml/vocabularies/amf/core#invalid-cross-spec
-  Message: Cannot reference fragments of another spec
+- Source: http://a.ml/vocabularies/amf/parser#WebAPI-name-minCount
+  Message: API title is mandatory
   Level: Violation
-  Target: 
-  Property: 
-  Position: Some(LexicalInformation([(2,9)-(2,17)]))
+  Target: file://amf-client/shared/src/test/resources/validations/invalid-cross-overlay/invalid-cross-overlay.raml#/web-api
+  Property: http://a.ml/vocabularies/core#name
+  Position: Some(LexicalInformation([(2,0)-(2,17)]))
   Location: file://amf-client/shared/src/test/resources/validations/invalid-cross-overlay/invalid-cross-overlay.raml

--- a/amf-client/shared/src/test/scala/amf/compiler/AMFCompilerTest.scala
+++ b/amf-client/shared/src/test/scala/amf/compiler/AMFCompilerTest.scala
@@ -197,7 +197,7 @@ class AMFCompilerTest extends AsyncFunSuite with CompilerTestBuilder {
       s should include("libraries")
     })
 
-    libraries.entries.length should be(references.count(!_.isInstanceOf[ExternalFragment]))
+    libraries.entries.length should be(references.size)
   }
 
   private def assertCycles(syntax: Syntax, hint: Hint) = {

--- a/amf-client/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
@@ -822,6 +822,17 @@ class EditingResolutionTest extends ResolutionTest {
     )
   }
 
+  test("Reduced KG Service API resolution") {
+    cycle(
+      "knowledge-graph-reduced/api.raml",
+      "knowledge-graph-reduced/api.jsonld",
+      RamlYamlHint,
+      target = Amf,
+      directory = productionPath,
+      transformWith = Some(Raml10)
+    )
+  }
+
   test("Example1 resolution to Raml") {
     cycle("example1.yaml", "example1.resolved.yaml", OasYamlHint, Oas20, resolutionPath, syntax = Some(Yaml))
   }

--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,4 +1,4 @@
 amf.webapi=4.8.0-SNAPSHOT
-amf.core=4.1.208
+amf.core=4.1.209
 amf.custom.validations=5.2.0-SNAPSHOT
 amf.model=3.0.0

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/AsyncPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/AsyncPlugin.scala
@@ -26,8 +26,6 @@ sealed trait AsyncPlugin extends OasLikePlugin with CrossSpecRestriction {
 
   override val vendors: Seq[String] = Seq(vendor.name, AsyncApi.name)
 
-  override val validVendorsToReference: Seq[Vendor] = Seq(Raml10)
-
   override def specContext(options: RenderOptions, errorHandler: ErrorHandler): AsyncSpecEmitterContext
 
   def context(loc: String,
@@ -78,6 +76,8 @@ object Async20Plugin extends AsyncPlugin {
     new Async20SpecEmitterContext(errorHandler)
 
   override protected def vendor: Vendor = AsyncApi20
+
+  override def validVendorsToReference: Seq[String] = super.validVendorsToReference :+ Raml10.name
 
   override val validationProfile: ProfileName = Async20Profile
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/BaseWebApiPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/BaseWebApiPlugin.scala
@@ -39,6 +39,8 @@ trait BaseWebApiPlugin extends AMFDocumentPlugin with AMFValidationPlugin with W
     ExternalJsonYamlRefsPlugin
   )
 
+  def validVendorsToReference: Seq[String] = List(ExternalJsonYamlRefsPlugin.ID)
+
   def specContext(options: RenderOptions, errorHandler: ErrorHandler): SpecEmitterContext
 
   /**

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/CrossSpecRestriction.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/CrossSpecRestriction.scala
@@ -1,20 +1,18 @@
 package amf.plugins.document.webapi
 
+import amf.client.plugins.AMFDocumentPlugin
 import amf.core.Root
 import amf.core.errorhandling.ErrorHandler
 import amf.core.parser.{ParserContext, Reference}
 import amf.core.remote.Vendor
 import amf.plugins.features.validation.CoreValidations.InvalidCrossSpec
 
-trait CrossSpecRestriction {
-
-  protected def vendors: Seq[String]
-  protected def validVendorsToReference: Seq[Vendor] = Seq.empty
+trait CrossSpecRestriction { this: AMFDocumentPlugin =>
 
   // TODO: all documents should have a Vendor
   protected def restrictCrossSpecReferences(optionalReferencedVendor: Option[Vendor], reference: Reference)(
       implicit errorHandler: ErrorHandler): Unit = {
-    val possibleReferencedVendors = vendors ++ validVendorsToReference.map(_.name)
+    val possibleReferencedVendors = vendors ++ validVendorsToReference
     optionalReferencedVendor.foreach { referencedVendor =>
       if (!possibleReferencedVendors.contains(referencedVendor.name)) {
         referenceNodes(reference).foreach(node =>

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/ExternalJsonYamlRefsPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/ExternalJsonYamlRefsPlugin.scala
@@ -24,6 +24,7 @@ import amf.core.utils._
 import amf.plugins.features.validation.CoreValidations.UnresolvedReference
 import org.yaml.model._
 import amf.core.exception.UnsupportedParsedDocumentException
+
 import scala.concurrent.{ExecutionContext, Future}
 
 class JsonRefsReferenceHandler extends ReferenceHandler {
@@ -134,6 +135,8 @@ class ExternalJsonYamlRefsPlugin extends JsonSchemaPlugin {
   override def referenceHandler(eh: ErrorHandler): ReferenceHandler = new JsonRefsReferenceHandler()
 
   override def dependencies(): Seq[AMFPlugin] = Nil
+
+  override val validVendorsToReference: Seq[String] = Nil
 
   override def init()(implicit executionContext: ExecutionContext): Future[AMFPlugin] = Future.successful(this)
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/JsonSchemaPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/JsonSchemaPlugin.scala
@@ -111,6 +111,8 @@ class JsonSchemaPlugin extends AMFDocumentPlugin with PlatformSecrets {
 
   override def dependencies(): Seq[AMFPlugin] = Nil
 
+  override val validVendorsToReference: Seq[String] = Nil
+
   override def init()(implicit executionContext: ExecutionContext): Future[AMFPlugin] = Future.successful(this)
 
   /**

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/PayloadPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/PayloadPlugin.scala
@@ -34,7 +34,9 @@ object PayloadPlugin extends AMFDocumentPlugin {
 
   override def dependencies(): Seq[AMFDomainPlugin] = Seq(APIDomainPlugin, DataShapesDomainPlugin)
 
-  // we are looking for documents with a very specific payload
+  override val validVendorsToReference: Seq[String] = Nil
+
+// we are looking for documents with a very specific payload
   // otherwise, this plugin can become the fallback option.
   // Fallback option should be an external fragment.
   override def documentSyntaxes: Seq[String] = Seq(

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/RamlPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/RamlPlugin.scala
@@ -3,6 +3,7 @@ package amf.plugins.document.webapi
 import amf._
 import amf.core.client.ParsingOptions
 import amf.client.remod.amfcore.config.RenderOptions
+import amf.client.remod.amfcore.plugins.parse.AMFParsePluginAdapter
 import amf.core.errorhandling.ErrorHandler
 import amf.core.exception.InvalidDocumentHeaderException
 import amf.core.model.document._
@@ -50,7 +51,7 @@ sealed trait RamlPlugin extends BaseWebApiPlugin with CrossSpecRestriction {
 
   override val vendors: Seq[String] = Seq(vendor.name, Raml.name)
 
-  override def referenceHandler(eh: ErrorHandler) = new RamlReferenceHandler(ID)
+  override def referenceHandler(eh: ErrorHandler) = new RamlReferenceHandler(AMFParsePluginAdapter(this))
 
   def context(wrapped: ParserContext,
               root: Root,
@@ -184,7 +185,7 @@ object Raml08Plugin extends RamlPlugin {
       // Partial raml0.8 fragment with RAML header but linked through !include
       // we need to generate an external fragment and inline it in the parent document
       case Raml08 if root.referenceKind != LinkReference => true
-      case _: RamlFragment                               => true
+      case _: RamlFragment                               => true // this is incorrect, should be removed
       case _                                             => false
     }
   }


### PR DESCRIPTION
Depends on https://github.com/aml-org/amf-core/pull/189.

Detail of tests that where modified:

- AMFCompilerTest ("Libraries (oas)")
```
{
  "swagger": "2.0",
  "info": {
    "title": "Baeldung Foo REST Services API"
  },
  "x-amf-uses": {
    "mySecuritySchemes" : "libraries/security.raml",
    "myDataTypes" : "libraries/dataTypes.raml"
  }
}
```
The parsed Document of this swagger now contains 2 external fragments within references as raml is not a valid vendor to reference.

- RamlModelUniquePlatformReportTest ("Invalid reference from overlay to swagger document")

RAML Overlay with an extends that references OAS document. Previously the referenced OAS was parsed as a Document and a cross reference violation was present. This external file is now parsed as an external fragment, and is simply not applied in the ExtendsResolutionStage resolveOverlay method. This leads to "API title is mandatory" violation, we could add a violation in the overlay parser to make sure a valid document is being extended if a more detailed error is needed.

- OasInterSpecRefsReportTest

Two tests cases of OAS documents referencing raml fragments. Previously a cross spec reference violation was present, now there are violations for invalid values, such as "YAML map expected" and "Syntax error : Unexpected '#%RAML 1.0 DataType'" which are correct.