### PR TITLE
APIMF-2896: add scaladoc to remod/exported files

### DIFF
--- a/amf-webapi/shared/src/main/scala/amf/client/environment/AMFClient.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/environment/AMFClient.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * The AMF Client contains common AMF operations.
-  * For more complex uses see {@link amf.client.remod.AMFParser} or {@link amf.client.remod.AMFRenderer}
+  * For more complex uses see [[AMFParser]] or [[amf.client.remod.AMFRenderer]]
   */
 class AMFClient private[amf] (override protected val configuration: AMFConfiguration)
     extends AMLClient(configuration) {
@@ -18,9 +18,9 @@ class AMFClient private[amf] (override protected val configuration: AMFConfigura
   override def getConfiguration: AMFConfiguration = configuration
 
   /**
-    * parse a {@link amf.core.model.document.Document}
+    * parse a [[amf.core.model.document.Document]]
     * @param url of the resource to parse
-    * @return a Future{@link amf.client.environment.AMFDocumentResult}
+    * @return a Future [[AMFDocumentResult]]
     */
   def parseDocument(url: String): Future[AMFDocumentResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: Document, r) => new AMFDocumentResult(d, r)
@@ -29,9 +29,9 @@ class AMFClient private[amf] (override protected val configuration: AMFConfigura
   }
 
   /**
-    * parse a {@link amf.core.model.document.Module}
+    * parse a [[amf.core.model.document.Module]]
     * @param url of the resource to parse
-    * @return a Future {@link amf.client.environment.AMFLibraryResult}
+    * @return a Future [[AMFLibraryResult]]
     */
   def parseLibrary(url: String): Future[AMFLibraryResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(m: Module, r) => new AMFLibraryResult(m, r)

--- a/amf-webapi/shared/src/main/scala/amf/client/environment/AMFConfiguration.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/environment/AMFConfiguration.scala
@@ -35,12 +35,10 @@ sealed trait APIConfigurationBuilder {
 }
 
 /**
-  * {@link APIConfigurationBuilder.common common()} configuration with all configurations needed for RAML like:
-  * <ul>
-  *   <li>Validation rules</li>
-  *   <li>Parse and emit plugins</li>
-  *   <li>Transformation Pipelines</li>
-  * </ul>
+  * [[APIConfigurationBuilder.common common()]] configuration with all configurations needed for RAML like:
+  *   - Validation rules
+  *   - Parse and emit plugins
+  *   - Transformation Pipelines
   */
 object RAMLConfiguration extends APIConfigurationBuilder {
   def RAML10(): AMFConfiguration =
@@ -71,12 +69,10 @@ object RAMLConfiguration extends APIConfigurationBuilder {
 }
 
 /**
-  * {@link APIConfigurationBuilder.common common()} configuration with all configurations needed for OAS like:
-  * <ul>
-  *   <li>Validation rules</li>
-  *   <li>Parse and emit plugins</li>
-  *   <li>Transformation Pipelines</li>
-  * </ul>
+  * [[APIConfigurationBuilder.common common()]] configuration with all configurations needed for OAS like:
+  *  - Validation rules
+  *  - Parse and emit plugins
+  *  - Transformation Pipelines
   */
 object OASConfiguration extends APIConfigurationBuilder {
   def OAS20(): AMFConfiguration =
@@ -104,18 +100,16 @@ object OASConfiguration extends APIConfigurationBuilder {
   def OAS(): AMFConfiguration = OAS20().merge(OAS30())
 }
 
-/** Merged {@link OASConfiguration} and {@link RAMLConfiguration} configurations */
+/** Merged [[OASConfiguration]] and [[RAMLConfiguration]] configurations */
 object WebAPIConfiguration {
   def WebAPI(): AMFConfiguration = OASConfiguration.OAS().merge(RAMLConfiguration.RAML())
 }
 
 /**
-  * {@link APIConfigurationBuilder.common common()} configuration with all configurations needed for AsyncApi like:
-  * <ul>
-  *   <li>Validation rules</li>
-  *   <li>Parse and emit plugins</li>
-  *   <li>Transformation Pipelines</li>
-  * </ul>
+  * [[APIConfigurationBuilder.common common()]] configuration with all configurations needed for AsyncApi like:
+  *   - Validation rules
+  *   - Parse and emit plugins
+  *   - Transformation Pipelines
   */
 object AsyncAPIConfiguration extends APIConfigurationBuilder {
   def Async20(): AMFConfiguration =
@@ -133,7 +127,7 @@ object AsyncAPIConfiguration extends APIConfigurationBuilder {
 /**
   * The AMFConfiguration lets you customize all AMF-specific configurations.
   * Its immutable and created through builders. An instance is needed to use AMF.
-  * @see {@link AMFClient}
+  * @see [[AMFClient]]
   */
 class AMFConfiguration private[amf] (override private[amf] val resolvers: AMFResolvers,
                                      override private[amf] val errorHandlerProvider: ErrorHandlerProvider,

--- a/amf-webapi/shared/src/main/scala/amf/client/environment/AMFDocumentResult.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/environment/AMFDocumentResult.scala
@@ -5,17 +5,17 @@ import amf.core.model.document.{Document, Module}
 import amf.core.validation.AMFValidationReport
 
 /**
-  * An {@link amf.client.remod.AMFResult} where the parsing result is a {@link amf.core.model.document.Document}
+  * An [[AMFResult]] where the parsing result is a [[Document]]
   * @param document the Document parsed
-  * @param report The {@link amf.core.validation.AMFValidationReport} from parsing the Document
-  * @see {@linkplain AMFClient.parseDocument parseDocument}
+  * @param report The [[AMFValidationReport]] from parsing the Document
+  * @see [[AMFClient.parseDocument parseDocument]]
   */
 class AMFDocumentResult(val document: Document, report: AMFValidationReport) extends AMFResult(document, report)
 
 /**
-  * An {@link amf.client.remod.AMFResult} where the parsing result is a library a.k.a. {@link amf.core.model.document.Module}
+  * An [[AMFResult]] where the parsing result is a library a.k.a. [[Module]]
   * @param library The library parsed
-  * @param report The {@link amf.core.validation.AMFValidationReport} from parsing the library
-  * @see {@linkplain AMFClient.parseLibrary parseLibrary}
+  * @param report The [[AMFValidationReport]] from parsing the library
+  * @see [[AMFClient.parseLibrary parseLibrary]]
   */
 class AMFLibraryResult(val library: Module, report: AMFValidationReport) extends AMFResult(library, report)

--- a/amf-webapi/shared/src/main/scala/amf/client/exported/AMFClient.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/exported/AMFClient.scala
@@ -6,6 +6,10 @@ import amf.client.convert.WebApiClientConverters._
 
 import scala.concurrent.ExecutionContext
 
+/**
+  * The AMF Client contains common AMF operations.
+  * For more complex uses see [[AMFParser]] or [[amf.client.remod.AMFRenderer]]
+  */
 @JSExportAll
 class AMFClient private (private val _internal: InternalAMFClient) extends AMLClient(_internal) {
 
@@ -19,16 +23,16 @@ class AMFClient private (private val _internal: InternalAMFClient) extends AMLCl
   override def getConfiguration: AMFConfiguration = _internal.getConfiguration
 
   /**
-    * parse a {@link amf.client.model.document.Document}
+    * parse a [[amf.client.model.document.Document]]
     * @param url of the resource to parse
-    * @return a Future{@link amf.client.exported.AMFDocumentResult}
+    * @return a Future [[AMFDocumentResult]]
     */
   def parseDocument(url: String): ClientFuture[AMFDocumentResult] = _internal.parseDocument(url).asClient
 
   /**
-    * parse a {@link amf.client.model.document.Module}
+    * parse a [[amf.client.model.document.Module]]
     * @param url of the resource to parse
-    * @return a Future {@link amf.client.exported.AMFLibraryResult}
+    * @return a Future [[AMFLibraryResult]]
     */
   def parseLibrary(url: String): ClientFuture[AMFLibraryResult] = _internal.parseLibrary(url).asClient
 }

--- a/amf-webapi/shared/src/main/scala/amf/client/exported/AMFConfiguration.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/exported/AMFConfiguration.scala
@@ -54,11 +54,9 @@ class AMFConfiguration private[amf] (private[amf] override val _internal: Intern
 
 /**
   * common configuration with all configurations needed for RAML like:
-  * <ul>
-  *   <li>Validation rules</li>
-  *   <li>Parse and emit plugins</li>
-  *   <li>Transformation Pipelines</li>
-  * </ul>
+  *   - Validation rules
+  *   - Parse and emit plugins
+  *   - Transformation Pipelines
   */
 @JSExportAll
 @JSExportTopLevel("RAMLConfiguration")
@@ -70,11 +68,9 @@ object RAMLConfiguration {
 
 /**
   * common configuration with all configurations needed for OAS like:
-  * <ul>
-  *   <li>Validation rules</li>
-  *   <li>Parse and emit plugins</li>
-  *   <li>Transformation Pipelines</li>
-  * </ul>
+  *   - Validation rules
+  *   - Parse and emit plugins
+  *   - Transformation Pipelines
   */
 @JSExportAll
 @JSExportTopLevel("OASConfiguration")
@@ -84,7 +80,7 @@ object OASConfiguration {
   def OAS(): AMFConfiguration   = InternalOASConfiguration.OAS()
 }
 
-/** Merged {@link OASConfiguration} and {@link RAMLConfiguration} configurations */
+/** Merged [[OASConfiguration]] and [[RAMLConfiguration]] configurations */
 @JSExportAll
 @JSExportTopLevel("WebAPIConfiguration")
 object WebAPIConfiguration {
@@ -93,11 +89,9 @@ object WebAPIConfiguration {
 
 /**
   * common configuration with all configurations needed for AsyncApi like:
-  * <ul>
-  *   <li>Validation rules</li>
-  *   <li>Parse and emit plugins</li>
-  *   <li>Transformation Pipelines</li>
-  * </ul>
+  *   - Validation rules
+  *   - Parse and emit plugins
+  *   - Transformation Pipelines
   */
 @JSExportAll
 @JSExportTopLevel("AsyncAPIConfiguration")


### PR DESCRIPTION
- add missing scaladoc
- remove full path from already-imported classes to simplify scaladoc
- refactor `env` parameter name to `configuration`
- replace HTML lists for scaladoc lists