### PR TITLE
APIMF-3048: add javadoc and remove private[amf]

### DIFF
--- a/amf-webapi/shared/src/main/scala/amf/client/environment/AMFClient.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/environment/AMFClient.scala
@@ -6,19 +6,33 @@ import amf.core.model.document.{Document, Module}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AMFClient private[amf](override protected val configuration: AMFConfiguration)
+/**
+  * AMF client for parsing {@link amf.core.model.document.Document} and {@link amf.core.model.document.Module} created with {@link amf.client.environment.AMFConfiguration.createClient createClient} method
+  * @param configuration {@link amf.client.environment.AMFConfiguration}
+  */
+class AMFClient private[amf] (override protected val configuration: AMFConfiguration)
     extends AMLClient(configuration) {
 
   override implicit val exec: ExecutionContext = configuration.resolvers.executionContext.executionContext
 
   override def getConfiguration: AMFConfiguration = configuration
 
+  /**
+    * parse a {@link amf.core.model.document.Document}
+    * @param url of the resource to parse
+    * @return a Future{@link amf.client.environment.AMFDocumentResult}
+    */
   def parseDocument(url: String): Future[AMFDocumentResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: Document, r) => new AMFDocumentResult(d, r)
     case other =>
       throw InvalidBaseUnitTypeException.forMeta(other.bu.meta, DocumentModel)
   }
 
