### PR TITLE
Custom validations severity fix

### DIFF
--- a/amf-client/shared/src/test/resources/validations/banking-api-error.raml
+++ b/amf-client/shared/src/test/resources/validations/banking-api-error.raml
@@ -1,0 +1,39 @@
+#%RAML 1.0
+
+title: Banking HTTP API
+version: 1.0
+mediaType: application/json
+protocols:
+  - FTP
+
+/customers:
+  /{customer_id}:
+    uriParameters:
+      customer_id: string
+    get:
+      description: Returns Customer data
+      responses:
+        200:
+          body:
+            application/json:
+    delete:
+      description: Removes a Customer from the system
+    /accounts:
+      get:
+        description: Returns a collection accounts
+        responses:
+          200:
+            body:
+              application/json:
+    /cards:
+      /debit:
+        get:
+          description: Returns a collection of cards
+          responses:
+            200:
+              body:
+                application/json:
+        post:
+          description: Requests the creation of a new DebitCard
+          body:
+            application/json:

--- a/amf-client/shared/src/test/resources/validations/profiles/validation-profile.yaml
+++ b/amf-client/shared/src/test/resources/validations/profiles/validation-profile.yaml
@@ -1,0 +1,22 @@
+#%Validation Profile 1.0
+
+description: Validation profile implementing common validations
+
+profile: Banking
+
+extends: RAML
+
+warning:
+  - amf-parser.raml-root-schemes-values
+
+violation:
+  - custom-schemes
+
+validations:
+
+  custom-schemes:
+    message: Supported schemes are HTTP, HTTPS and FTP
+    targetClass: schema-org.WebAPI
+    propertyConstraints:
+      raml-http.scheme:
+        in: ["http", "https", "HTTP", "HTTPS", "ftp", "FTP"]

--- a/amf-client/shared/src/test/resources/validations/reports/banking.report
+++ b/amf-client/shared/src/test/resources/validations/reports/banking.report
@@ -1,0 +1,14 @@
+Model: file://amf-client/shared/src/test/resources/validations/banking-api-error.raml
+Profile: Banking
+Conforms? true
+Number of results: 1
+
+Level: Warning
+
+- Source: http://a.ml/vocabularies/amf/parser#raml-root-schemes-values
+  Message: Protocols property must be http or https
+  Level: Warning
+  Target: file://amf-client/shared/src/test/resources/validations/banking-api-error.raml#/web-api
+  Property: http://a.ml/vocabularies/apiContract#scheme
+  Position: Some(LexicalInformation([(7,0)-(9,0)]))
+  Location: file://amf-client/shared/src/test/resources/validations/banking-api-error.raml

--- a/amf-client/shared/src/test/scala/amf/validation/CustomValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/CustomValidationTest.scala
@@ -38,6 +38,13 @@ class CustomValidationTest extends UniquePlatformReportGenTest {
     validate("logical.raml", Some("logical.report"), ProfileName("logical"), Some("profiles/logical.yaml"))
   }
 
+  test("Defining raml validation as warning") {
+    validate("banking-api-error.raml",
+             Some("banking.report"),
+             ProfileName("Banking"),
+             Some("profiles/validation-profile.yaml"))
+  }
+
   if (platform.name == "jvm") { // not supported in JS yet
     test("Query constraints") {
       validate("query.raml", Some("query.report"), ProfileName("query"), Some("profiles/query.yaml"))

--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,4 +1,4 @@
 amf.webapi=4.8.0-SNAPSHOT
-amf.core=4.1.207
+amf.core=4.1.208
 amf.custom.validations=5.2.0-SNAPSHOT
 amf.model=3.0.0


### PR DESCRIPTION
- remove severity defined in property constraints, use severity defined in ValidationSpecification directly.
- set custom severity levels in effective validation specifications.

https://github.com/aml-org/amf-aml/pull/239 and https://github.com/aml-org/amf-core/pull/209