### PR TITLE
APIMF-3020: add globalThis to buildjs.sh script

### DIFF
--- a/amf-client/js/build-scripts/buildjs.sh
+++ b/amf-client/js/build-scripts/buildjs.sh
@@ -2,8 +2,8 @@
 
 cd ./amf-client/js
 
-echo 'SHACLValidator = require("amf-shacl-node")' > amf.js
-echo 'Ajv = require("ajv")' >> amf.js
+echo 'globalThis.SHACLValidator = require("amf-shacl-node")' > amf.js
+echo 'globalThis.Ajv = require("ajv")' >> amf.js
 cat ./target/artifact/amf-client-module.js >> amf.js
 chmod a+x amf.js
 


### PR DESCRIPTION
- add `globalThis.` to SHACLValidator and Ajv declarations in the `buildjs.sh` script to make the `amf.js` file ES6-compatible.

Solves the following issue: https://github.com/aml-org/amf/issues/888