+  /**
+    * parse a {@link amf.core.model.document.Module}
+    * @param url of the resource to parse
+    * @return a Future {@link amf.client.environment.AMFLibraryResult}
+    */
   def parseLibrary(url: String): Future[AMFLibraryResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(m: Module, r) => new AMFLibraryResult(m, r)
     case other =>

--- a/amf-webapi/shared/src/main/scala/amf/client/environment/AMFClient.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/environment/AMFClient.scala
@@ -7,8 +7,8 @@ import amf.core.model.document.{Document, Module}
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * AMF client for parsing {@link amf.core.model.document.Document} and {@link amf.core.model.document.Module} created with {@link amf.client.environment.AMFConfiguration.createClient createClient} method
-  * @param configuration {@link amf.client.environment.AMFConfiguration}
+  * The AMF Client contains common AMF operations.
+  * For more complex uses see {@link amf.client.remod.AMFParser} or {@link amf.client.remod.AMFRenderer}
   */
 class AMFClient private[amf] (override protected val configuration: AMFConfiguration)
     extends AMLClient(configuration) {

--- a/amf-webapi/shared/src/main/scala/amf/client/environment/AMFConfiguration.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/environment/AMFConfiguration.scala
@@ -33,7 +33,14 @@ sealed trait APIConfigurationBuilder {
   }
 }
 
-/** Common configuration with RAML plugins and transformation pipelines */
+/**
+  * {@link APIConfigurationBuilder.common common()} configuration with all configurations needed for RAML like:
+  * <ul>
+  *   <li>Validation rules</li>
+  *   <li>Parse and emit plugins</li>
+  *   <li>Transformation Pipelines</li>
+  * </ul>
+  */
 object RAMLConfiguration extends APIConfigurationBuilder {
   def RAML10(): AMFConfiguration =
     common()
@@ -62,7 +69,14 @@ object RAMLConfiguration extends APIConfigurationBuilder {
   def RAML(): AMFConfiguration = RAML08().merge(RAML10())
 }
 
-/** Common configuration with OAS plugins and transformation pipelines */
+/**
+  * {@link APIConfigurationBuilder.common common()} configuration with all configurations needed for OAS like:
+  * <ul>
+  *   <li>Validation rules</li>
+  *   <li>Parse and emit plugins</li>
+  *   <li>Transformation Pipelines</li>
+  * </ul>
+  */
 object OASConfiguration extends APIConfigurationBuilder {
   def OAS20(): AMFConfiguration =
     common()
@@ -89,12 +103,19 @@ object OASConfiguration extends APIConfigurationBuilder {
   def OAS(): AMFConfiguration = OAS20().merge(OAS30())
 }
 
-/** Configuration with OAS and RAML plugins and transformation pipelines */
+/** Merged {@link OASConfiguration} and {@link RAMLConfiguration} configurations */
 object WebAPIConfiguration {
   def WebAPI(): AMFConfiguration = OASConfiguration.OAS().merge(RAMLConfiguration.RAML())
 }
 
-/** Common configuration with AsyncAPI plugins and transformation pipelines */
+/**
+  * {@link APIConfigurationBuilder.common common()} configuration with all configurations needed for AsyncApi like:
+  * <ul>
+  *   <li>Validation rules</li>
+  *   <li>Parse and emit plugins</li>
+  *   <li>Transformation Pipelines</li>
+  * </ul>
+  */
 object AsyncAPIConfiguration extends APIConfigurationBuilder {
   def Async20(): AMFGraphConfiguration =
     common()
@@ -109,13 +130,9 @@ object AsyncAPIConfiguration extends APIConfigurationBuilder {
 }
 
 /**
-  * The configuration object required for using AMF
-  * @param resolvers {@link amf.client.remod.amfcore.config.AMFResolvers}
-  * @param errorHandlerProvider {@link amf.client.remod.ErrorHandlerProvider}
-  * @param registry {@link amf.client.remod.amfcore.registry.AMFRegistry}
-  * @param logger {@link amf.client.remod.amfcore.config.AMFLogger}
-  * @param listeners a Set of {@link amf.client.remod.amfcore.config.AMFEventListener}
-  * @param options {@link amf.client.remod.amfcore.config.AMFOptions}
+  * The AMFConfiguration lets you customize all AMF-specific configurations.
+  * Its immutable and created through builders. An instance is needed to use AMF.
+  * @see {@link AMFClient}
   */
 class AMFConfiguration private[amf] (override private[amf] val resolvers: AMFResolvers,
                                      override private[amf] val errorHandlerProvider: ErrorHandlerProvider,
@@ -151,11 +168,7 @@ class AMFConfiguration private[amf] (override private[amf] val resolvers: AMFRes
   override def withTransformationPipeline(pipeline: TransformationPipeline): AMFConfiguration =
     super._withTransformationPipeline(pipeline)
 
-  /**
-    * AMF internal method just to facilitate the construction
-    * @param pipelines
-    * @return
-    */
+  /** AMF internal method just to facilitate the construction */
   override private[amf] def withTransformationPipelines(pipelines: List[TransformationPipeline]): AMFConfiguration =
     super._withTransformationPipelines(pipelines)
 

--- a/amf-webapi/shared/src/main/scala/amf/client/environment/AMFConfiguration.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/environment/AMFConfiguration.scala
@@ -1,6 +1,5 @@
 package amf.client.environment
 
-import amf.ProfileName
 import amf.client.remod.amfcore.config._
 import amf.client.remod.amfcore.plugins.AMFPlugin
 import amf.client.remod.amfcore.registry.AMFRegistry
@@ -17,15 +16,7 @@ import amf.plugins.document.webapi.resolution.pipelines.compatibility.{
   Raml08CompatibilityPipeline,
   Raml10CompatibilityPipeline
 }
-import amf.plugins.document.webapi.validation.ApiValidationProfiles
-import amf.plugins.document.webapi.validation.ApiValidationProfiles.{
-  AmfValidationProfile,
-  Async20ValidationProfile,
-  Oas20ValidationProfile,
-  Oas30ValidationProfile,
-  Raml08ValidationProfile,
-  Raml10ValidationProfile
-}
+import amf.plugins.document.webapi.validation.ApiValidationProfiles._
 
 sealed trait APIConfigurationBuilder {
 
@@ -41,6 +32,8 @@ sealed trait APIConfigurationBuilder {
       .withPlugins(List(ExternalJsonYamlRefsParsePlugin, PayloadParsePlugin, JsonSchemaParsePlugin))
   }
 }
+
+/** Common configuration with RAML plugins and transformation pipelines */
 object RAMLConfiguration extends APIConfigurationBuilder {
   def RAML10(): AMFConfiguration =
     common()
@@ -69,6 +62,7 @@ object RAMLConfiguration extends APIConfigurationBuilder {
   def RAML(): AMFConfiguration = RAML08().merge(RAML10())
 }
 
+/** Common configuration with OAS plugins and transformation pipelines */
 object OASConfiguration extends APIConfigurationBuilder {
   def OAS20(): AMFConfiguration =
     common()
@@ -95,10 +89,12 @@ object OASConfiguration extends APIConfigurationBuilder {
   def OAS(): AMFConfiguration = OAS20().merge(OAS30())
 }
 
+/** Configuration with OAS and RAML plugins and transformation pipelines */
 object WebAPIConfiguration {
   def WebAPI(): AMFConfiguration = OASConfiguration.OAS().merge(RAMLConfiguration.RAML())
 }
 
+/** Common configuration with AsyncAPI plugins and transformation pipelines */
 object AsyncAPIConfiguration extends APIConfigurationBuilder {
   def Async20(): AMFGraphConfiguration =
     common()
@@ -112,6 +108,15 @@ object AsyncAPIConfiguration extends APIConfigurationBuilder {
         ))
 }
 
+/**
+  * The configuration object required for using AMF
+  * @param resolvers {@link amf.client.remod.amfcore.config.AMFResolvers}
+  * @param errorHandlerProvider {@link amf.client.remod.ErrorHandlerProvider}
+  * @param registry {@link amf.client.remod.amfcore.registry.AMFRegistry}
+  * @param logger {@link amf.client.remod.amfcore.config.AMFLogger}
+  * @param listeners a Set of {@link amf.client.remod.amfcore.config.AMFEventListener}
+  * @param options {@link amf.client.remod.amfcore.config.AMFOptions}
+  */
 class AMFConfiguration private[amf] (override private[amf] val resolvers: AMFResolvers,
                                      override private[amf] val errorHandlerProvider: ErrorHandlerProvider,
                                      override private[amf] val registry: AMFRegistry,

--- a/amf-webapi/shared/src/main/scala/amf/client/environment/AMFDocumentResult.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/environment/AMFDocumentResult.scala
@@ -4,6 +4,18 @@ import amf.client.remod.AMFResult
 import amf.core.model.document.{Document, Module}
 import amf.core.validation.AMFValidationReport
 
+/**
+  * An {@link amf.client.remod.AMFResult} where the parsing result is a {@link amf.core.model.document.Document}
+  * @param document the Document parsed
+  * @param report The {@link amf.core.validation.AMFValidationReport} from parsing the Document
+  * @see {@linkplain AMFClient.parseDocument parseDocument}
+  */
 class AMFDocumentResult(document: Document, report: AMFValidationReport) extends AMFResult(document, report)
 
+/**
+  * An {@link amf.client.remod.AMFResult} where the parsing result is a library a.k.a. {@link amf.core.model.document.Module}
+  * @param library The library parsed
+  * @param report The {@link amf.core.validation.AMFValidationReport} from parsing the library
+  * @see {@linkplain AMFClient.parseLibrary parseLibrary}
+  */
 class AMFLibraryResult(library: Module, report: AMFValidationReport) extends AMFResult(library, report)


### PR DESCRIPTION
- Add javadoc to most remodularization classes, methods and objects
- Remove the private[amf] modifier on those classes/methods/objects