### PR TITLE
WIP

### DIFF
--- a/amf-client/js/src/test/scala/amf/convert/JsOutputBuilderTest.scala
+++ b/amf-client/js/src/test/scala/amf/convert/JsOutputBuilderTest.scala
@@ -1,7 +1,8 @@
 package amf.convert
 
+import amf.client.environment.{AsyncAPIConfiguration, WebAPIConfiguration}
+import amf.client.remod.amfcore.config.RenderOptions
 import amf.core.AMFSerializer
-import amf.core.emitter.RenderOptions
 import amf.core.model.document.BaseUnit
 import org.yaml.builder.JsOutputBuilder
 import org.yaml.model.YDocument
@@ -15,7 +16,8 @@ class JsOutputBuilderTest extends DocBuilderTest {
 
   override def render(unit: BaseUnit, config: CycleConfig, options: RenderOptions): Future[String] = {
     val builder: JsOutputBuilder = new JsOutputBuilder()
-    val renderer                 = new AMFSerializer(unit, "application/ld+json", "AMF Graph", options)
+    val config                   = WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20()).withRenderOptions(options)
+    val renderer                 = new AMFSerializer(unit, "application/graph+ldjson", config.renderConfiguration)
     renderer
       .renderToBuilder(builder)
       .map(_ => {

--- a/amf-client/jvm/src/main/scala/amf/Main.scala
+++ b/amf-client/jvm/src/main/scala/amf/Main.scala
@@ -1,7 +1,7 @@
 package amf
 
 import amf.client.commands._
-import amf.client.environment.{AMLConfiguration, AsyncAPIConfiguration, WebAPIConfiguration}
+import amf.client.environment.{AMFConfiguration, AMLConfiguration, AsyncAPIConfiguration, WebAPIConfiguration}
 import amf.client.remod.AMFGraphConfiguration
 import amf.core.benchmark.ExecutionLog
 import amf.core.client.{ExitCodes, ParserConfig}
@@ -60,6 +60,6 @@ object Main extends PlatformSecrets {
   def runParse(config: ParserConfig): Future[Any]     = amfConfig.map(ParseCommand(platform).run(config, _))
   def runPatch(config: ParserConfig): Future[Any]     = amfConfig.map(PatchCommand(platform).run(config, _))
 
-  private val amfConfig: Future[AMLConfiguration] =
+  private val amfConfig: Future[AMFConfiguration] =
     WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20()).withCustomValidationsEnabled
 }

--- a/amf-client/shared/src/main/scala/amf/client/commands/ParseCommand.scala
+++ b/amf-client/shared/src/main/scala/amf/client/commands/ParseCommand.scala
@@ -1,6 +1,6 @@
 package amf.client.commands
 
-import amf.client.environment.AMLConfiguration
+import amf.client.environment.{AMFConfiguration, AMLConfiguration}
 import amf.core.client.{ExitCodes, ParserConfig}
 import amf.core.remote.Platform
 
@@ -9,11 +9,10 @@ import scala.util.{Failure, Success}
 
 class ParseCommand(override val platform: Platform) extends TranslateCommand(platform) {
 
-  override def run(origConfig: ParserConfig, configuration: AMLConfiguration): Future[Any] = {
+  override def run(origConfig: ParserConfig, configuration: AMFConfiguration): Future[Any] = {
     implicit val ec: ExecutionContext = configuration.getExecutionContext
     val parserConfig                  = origConfig.copy(outputFormat = Some("AMF Graph"), outputMediaType = Some("application/ld+json"))
     val res = for {
-      _         <- AMFInit(configuration)
       newConf   <- processDialects(parserConfig, configuration)
       model     <- parseInput(parserConfig, newConf)
       _         <- checkValidation(parserConfig, model, configuration)

--- a/amf-client/shared/src/main/scala/amf/client/commands/PatchCommand.scala
+++ b/amf-client/shared/src/main/scala/amf/client/commands/PatchCommand.scala
@@ -1,5 +1,5 @@
 package amf.client.commands
-import amf.client.environment.AMLConfiguration
+import amf.client.environment.{AMFConfiguration, AMLConfiguration}
 import amf.client.remod.AMFGraphConfiguration
 import amf.core.client.{ExitCodes, ParserConfig}
 import amf.core.model.document.BaseUnit
@@ -11,12 +11,11 @@ import scala.util.{Failure, Success}
 
 class PatchCommand(override val platform: Platform) extends TranslateCommand(platform) {
 
-  override def run(parserConfig: ParserConfig, configuration: AMLConfiguration): Future[Any] = {
+  override def run(parserConfig: ParserConfig, configuration: AMFConfiguration): Future[Any] = {
     implicit val context: ExecutionContext = configuration.getExecutionContext
     val parsingConfig =
       parserConfig.copy(outputFormat = Some("AML 1.0"), outputMediaType = Some("application/yaml"), resolve = true)
     val res = for {
-      _         <- AMFInit(configuration)
       newConfig <- processDialects(parsingConfig, configuration)
       model     <- parseInput(parsingConfig, newConfig)
       _         <- checkValidation(parsingConfig, model, configuration)

--- a/amf-client/shared/src/main/scala/amf/client/commands/ValidateCommand.scala
+++ b/amf-client/shared/src/main/scala/amf/client/commands/ValidateCommand.scala
@@ -1,17 +1,15 @@
 package amf.client.commands
 
 import amf.ProfileName
-import amf.client.environment.AMLConfiguration
-import amf.client.remod.AMFGraphConfiguration
-import amf.client.remod.amfcore.plugins.validate.ValidationConfiguration
+import amf.client.environment.AMFConfiguration
+import amf.client.remod.parsing.AMLDialectInstanceParsingPlugin
 import amf.core.client.{ExitCodes, ParserConfig}
-import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.remote.Platform
-import amf.core.services.RuntimeValidator
 import amf.core.validation.AMFValidationReport
-import amf.plugins.document.vocabularies.AMLPlugin
-import amf.plugins.document.vocabularies.model.document.DialectInstance
+import amf.plugins.document.vocabularies.custom.ParsedValidationProfile
+import amf.plugins.document.vocabularies.model.document.{Dialect, DialectInstance}
+import amf.plugins.document.vocabularies.model.domain.DialectDomainElement
 import amf.plugins.features.validation.emitters.ValidationReportJSONLDEmitter
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -19,10 +17,9 @@ import scala.util.{Failure, Success}
 
 class ValidateCommand(override val platform: Platform) extends CommandHelper {
 
-  def run(config: ParserConfig, configuration: AMLConfiguration): Future[Any] = {
+  def run(config: ParserConfig, configuration: AMFConfiguration): Future[Any] = {
     implicit val context: ExecutionContext = configuration.getExecutionContext
     val res = for {
-      _        <- AMFInit(configuration)
       newCofig <- processDialects(config, configuration)
       model    <- parseInput(config, newCofig)
       report   <- report(model, config, newCofig)
@@ -41,32 +38,41 @@ class ValidateCommand(override val platform: Platform) extends CommandHelper {
     res
   }
 
-  def report(model: BaseUnit, config: ParserConfig, configuration: AMLConfiguration): Future[AMFValidationReport] = {
+  // TODO ARM: move to registry? or to contxt parsng? discuss with tomi
+  def findDialect(configuration: AMFConfiguration, id: String): Option[Dialect] = {
+    configuration.registry.plugins.parsePlugins.collectFirst({
+      case aml: AMLDialectInstanceParsingPlugin if aml.dialect.id == id => aml.dialect
+    })
+  }
+
+  def report(model: BaseUnit, config: ParserConfig, configuration: AMFConfiguration): Future[AMFValidationReport] = {
     implicit val executionContext: ExecutionContext = configuration.getExecutionContext
-    val customProfileLoaded: Future[ProfileName] = if (config.customProfile.isDefined) {
-      val withProfile: Future[AMLConfiguration] =
-        configuration.withCustomValidationsEnabled.flatMap(_.withCustomProfile(config.customProfile.get))
-      withProfile.map { conf =>
-        // TODO: validation profile is present in config, no clear way to obtain the profile name.
-        ProfileName(config.customProfile.get)
+    val customProfileLoaded: Future[(ProfileName, AMFConfiguration)] = if (config.customProfile.isDefined) {
+      for {
+        confCustom    <- configuration.withCustomValidationsEnabled
+        customProfile <- confCustom.createClient().parseDialectInstance(config.customProfile.get)
+      } yield {
+        val profile = ParsedValidationProfile(customProfile.dialectInstance.encodes.asInstanceOf[DialectDomainElement])
+        (profile.name, confCustom.withValidationProfile(profile))
       }
     } else {
       Future {
         model match {
           case dialectInstance: DialectInstance =>
-            AMLPlugin().registry.dialectFor(dialectInstance) match {
+            findDialect(configuration, dialectInstance.definedBy().value()) match {
               case Some(dialect) =>
-                ProfileName(dialect.nameAndVersion())
+                (ProfileName(dialect.nameAndVersion()), configuration)
               case _ =>
-                config.profile
+                (config.profile, configuration)
             }
           case _ =>
-            config.profile
+            (config.profile, configuration)
         }
       }
     }
-    customProfileLoaded flatMap { profileName =>
-      configuration.createClient().validate(model, profileName)
+    customProfileLoaded flatMap {
+      case (profileName, conf) =>
+        conf.createClient().validate(model, profileName)
     }
   }
 

--- a/amf-client/shared/src/main/scala/amf/facades/AMFCompiler.scala
+++ b/amf-client/shared/src/main/scala/amf/facades/AMFCompiler.scala
@@ -63,6 +63,7 @@ class AMFCompiler private (val url: String,
 
 object AMFCompiler {
   // interface used by some testing classes, ideally will be removed
+  // TODO ARM NOT use anymore, remove
   def apply(url: String,
             remote: Platform,
             hint: Hint,

--- a/amf-client/shared/src/test/scala/amf/client/commands/CommandLineTests.scala
+++ b/amf-client/shared/src/test/scala/amf/client/commands/CommandLineTests.scala
@@ -203,7 +203,7 @@ class CommandLineTests extends AsyncFunSuite with PlatformSecrets {
         stderr = stderr,
         proc = proc
       ),
-      AMLConfiguration.predefined()
+      WebAPIConfiguration.WebAPI()
     ) map { _ =>
       assert(stderr.acc == "")
       assert(stdout.acc != "")

--- a/amf-client/shared/src/test/scala/amf/compiler/AnnotationInFieldTest.scala
+++ b/amf-client/shared/src/test/scala/amf/compiler/AnnotationInFieldTest.scala
@@ -1,5 +1,7 @@
 package amf.compiler
 
+import amf.client.environment.AMFConfiguration
+import amf.client.parse.IgnoringErrorHandler
 import amf.core.annotations.{LexicalInformation, ReferenceTargets, SourceAST}
 import amf.core.model.document.Document
 import amf.core.model.domain.NamedDomainElement
@@ -18,6 +20,8 @@ import scala.concurrent.ExecutionContext
 class AnnotationInFieldTest extends AsyncFunSuite with CompilerTestBuilder {
   override implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
+  override def defaultConfig: AMFConfiguration =
+    super.defaultConfig.withErrorHandlerProvider(() => IgnoringErrorHandler)
   test("test source and lexical info in response name oas") {
     for {
       unit <- build("file://amf-client/shared/src/test/resources/nodes-annotations-examples/oas-responses.yaml",

--- a/amf-client/shared/src/test/scala/amf/compiler/ApikitApiSyncCasesTest.scala
+++ b/amf-client/shared/src/test/scala/amf/compiler/ApikitApiSyncCasesTest.scala
@@ -4,9 +4,9 @@ import amf.client.environment.WebAPIConfiguration
 import amf.client.parse.DefaultErrorHandler
 import amf.client.remod.{ErrorHandlerProvider, ParseConfiguration}
 import amf.client.remote.Content
+import amf.core.AMFCompiler
 import amf.core.errorhandling.AMFErrorHandler
 import amf.core.remote.{Cache, Context, FileNotFound}
-import amf.core.services.RuntimeCompiler
 import amf.core.unsafe.PlatformSecrets
 import amf.facades.Validation
 import amf.internal.resource.ResourceLoader
@@ -37,8 +37,7 @@ class ApikitApiSyncCasesTest extends AsyncBeforeAndAfterEach with PlatformSecret
     val ehp = new ErrorHandlerProvider {
       override def errorHandler(): AMFErrorHandler = eh
     }
-    RuntimeCompiler
-      .apply(
+    AMFCompiler(
         url,
         None,
         base = Context(platform),
@@ -48,7 +47,7 @@ class ApikitApiSyncCasesTest extends AsyncBeforeAndAfterEach with PlatformSecret
             .WebAPI()
             .withResourceLoaders(List(new URNResourceLoader(mappings)))
             .withErrorHandlerProvider(ehp))
-      )
+      ).build()
       .map { _ =>
         eh.getResults should have size 0
       }

--- a/amf-client/shared/src/test/scala/amf/compiler/CompilerTestBuilder.scala
+++ b/amf-client/shared/src/test/scala/amf/compiler/CompilerTestBuilder.scala
@@ -1,40 +1,42 @@
 package amf.compiler
 
+import amf.client.environment.{AMFConfiguration, AsyncAPIConfiguration, WebAPIConfiguration}
+import amf.core.AMFCompiler
+import amf.core.errorhandling.UnhandledErrorHandler
 import amf.client.environment.WebAPIConfiguration
 import amf.client.parse.DefaultErrorHandler
 import amf.core.errorhandling.AMFErrorHandler
 import amf.core.model.document.BaseUnit
-import amf.core.remote.{Cache, Hint}
+import amf.core.remote.{Cache, Context, Hint}
 import amf.core.unsafe.PlatformSecrets
-import amf.facades.{AMFCompiler, Validation}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 trait CompilerTestBuilder extends PlatformSecrets {
 
-  protected def build(url: String,
-                      hint: Hint,
-                      cache: Option[Cache] = None,
-                      validation: Option[Validation] = None,
-                      eh: Option[AMFErrorHandler] = None): Future[BaseUnit] =
-    compiler(url, hint, cache, resolveValidation(validation), eh).flatMap(_.build())
+  protected def defaultConfig: AMFConfiguration =
+    WebAPIConfiguration
+      .WebAPI()
+      .merge(AsyncAPIConfiguration.Async20())
+      .withErrorHandlerProvider(() => UnhandledErrorHandler)
 
-  private def resolveValidation(validation: Option[Validation]) = validation match {
-    case Some(v) => Future { v }
-    case _       => Validation(platform)
+  protected def build(url: String, hint: Hint, amfConfig: AMFConfiguration, cache: Option[Cache]): Future[BaseUnit] =
+    compiler(url, hint, amfConfig, cache).build()
+
+  protected def build(url: String, hint: Hint, cache: Option[Cache] = None): Future[BaseUnit] =
+    build(url, hint, defaultConfig, cache)
+
+  protected def compiler(url: String, hint: Hint, amfConfig: AMFConfiguration, cache: Option[Cache]): AMFCompiler =
+    AMFCompiler(
+      url,
+      Some(hint.vendor.mediaType + "+" + hint.syntax.extension),
+      cache = cache.getOrElse(Cache()),
+      parserConfig = amfConfig.parseConfiguration,
+      base = Context(platform)
+    )
+
+  protected def compiler(url: String, hint: Hint): AMFCompiler = {
+    compiler(url, hint, defaultConfig, None)
   }
-
-  protected def compiler(url: String, hint: Hint): Future[AMFCompiler] =
-    compiler(url, hint, validation = Validation(platform))
-
-  protected def compiler(url: String,
-                         hint: Hint,
-                         cache: Option[Cache] = None,
-                         validation: Future[Validation],
-                         eh: Option[AMFErrorHandler] = None): Future[AMFCompiler] =
-    validation.map(v => {
-      val config = WebAPIConfiguration.WebAPI().withErrorHandlerProvider(() => eh.getOrElse(DefaultErrorHandler()))
-      AMFCompiler(url, platform, hint, cache = cache, config = config)
-    })
 }

--- a/amf-client/shared/src/test/scala/amf/compiler/SourceNodeAnnotationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/compiler/SourceNodeAnnotationTest.scala
@@ -1,5 +1,7 @@
 package amf.compiler
 
+import amf.client.environment.AMFConfiguration
+import amf.client.parse.IgnoringErrorHandler
 import amf.core.annotations.{LexicalInformation, SourceAST, SourceNode}
 import amf.core.model.document.Document
 import amf.core.model.domain.{AmfArray, AmfObject, Shape}
@@ -16,6 +18,8 @@ import scala.concurrent.ExecutionContext
 class SourceNodeAnnotationTest extends AsyncFunSuite with CompilerTestBuilder with Matchers {
   override implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
+  override def defaultConfig: AMFConfiguration =
+    super.defaultConfig.withErrorHandlerProvider(() => IgnoringErrorHandler)
   test("test full raml") {
     build("file://amf-client/shared/src/test/resources/upanddown/cycle/raml10/full-example/api.raml", Raml10YamlHint) map {
       checkAnnotation

--- a/amf-client/shared/src/test/scala/amf/convert/YDocumentBuilderTest.scala
+++ b/amf-client/shared/src/test/scala/amf/convert/YDocumentBuilderTest.scala
@@ -1,7 +1,9 @@
 package amf.convert
 
-import amf.client.environment.{AsyncAPIConfiguration, WebAPIConfiguration}
+import amf.client.environment.{AMFConfiguration, AsyncAPIConfiguration, WebAPIConfiguration}
+import amf.client.remod.AMFRenderer
 import amf.client.remod.amfcore.config.RenderOptions
+import amf.client.remod.amfcore.resolution.PipelineName
 import amf.core.AMFSerializer
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit
@@ -9,6 +11,7 @@ import amf.core.remote._
 import amf.core.resolution.pipelines.TransformationPipeline
 import amf.core.services.RuntimeResolver
 import amf.io.FunSuiteCycleTests
+import amf.plugins.document.webapi.resolution.pipelines.{Raml10EditingPipeline, Raml10TransformationPipeline}
 import org.scalatest.Assertion
 import org.yaml.builder.YDocumentBuilder
 import org.yaml.model.YDocument
@@ -24,8 +27,13 @@ abstract class DocBuilderTest extends FunSuiteCycleTests {
   override def defaultRenderOptions: RenderOptions =
     RenderOptions().withSourceMaps.withPrettyPrint.withAmfJsonLdSerialization
 
-  override def transform(unit: BaseUnit, config: CycleConfig): BaseUnit =
-    RuntimeResolver.resolve(Vendor.RAML10.name, unit, TransformationPipeline.EDITING_PIPELINE, UnhandledErrorHandler)
+  override def transform(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): BaseUnit = {
+    amfConfig
+      .withErrorHandlerProvider(() => UnhandledErrorHandler)
+      .createClient()
+      .transform(unit, Raml10EditingPipeline.name)
+      .bu
+  }
 
   private def run(source: String, golden: String, renderOptions: RenderOptions): Future[Assertion] =
     cycle(source, golden, Raml10YamlHint, target = Amf, eh = None, renderOptions = Some(renderOptions))
@@ -45,10 +53,9 @@ abstract class DocBuilderTest extends FunSuiteCycleTests {
 
 class YDocumentBuilderTest extends DocBuilderTest {
 
-  override def render(unit: BaseUnit, config: CycleConfig, options: RenderOptions): Future[String] = {
+  override def render(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): Future[String] = {
     val builder: YDocumentBuilder = new YDocumentBuilder()
-    val config                    = WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20()).withRenderOptions(options)
-    val renderer                  = new AMFSerializer(unit, "application/graph+ldjson", config.renderConfiguration)
+    val renderer                  = new AMFSerializer(unit, "application/graph+ldjson", amfConfig.renderConfiguration)
     renderer
       .renderToBuilder(builder)
       .map(_ => {

--- a/amf-client/shared/src/test/scala/amf/cycle/Async20ElementCycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/cycle/Async20ElementCycleTest.scala
@@ -1,6 +1,6 @@
 package amf.cycle
 
-import amf.core.remote.{AsyncYamlHint, Vendor}
+import amf.core.remote.{Async20YamlHint, Vendor}
 import amf.plugins.domain.shapes.models.AnyShape
 
 class Async20ElementCycleTest extends DomainElementCycleTest {
@@ -15,7 +15,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "type/draft-7-schemas.yaml",
       CommonExtractors.declaresIndex(0),
       "type/schema-emission.yaml",
-      AsyncYamlHint
+      Async20YamlHint
     )
   }
 
@@ -24,7 +24,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "parameter/parameter-definition.yaml",
       CommonExtractors.declaresIndex(1),
       "parameter/param.yaml",
-      AsyncYamlHint
+      Async20YamlHint
     )
   }
 
@@ -33,7 +33,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "components/async-components.yaml",
       CommonExtractors.declaresIndex(16),
       "components/async-components-message-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = validationsPath
     )
   }
@@ -43,7 +43,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "message-obj.yaml",
       CommonExtractors.firstRequest,
       "message-obj-single-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = validationsPath
     )
   }
@@ -53,7 +53,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "api.yaml",
       CommonExtractors.firstRequest.andThen(_.map(_.correlationId)),
       "correlation-id-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = validationsPath + "validations/nested-libraries/nested-correlationIds/"
     )
   }
@@ -63,7 +63,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "/correlation-id/api.yaml",
       CommonExtractors.firstRequest.andThen(_.map(_.correlationId)),
       "correlation-id/correlation-id-emission.yaml",
-      AsyncYamlHint
+      Async20YamlHint
     )
   }
 
@@ -72,7 +72,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "ws-channel-binding.yaml",
       CommonExtractors.firstEndpoint.andThen(_.map(_.bindings)),
       "ws-channel-binding-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = validationsPath
     )
   }
@@ -82,7 +82,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "mqtt-server-binding.yaml",
       CommonExtractors.firstServer.andThen(_.map(_.bindings)),
       "mqtt-server-binding-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = validationsPath
     )
   }
@@ -92,7 +92,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "kafka-operation-binding.yaml",
       CommonExtractors.firstOperation.andThen(_.map(_.bindings)),
       "kafka-operation-binding-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = validationsPath
     )
   }
@@ -102,7 +102,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "http-message-binding.yaml",
       CommonExtractors.firstRequest.andThen(_.map(_.bindings)),
       "http-message-binding-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = validationsPath
     )
   }
@@ -112,7 +112,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "operation-traits.yaml",
       CommonExtractors.declaresIndex(0),
       "operation-traits-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = validationsPath + "components/"
     )
   }
@@ -122,7 +122,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "message-traits.yaml",
       CommonExtractors.declaresIndex(0),
       "message-traits-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = validationsPath + "components/"
     )
   }
@@ -132,7 +132,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "server.yaml",
       CommonExtractors.webapi.andThen(_.map(_.servers.head)),
       "server-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = upanddownPath
     )
   }
@@ -142,7 +142,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "security-schemes.yaml",
       CommonExtractors.declaresIndex(8),
       "scheme-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = upanddownPath
     )
   }
@@ -152,7 +152,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "type/draft-7-schemas.yaml",
       CommonExtractors.declaresIndex(0)(_).map(_.asInstanceOf[AnyShape].examples.head),
       "type/example-emission.yaml",
-      AsyncYamlHint
+      Async20YamlHint
     )
   }
 
@@ -161,7 +161,7 @@ class Async20ElementCycleTest extends DomainElementCycleTest {
       "publish-subscribe.yaml",
       CommonExtractors.firstEndpoint,
       "publish-subscribe-emission.yaml",
-      AsyncYamlHint,
+      Async20YamlHint,
       directory = upanddownPath
     )
   }

--- a/amf-client/shared/src/test/scala/amf/cycle/DomainElementCycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/cycle/DomainElementCycleTest.scala
@@ -48,13 +48,11 @@ trait DomainElementCycleTest extends AsyncFunSuite with FileAssertionTest with B
   override protected def beforeAll(): Unit = WebApiRegister.register(platform)
 
   private def build(config: EmissionConfig, eh: Option[AMFErrorHandler]): Future[BaseUnit] = {
-    Validation(platform).flatMap { _ =>
-      val amfConfig = WebAPIConfiguration
-        .WebAPI()
-        .merge(AsyncAPIConfiguration.Async20())
-        .withErrorHandlerProvider(() => eh.getOrElse(UnhandledErrorHandler))
-      amfConfig.createClient().parse(s"file://${config.sourcePath}").map(_.bu)
-    }
+    val amfConfig = WebAPIConfiguration
+      .WebAPI()
+      .merge(AsyncAPIConfiguration.Async20())
+      .withErrorHandlerProvider(() => eh.getOrElse(UnhandledErrorHandler))
+    amfConfig.createClient().parse(s"file://${config.sourcePath}").map(_.bu)
   }
 
   private def render(element: Option[DomainElement]): Future[String] = {

--- a/amf-client/shared/src/test/scala/amf/cycle/FromRdfCycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/cycle/FromRdfCycleTest.scala
@@ -1,6 +1,7 @@
 package amf.cycle
 
 import amf.client.environment.WebAPIConfiguration
+import amf.client.environment.{AsyncAPIConfiguration, WebAPIConfiguration}
 import amf.client.remod.AMFGraphConfiguration
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit

--- a/amf-client/shared/src/test/scala/amf/cycle/JsonSchemaCycle.scala
+++ b/amf-client/shared/src/test/scala/amf/cycle/JsonSchemaCycle.scala
@@ -1,5 +1,6 @@
 package amf.cycle
 
+import amf.client.environment.{AsyncAPIConfiguration, WebAPIConfiguration}
 import amf.core.remote.Vendor
 import amf.core.unsafe.PlatformSecrets
 import amf.cycle.JsonSchemaTestEmitters._
@@ -162,12 +163,10 @@ class JsonSchemaCycle extends AsyncFunSuite with PlatformSecrets with FileAssert
                     mediatype: String = JSON): Future[Assertion] = {
     val finalPath   = basePath + path
     val finalGolden = basePath + golden
-    amf.core.AMF
-      .init()
-      .flatMap { _ =>
-        val fragment = parseSchema(platform, finalPath, mediatype)
-        emitter.emitSchema(fragment.bu.asInstanceOf[DataTypeFragment])
-      }
+    val fragment =
+      parseSchema(platform, finalPath, mediatype, WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20()))
+    emitter
+      .emitSchema(fragment.bu.asInstanceOf[DataTypeFragment])
       .flatMap { expected =>
         writeTemporaryFile(finalGolden)(expected).flatMap(s => assertDifferences(s, finalGolden))
       }

--- a/amf-client/shared/src/test/scala/amf/cycle/JsonSchemaSuite.scala
+++ b/amf-client/shared/src/test/scala/amf/cycle/JsonSchemaSuite.scala
@@ -1,9 +1,10 @@
 package amf.cycle
 
-import amf.client.remod.{AMFResult, ParseConfiguration}
+import amf.client.environment.AMFConfiguration
 import amf.client.remod.amfcore.config.ParsingOptions
+import amf.client.remod.{AMFResult, ParseConfiguration}
 import amf.core.Root
-import amf.core.errorhandling.{AMFErrorHandler, UnhandledErrorHandler}
+import amf.core.errorhandling.AMFErrorHandler
 import amf.core.parser.{ParserContext, SchemaReference, SyamlParsedDocument}
 import amf.core.remote.Platform
 import amf.core.validation.AMFValidationReport
@@ -20,7 +21,7 @@ trait JsonSchemaSuite {
   protected def parseSchema(platform: Platform,
                             path: String,
                             mediatype: String,
-                            eh: AMFErrorHandler = UnhandledErrorHandler): AMFResult = {
+                            amfConfig: AMFConfiguration): AMFResult = {
     val content  = platform.fs.syncFile(path).read().toString
     val document = JsonParser.withSource(content, path).document()
     val root = Root(
@@ -32,6 +33,7 @@ trait JsonSchemaSuite {
       content
     )
     val options = ParsingOptions()
+    val eh      = amfConfig.errorHandlerProvider.errorHandler()
     val parsed  = new JsonSchemaParser().parse(root, getBogusParserCtx(path, options, eh), options, None)
     val unit    = wrapInDataTypeFragment(root, parsed)
     AMFResult(unit, AMFValidationReport.forModel(unit, eh.getResults))

--- a/amf-client/shared/src/test/scala/amf/cycle/OasRecursiveFilesCycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/cycle/OasRecursiveFilesCycleTest.scala
@@ -1,26 +1,19 @@
 package amf.cycle
 
-import amf.client.remod.{AMFGraphConfiguration, ParseConfiguration}
-import amf.core.CompilerContextBuilder
-import amf.core.errorhandling.{AMFErrorHandler, UnhandledErrorHandler}
-import amf.core.model.document.BaseUnit
-import amf.core.parser.UnspecifiedReference
-import amf.core.remote.{Amf, Oas30YamlHint}
-import amf.core.services.RuntimeCompiler
-import amf.facades.Validation
+import amf.client.remod.amfcore.config.RenderOptions
+import amf.core.remote.{Amf, Oas20YamlHint, Oas30YamlHint, PayloadYamlHint}
 import amf.io.FunSuiteCycleTests
-
-import scala.concurrent.{ExecutionContext, Future}
 
 class OasRecursiveFilesCycleTest extends FunSuiteCycleTests {
   override def basePath: String = "amf-client/shared/src/test/resources/references/oas/oas-references/"
 
+  override def renderOptions() = RenderOptions().withSourceMaps.withPrettyPrint
   test("YAML OAS 2.0 with recursive file dependency doesn't output unresolved shape") {
-    cycle("oas-2-root.yaml", "oas-2-root.jsonld", Oas30YamlHint, Amf)
+    cycle("oas-2-root.yaml", "oas-2-root.jsonld", Oas20YamlHint, Amf)
   }
 
   test("YAML OAS 2.0 with recursive file dependency doesn't output unresolved shape starting from ref") {
-    cycle("oas-2-ref.yaml", "oas-2-ref.jsonld", Oas30YamlHint, Amf)
+    cycle("oas-2-ref.yaml", "oas-2-ref.jsonld", Oas20YamlHint, Amf)
   }
 
   test("YAML OAS 3.0 with recursive file dependency doesn't output unresolved shape") {
@@ -28,29 +21,6 @@ class OasRecursiveFilesCycleTest extends FunSuiteCycleTests {
   }
 
   test("YAML OAS 3.0 with recursive file dependency doesn't output unresolved shape starting from ref") {
-    cycle("oas-3-ref.yaml", "oas-3-ref.jsonld", Oas30YamlHint, Amf)
-  }
-
-  /** Method to parse unit. Override if necessary. */
-  override def build(config: CycleConfig,
-                     eh: Option[AMFErrorHandler],
-                     useAmfJsonldSerialisation: Boolean): Future[BaseUnit] = {
-    Validation(platform).flatMap { _ =>
-      implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
-      val finalPath =
-        if (config.sourcePath.startsWith("file://")) config.sourcePath else s"file://${config.sourcePath}"
-      val compilerContextBuilder =
-        new CompilerContextBuilder(finalPath,
-                                   platform,
-                                   ParseConfiguration(AMFGraphConfiguration.fromEH(UnhandledErrorHandler)))
-
-      RuntimeCompiler
-        .forContext(
-          compilerContextBuilder.build(),
-          None,
-          UnspecifiedReference
-        )
-        .map(m => m)
-    }
+    cycle("oas-3-ref.yaml", "oas-3-ref.jsonld", PayloadYamlHint, Amf)
   }
 }

--- a/amf-client/shared/src/test/scala/amf/cycle/ParsedCloneTest.scala
+++ b/amf-client/shared/src/test/scala/amf/cycle/ParsedCloneTest.scala
@@ -16,7 +16,7 @@ class ParsedCloneTest extends FunSuiteCycleTests {
   test("Test error trait clone") {
     val config = CycleConfig("error-trait.raml", "", Raml10YamlHint, Amf, basePath, None, None)
     for {
-      model <- build(config, Some(IgnoreError), useAmfJsonldSerialisation = true)
+      model <- build(config, buildConfig(None, None))
     } yield {
       val element =
         model.cloneUnit().asInstanceOf[DeclaresModel].declares.head.asInstanceOf[Trait].effectiveLinkTarget()
@@ -25,9 +25,10 @@ class ParsedCloneTest extends FunSuiteCycleTests {
   }
 
   test("Test clone http settings of security scheme") {
-    val config = CycleConfig("api-key-name.json", "", Oas30JsonHint, Amf, basePath, None, None)
+    val config    = CycleConfig("api-key-name.json", "", Oas30JsonHint, Amf, basePath, None, None)
+    val amfConfig = buildConfig(None, Some(IgnoreError))
     for {
-      model <- build(config, Some(IgnoreError), useAmfJsonldSerialisation = true)
+      model <- build(config, amfConfig)
     } yield {
       val settings = model.asInstanceOf[DeclaresModel].declares.head.asInstanceOf[SecurityScheme].settings
       val clonedSettings =

--- a/amf-client/shared/src/test/scala/amf/cycle/ToRdfCycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/cycle/ToRdfCycleTest.scala
@@ -1,13 +1,15 @@
 package amf.cycle
 
 import amf.client.environment.WebAPIConfiguration
+import amf.client.remod.AMFGraphConfiguration
+import amf.client.environment.{AsyncAPIConfiguration, WebAPIConfiguration}
 import amf.client.remod.amfcore.config.RenderOptions
 import amf.client.remod.{AMFGraphConfiguration, ParseConfiguration}
+import amf.core.AMFCompiler
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit
-import amf.core.remote.{Cache, Context, Vendor}
+import amf.core.remote.Vendor
 import amf.core.resolution.pipelines.TransformationPipeline
-import amf.core.services.RuntimeCompiler
 import amf.facades.Validation
 import amf.io.FileAssertionTest
 import amf.resolution.ResolutionCapabilities
@@ -43,7 +45,7 @@ class ToRdfCycleTest
   private def rdfFromApi(path: String, vendor: Vendor): Future[String] = {
     val config = WebAPIConfiguration.WebAPI().withErrorHandlerProvider(() => UnhandledErrorHandler)
     build(path, config)
-      .map(transform(_, TransformationPipeline.EDITING_PIPELINE, vendor))
+      .map(transform(_, TransformationPipeline.EDITING_PIPELINE, vendor, config))
       .map(_.toNativeRdfModel(RenderOptions().withSourceMaps))
       .map(_.toN3())
   }

--- a/amf-client/shared/src/test/scala/amf/emit/Async20CycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/emit/Async20CycleTest.scala
@@ -2,7 +2,7 @@ package amf.emit
 
 import amf.client.remod.amfcore.config.RenderOptions
 import amf.core.remote.Syntax.Yaml
-import amf.core.remote.{Amf, AsyncApi20, AsyncYamlHint}
+import amf.core.remote.{Amf, AsyncApi20, Async20YamlHint}
 import amf.io.FunSuiteCycleTests
 
 class Async20CycleTest extends FunSuiteCycleTests {
@@ -13,13 +13,13 @@ class Async20CycleTest extends FunSuiteCycleTests {
 
   cyclesAsyncAmf.foreach { f =>
     multiGoldenTest(s"${f.name} - async to amf", f.apiTo) { config =>
-      cycle(f.apiFrom, config.golden, AsyncYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+      cycle(f.apiFrom, config.golden, Async20YamlHint, target = Amf, renderOptions = Some(config.renderOptions))
     }
   }
 
   cyclesAsyncAsync.foreach { f =>
     test(s"${f.name} - async to async") {
-      cycle(f.apiFrom, f.apiTo, AsyncYamlHint, target = AsyncApi20, directory = upanddown, syntax = Some(Yaml))
+      cycle(f.apiFrom, f.apiTo, Async20YamlHint, target = AsyncApi20, directory = upanddown, syntax = Some(Yaml))
     }
   }
 

--- a/amf-client/shared/src/test/scala/amf/emit/CompleteCycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/emit/CompleteCycleTest.scala
@@ -254,7 +254,11 @@ class CompleteCycleTest extends FunSuiteCycleTests {
 
   // TODO migrate to multiGoldenTest
   test("File type cycle") {
-    cycle("file-type.raml", "file-type.json", Raml10YamlHint, target = Amf)
+    cycle("file-type.raml",
+          "file-type.json",
+          Raml10YamlHint,
+          target = Amf,
+          renderOptions = Some(RenderOptions().withPrettyPrint.withSourceMaps))
   }
 
   multiTest("Types amf(raml) to amf test", "types.raml.%s", "types.raml.%s") { config =>

--- a/amf-client/shared/src/test/scala/amf/emit/ExampleToJsonTest.scala
+++ b/amf-client/shared/src/test/scala/amf/emit/ExampleToJsonTest.scala
@@ -69,7 +69,6 @@ class ExampleToJsonTest extends AsyncFunSuite with FileAssertionTest {
   private def cycle(source: String, golden: String, removeRaw: Boolean = false): Future[Assertion] = {
     val config = WebAPIConfiguration.WebAPI().withErrorHandlerProvider(() => UnhandledErrorHandler)
     for {
-      _       <- Validation(platform)
       unit    <- config.createClient().parse(basePath + source).map(_.bu)
       example <- findExample(unit, removeRaw)
       temp    <- writeTemporaryFile(golden)(example.toJson(config))

--- a/amf-client/shared/src/test/scala/amf/emit/MutateModelCycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/emit/MutateModelCycleTest.scala
@@ -3,7 +3,7 @@ package amf.emit
 import amf.core.model.document.{BaseUnit, Document}
 import amf.core.model.domain.templates.{ParametrizedDeclaration, VariableValue}
 import amf.core.remote._
-import amf.io.{BuildCycleTests, FunSuiteCycleTests}
+import amf.io.FunSuiteCycleTests
 import amf.plugins.domain.webapi.models.api.WebApi
 import org.scalatest.Assertion
 
@@ -28,11 +28,11 @@ class MutateModelCycleTest extends FunSuiteCycleTests {
                            target: Vendor,
                            transform: BaseUnit => BaseUnit,
                            directory: String = basePath): Future[Assertion] = {
-    val config = CycleConfig(source, golden, hint, target, directory, None, None)
-
-    build(config, None, useAmfJsonldSerialisation = true)
+    val config    = CycleConfig(source, golden, hint, target, directory, None, None)
+    val amfConfig = buildConfig(None, None)
+    build(config, amfConfig)
       .map(transform(_))
-      .flatMap(render(_, config, useAmfJsonldSerialization = true))
+      .flatMap(render(_, config, amfConfig))
       .flatMap(writeTemporaryFile(golden))
       .flatMap(assertDifferences(_, config.goldenPath))
   }

--- a/amf-client/shared/src/test/scala/amf/emit/Oas30CycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/emit/Oas30CycleTest.scala
@@ -1,5 +1,6 @@
 package amf.emit
 
+import amf.core.remote.Syntax.{Json, Yaml}
 import amf.core.remote._
 import amf.io.FunSuiteCycleTests
 
@@ -22,7 +23,7 @@ class Oas30CycleTest extends FunSuiteCycleTests {
 
   cycleOas2ToOas3.foreach { f =>
     test(s"${f.name} - oas2 to oas3") {
-      cycle(f.apiFrom, f.apiTo, Oas20JsonHint, Oas30)
+      cycle(f.apiFrom, f.apiTo, Oas20JsonHint, Oas30, syntax = Some(Json))
     }
   }
 
@@ -63,7 +64,7 @@ class Oas30CycleTest extends FunSuiteCycleTests {
 
   cyclesOas3.foreach { f =>
     test(s"${f.name} - oas3 to oas3") {
-      cycle(f.apiFrom, f.apiTo, Oas30JsonHint, Oas30)
+      cycle(f.apiFrom, f.apiTo, Oas30JsonHint, Oas30, syntax = Some(Json))
     }
   }
 
@@ -71,10 +72,11 @@ class Oas30CycleTest extends FunSuiteCycleTests {
 
   cyclesRamlOas3.foreach { f =>
     test(s"${f.name} - raml to oas3") {
-      cycle(f.apiFrom, f.apiTo, Raml10YamlHint, Oas30)
+      cycle(f.apiFrom, f.apiTo, Raml10YamlHint, Oas30, syntax = Some(Json))
     }
   }
 
+  // TODO: jajaja
   val cyclesOas3Amf: Seq[FixtureData] = Nil
 
   cyclesOas3Amf.foreach { f =>

--- a/amf-client/shared/src/test/scala/amf/emit/UnionRamlEmissionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/emit/UnionRamlEmissionTest.scala
@@ -1,5 +1,7 @@
 package amf.emit
 
+import amf.client.environment.AMFConfiguration
+import amf.client.remod.amfcore.resolution.PipelineName
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.remote._
@@ -14,10 +16,15 @@ class UnionRamlEmissionTest extends FunSuiteCycleTests {
 
   override val basePath = "amf-client/shared/src/test/resources/union/"
 
-  override def transform(unit: BaseUnit, config: CycleConfig): BaseUnit = {
-    val res = config.pipeline match {
-      case Some(pipeline) => RuntimeResolver.resolve(Vendor.RAML10.name, unit, pipeline, UnhandledErrorHandler)
-      case None           => unit
+  override def transform(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): BaseUnit = {
+    val res: BaseUnit = config.pipeline match {
+      case Some(pipeline) =>
+        amfConfig
+          .withErrorHandlerProvider(() => UnhandledErrorHandler)
+          .createClient()
+          .transform(unit, PipelineName.from(Raml10.name, pipeline))
+          .bu
+      case None => unit
     }
     res
   }

--- a/amf-client/shared/src/test/scala/amf/error/AsyncParserErrorTest.scala
+++ b/amf-client/shared/src/test/scala/amf/error/AsyncParserErrorTest.scala
@@ -3,7 +3,7 @@ package amf.error
 import amf.core.errorhandling.AMFErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.parser.Range
-import amf.core.remote.AsyncYamlHint
+import amf.core.remote.Async20YamlHint
 import amf.facades.AMFCompiler
 
 import scala.concurrent.Future

--- a/amf-client/shared/src/test/scala/amf/error/ParserErrorTest.scala
+++ b/amf-client/shared/src/test/scala/amf/error/ParserErrorTest.scala
@@ -1,8 +1,6 @@
 package amf.error
 
 import amf.client.environment.{AsyncAPIConfiguration, WebAPIConfiguration}
-import amf.client.parse.DefaultErrorHandler
-import amf.core.errorhandling.AMFErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.unsafe.PlatformSecrets
 import amf.core.validation.AMFValidationResult
@@ -25,21 +23,19 @@ trait ParserErrorTest extends AsyncFunSuite with PlatformSecrets with Matchers {
                                  unitAssertion: BaseUnit => Unit,
                                  fixture: Seq[AMFValidationResult => Unit]): Future[Assertion] = {
     val client = WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20()).createClient()
-    Validation(platform).flatMap { _ =>
-      client
-        .parse(basePath + file)
-        .map { amfResult =>
-          unitAssertion(amfResult.bu)
-          val report = amfResult.report.results
-          if (report.size != fixture.size) {
-            report.foreach(println)
-            fail(s"Expected results has length of ${fixture.size} while actual results are ${report.size}")
-          }
-          fixture.zip(report).foreach {
-            case (fn, result) => fn(result)
-          }
-          Succeeded
+    client
+      .parse(basePath + file)
+      .map { amfResult =>
+        unitAssertion(amfResult.bu)
+        val report = amfResult.report.results
+        if (report.size != fixture.size) {
+          report.foreach(println)
+          fail(s"Expected results has length of ${fixture.size} while actual results are ${report.size}")
         }
-    }
+        fixture.zip(report).foreach {
+          case (fn, result) => fn(result)
+        }
+        Succeeded
+      }
   }
 }

--- a/amf-client/shared/src/test/scala/amf/event/AMFEventListenerTest.scala
+++ b/amf-client/shared/src/test/scala/amf/event/AMFEventListenerTest.scala
@@ -1,11 +1,11 @@
 package amf.event
 
 import amf.client.environment.RAMLConfiguration
-import amf.client.remod.ParseConfiguration
 import amf.client.exported.config.AMFEventNames
+import amf.client.remod.ParseConfiguration
 import amf.client.remod.amfcore.config.{AMFEvent, AMFEventListener}
-import amf.core.remote.{Cache, Context, Raml10}
-import amf.core.services.RuntimeCompiler
+import amf.core.AMFCompiler
+import amf.core.remote.{Cache, Context}
 import amf.core.unsafe.PlatformSecrets
 import amf.facades.Validation
 import org.mulesoft.common.test.AsyncBeforeAndAfterEach
@@ -33,11 +33,11 @@ class AMFEventListenerTest extends AsyncBeforeAndAfterEach with PlatformSecrets 
     )
     val listener = EventAccumulator()
     // TODO set listener in config.
-    RuntimeCompiler(url,
-                    Some("application/yaml"),
-                    Context(platform),
-                    cache = Cache(),
-                    ParseConfiguration(RAMLConfiguration.RAML10())) map { _ =>
+    AMFCompiler(url,
+                Some("application/yaml"),
+                Context(platform),
+                cache = Cache(),
+                ParseConfiguration(RAMLConfiguration.RAML10())).build() map { _ =>
       assertEventFrequencies(expectedFrequency, listener)
     }
   }

--- a/amf-client/shared/src/test/scala/amf/io/BuildCycleTests.scala
+++ b/amf-client/shared/src/test/scala/amf/io/BuildCycleTests.scala
@@ -1,8 +1,12 @@
 package amf.io
 
+import amf.client.environment.{AMFConfiguration, AsyncAPIConfiguration, WebAPIConfiguration}
+import amf.client.parse.IgnoringErrorHandler
 import amf.client.environment.{AsyncAPIConfiguration, WebAPIConfiguration}
 import amf.client.parse.DefaultErrorHandler
 import amf.client.remod.AMFGraphConfiguration
+import amf.client.remod.amfcore.config.RenderOptions
+import amf.core.errorhandling.AMFErrorHandler
 import amf.client.remod.amfcore.config.{ParsingOptionsConverter, RenderOptions}
 import amf.core.client.ParsingOptions
 import amf.core.errorhandling.{AMFErrorHandler, UnhandledErrorHandler}
@@ -10,8 +14,6 @@ import amf.core.model.document.BaseUnit
 import amf.core.rdf.RdfModel
 import amf.core.remote.Syntax.Syntax
 import amf.core.remote.{Amf, Hint, Vendor}
-import amf.emit.AMFRenderer
-import amf.facades.{AMFCompiler, Validation}
 import amf.plugins.document.graph.{EmbeddedForm, FlattenedForm, JsonLdDocumentForm}
 import org.scalactic.Fail
 import org.scalatest.{Assertion, AsyncFunSuite}
@@ -123,39 +125,35 @@ trait BuildCycleTestCommon extends FileAssertionTest {
                          transformWith: Option[Vendor] = None) {
     val sourcePath: String = directory + source
     val goldenPath: String = directory + golden
+
+    val sourceMediaType: String = hint.vendor.mediaType + "+" + hint.syntax.extension
+    val targetMediaType: String = target.mediaType + syntax.map(s => s"+${s.extension}").getOrElse("")
   }
 
   /** Method to parse unit. Override if necessary. */
-  def build(config: CycleConfig, eh: Option[AMFErrorHandler], useAmfJsonldSerialisation: Boolean): Future[BaseUnit] = {
-    Validation(platform).flatMap { _ =>
-      var options =
-        if (!useAmfJsonldSerialisation) ParsingOptions().withoutAmfJsonLdSerialization
-        else ParsingOptions().withAmfJsonLdSerialization
-
-      options = options.withBaseUnitUrl("file://" + config.goldenPath)
-      val amfConfig = WebAPIConfiguration
-        .WebAPI()
-        .merge(AsyncAPIConfiguration.Async20())
-        .withErrorHandlerProvider(() => eh.getOrElse(UnhandledErrorHandler))
-        .withParsingOptions(ParsingOptionsConverter.fromLegacy(options))
-      AMFCompiler(s"file://${config.sourcePath}", platform, config.hint, config = amfConfig).build()
-    }
+  def build(config: CycleConfig, amfConfig: AMFGraphConfiguration): Future[BaseUnit] = {
+    amfConfig
+      .withParsingOptions(amfConfig.options.parsingOptions.withBaseUnitUrl("file://" + config.goldenPath))
+      .createClient()
+      .parse(s"file://${config.sourcePath}")
+      .map(_.bu)
   }
 
   /** Method to render parsed unit. Override if necessary. */
-  def render(unit: BaseUnit, config: CycleConfig, useAmfJsonldSerialization: Boolean): Future[String] = {
-    val target  = config.target
-    var options = RenderOptions().withSourceMaps.withPrettyPrint
-    options =
-      if (!useAmfJsonldSerialization) options.withoutAmfJsonLdSerialization else options.withAmfJsonLdSerialization
-    new AMFRenderer(unit, target, options, config.syntax).renderToString
+  def render(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): Future[String] = {
+    amfConfig.createClient().render(unit, config.targetMediaType)
+  }
+  def renderOptions(): RenderOptions = RenderOptions()
+
+  protected def buildConfig(options: Option[RenderOptions], eh: Option[AMFErrorHandler]): AMFConfiguration = {
+    val amfConfig: AMFConfiguration = WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20())
+    val renderedConfig: AMFConfiguration = options.fold(amfConfig.withRenderOptions(renderOptions()))(r => {
+      amfConfig.withRenderOptions(r)
+    })
+    eh.fold(renderedConfig.withErrorHandlerProvider(() => IgnoringErrorHandler))(e =>
+      renderedConfig.withErrorHandlerProvider(() => e))
   }
 
-  /** Method to render parsed unit. Override if necessary. */
-  def render(unit: BaseUnit, config: CycleConfig, options: RenderOptions): Future[String] = {
-    val target = config.target
-    new AMFRenderer(unit, target, options, config.syntax).renderToString
-  }
 }
 
 trait BuildCycleTests extends BuildCycleTestCommon {
@@ -182,31 +180,27 @@ trait BuildCycleTests extends BuildCycleTestCommon {
                   target: Vendor,
                   directory: String = basePath,
                   renderOptions: Option[RenderOptions] = None,
-                  useAmfJsonldSerialization: Boolean = true,
                   syntax: Option[Syntax] = None,
                   pipeline: Option[String] = None,
                   transformWith: Option[Vendor] = None,
                   eh: Option[AMFErrorHandler] = None): Future[Assertion] = {
 
-    val config                 = CycleConfig(source, golden, hint, target, directory, syntax, pipeline, transformWith)
-    val amfJsonLdSerialization = renderOptions.map(_.isAmfJsonLdSerialization).getOrElse(useAmfJsonldSerialization)
+    val config    = CycleConfig(source, golden, hint, target, directory, syntax, pipeline, transformWith)
+    val amfConfig = buildConfig(renderOptions, eh)
 
     for {
-      parsed   <- build(config, eh.orElse(Some(DefaultErrorHandler())), amfJsonLdSerialization)
-      resolved <- Future.successful(transform(parsed, config))
-      actualString <- renderOptions match {
-        case Some(options) => render(resolved, config, options)
-        case None          => render(resolved, config, useAmfJsonldSerialization)
-      }
-      actualFile <- writeTemporaryFile(golden)(actualString)
-      assertion  <- assertDifferences(actualFile, config.goldenPath)
+      parsed       <- build(config, amfConfig)
+      resolved     <- Future.successful(transform(parsed, config, amfConfig))
+      actualString <- render(resolved, config, amfConfig)
+      actualFile   <- writeTemporaryFile(golden)(actualString)
+      assertion    <- assertDifferences(actualFile, config.goldenPath)
     } yield {
       assertion
     }
   }
 
   /** Method for transforming parsed unit. Override if necessary. */
-  def transform(unit: BaseUnit, config: CycleConfig): BaseUnit = unit
+  def transform(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): BaseUnit = unit
 }
 
 trait BuildCycleRdfTests extends BuildCycleTestCommon {
@@ -216,20 +210,14 @@ trait BuildCycleRdfTests extends BuildCycleTestCommon {
                    hint: Hint,
                    target: Vendor = Amf,
                    directory: String = basePath,
-                   renderOptions: Option[RenderOptions] = None,
                    syntax: Option[Syntax] = None,
                    pipeline: Option[String] = None): Future[Assertion] = {
 
-    val config = CycleConfig(source, golden, hint, target, directory, syntax, pipeline, None)
-
-    build(config, None, useAmfJsonldSerialisation = true)
+    val config    = CycleConfig(source, golden, hint, target, directory, syntax, pipeline, None)
+    val amfConfig = buildConfig(None, None)
+    build(config, amfConfig)
       .map(transformThroughRdf(_, config))
-      .flatMap {
-        renderOptions match {
-          case Some(options) => render(_, config, options)
-          case None          => render(_, config, useAmfJsonldSerialization = true)
-        }
-      }
+      .flatMap { render(_, config, amfConfig) }
       .flatMap(writeTemporaryFile(golden))
       .flatMap(assertDifferences(_, config.goldenPath))
   }
@@ -244,9 +232,9 @@ trait BuildCycleRdfTests extends BuildCycleTestCommon {
                pipeline: Option[String] = None,
                transformWith: Option[Vendor] = None): Future[Assertion] = {
 
-    val config = CycleConfig(source, golden, hint, target, directory, syntax, pipeline, transformWith)
-
-    build(config, None, useAmfJsonldSerialisation = true)
+    val config    = CycleConfig(source, golden, hint, target, directory, syntax, pipeline, transformWith)
+    val amfConfig = buildConfig(None, None)
+    build(config, amfConfig)
       .map(transformRdf(_, config))
       .flatMap(renderRdf(_, config))
       .flatMap(writeTemporaryFile(golden))

--- a/amf-client/shared/src/test/scala/amf/iterator/IteratorTest.scala
+++ b/amf-client/shared/src/test/scala/amf/iterator/IteratorTest.scala
@@ -1,5 +1,6 @@
 package amf.iterator
 
+import amf.client.environment.{AsyncAPIConfiguration, WebAPIConfiguration}
 import amf.compiler.CompilerTestBuilder
 import amf.core.annotations.DomainExtensionAnnotation
 import amf.core.metamodel.domain.common.DescriptionField
@@ -58,8 +59,12 @@ class IteratorTest extends AsyncFunSuite with CompilerTestBuilder {
   }
 
   test("Full api with complete iterator") {
-    build("file://amf-client/shared/src/test/resources/validations/annotations/allowed-targets/allowed-targets.raml",
-          Raml10YamlHint) map (
+    build(
+      "file://amf-client/shared/src/test/resources/validations/annotations/allowed-targets/allowed-targets.raml",
+      Raml10YamlHint,
+      WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20()),
+      None
+    ) map (
         baseUnit => {
           val iterator = AmfElementStrategy.iterator(List(baseUnit.asInstanceOf[Document]), IdCollector())
           val elements = iterator.toList
@@ -69,8 +74,12 @@ class IteratorTest extends AsyncFunSuite with CompilerTestBuilder {
   }
 
   test("Full api with complete iterator using instance collector") {
-    build("file://amf-client/shared/src/test/resources/validations/annotations/allowed-targets/allowed-targets.raml",
-          Raml10YamlHint) map (
+    build(
+      "file://amf-client/shared/src/test/resources/validations/annotations/allowed-targets/allowed-targets.raml",
+      Raml10YamlHint,
+      WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20()),
+      None
+    ) map (
         baseUnit => {
           val iterator = AmfElementStrategy.iterator(List(baseUnit.asInstanceOf[Document]), InstanceCollector())
           val elements = iterator.toList
@@ -86,8 +95,12 @@ class IteratorTest extends AsyncFunSuite with CompilerTestBuilder {
   }
 
   test("Full api with domain element iterator") {
-    build("file://amf-client/shared/src/test/resources/validations/annotations/allowed-targets/allowed-targets.raml",
-          Raml10YamlHint) map (
+    build(
+      "file://amf-client/shared/src/test/resources/validations/annotations/allowed-targets/allowed-targets.raml",
+      Raml10YamlHint,
+      WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20()),
+      None
+    ) map (
         baseUnit => {
           val iterator = DomainElementStrategy.iterator(List(baseUnit.asInstanceOf[Document]), IdCollector())
           val elements = iterator.toList
@@ -97,8 +110,12 @@ class IteratorTest extends AsyncFunSuite with CompilerTestBuilder {
   }
 
   test("Full api with domain element iterator using instance collector") {
-    build("file://amf-client/shared/src/test/resources/validations/annotations/allowed-targets/allowed-targets.raml",
-          Raml10YamlHint) map (
+    build(
+      "file://amf-client/shared/src/test/resources/validations/annotations/allowed-targets/allowed-targets.raml",
+      Raml10YamlHint,
+      WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20()),
+      None
+    ) map (
         baseUnit => {
           val iterator = DomainElementStrategy.iterator(List(baseUnit.asInstanceOf[Document]), InstanceCollector())
           val elements = iterator.toList

--- a/amf-client/shared/src/test/scala/amf/javaparser/org/raml/json_schema/TypeToJsonSchemaTest.scala
+++ b/amf-client/shared/src/test/scala/amf/javaparser/org/raml/json_schema/TypeToJsonSchemaTest.scala
@@ -1,5 +1,7 @@
 package amf.javaparser.org.raml.json_schema
 
+import amf.client.environment.{AMFConfiguration, WebAPIConfiguration}
+import amf.client.remod.amfcore.config.RenderOptions
 import amf.client.environment.WebAPIConfiguration
 import amf.client.remod.amfcore.config.{RenderOptions, ShapeRenderOptions}
 import amf.core.model.document.{BaseUnit, DeclaresModel}
@@ -20,7 +22,7 @@ trait TypeToJsonSchemaTest extends ModelValidationTest {
 
   override val basePath: String = path
 
-  override def render(model: BaseUnit, d: String, vendor: Vendor): Future[String] = {
+  override def render(model: BaseUnit, d: String, vendor: Vendor, amfConfig: AMFConfiguration): Future[String] = {
     model match {
       case d: DeclaresModel =>
         d.declares.collectFirst { case s: AnyShape if s.name.is("root") => s } match {

--- a/amf-client/shared/src/test/scala/amf/ls/LanguageServerTest.scala
+++ b/amf-client/shared/src/test/scala/amf/ls/LanguageServerTest.scala
@@ -1,5 +1,7 @@
 package amf.ls
 
+import amf.client.environment.AMFConfiguration
+import amf.client.parse.DefaultErrorHandler
 import amf.compiler.CompilerTestBuilder
 import amf.core.model.document.Document
 import amf.core.model.domain.templates.ParametrizedDeclaration
@@ -17,6 +19,8 @@ class LanguageServerTest extends AsyncFunSuite with CompilerTestBuilder {
 
   private val file = "file://amf-client/shared/src/test/resources/ls/resource-type-trait.raml"
 
+  override def defaultConfig: AMFConfiguration =
+    super.defaultConfig.withErrorHandlerProvider(() => DefaultErrorHandler())
   test("Parse resource type from model.") {
     build(file, Raml10YamlHint)
       .map(_.asInstanceOf[Document])

--- a/amf-client/shared/src/test/scala/amf/maker/DeprecatedKeysTest.scala
+++ b/amf-client/shared/src/test/scala/amf/maker/DeprecatedKeysTest.scala
@@ -1,12 +1,8 @@
 package amf.maker
 
 import amf.client.environment.RAMLConfiguration
-import amf.client.remod.AMFGraphConfiguration
-import amf.client.remod.amfcore.plugins.validate.ValidationConfiguration
 import amf.compiler.CompilerTestBuilder
-import amf.core.remote.{Raml08YamlHint, Raml10YamlHint}
 import amf.core.validation.SeverityLevels
-import amf.facades.Validation
 import amf.{ProfileName, Raml08Profile, Raml10Profile}
 import org.scalatest.AsyncFunSuite
 
@@ -46,7 +42,6 @@ class DeprecatedKeysTest extends AsyncFunSuite with CompilerTestBuilder {
       val config = RAMLConfiguration.RAML()
       val client = config.createClient()
       for {
-        validation  <- Validation(platform)
         parseResult <- client.parse(basePath + f.file)
         report      <- client.validate(parseResult.bu, f.profileName)
         unifiedReport <- Future.successful(

--- a/amf-client/shared/src/test/scala/amf/maker/InvalidsRefElementTest.scala
+++ b/amf-client/shared/src/test/scala/amf/maker/InvalidsRefElementTest.scala
@@ -1,8 +1,11 @@
 package amf.maker
 
+import amf.client.environment.AMFConfiguration
+import amf.client.parse.IgnoringErrorHandler
 import amf.compiler.CompilerTestBuilder
 import amf.core.annotations.SourceAST
 import amf.core.model.document.Document
+import amf.core.remote.{Oas20YamlHint, Raml10YamlHint}
 import amf.core.remote.{Oas20YamlHint, Raml10, Raml10YamlHint}
 import amf.facades.Validation
 import amf.plugins.document.webapi.parser.spec.WebApiDeclarations.ErrorResponse
@@ -19,14 +22,11 @@ class InvalidsRefElementTest extends AsyncFunSuite with CompilerTestBuilder {
 
   override val executionContext: ExecutionContext = global
 
-  test("Invalid link to Response with ast") {
-    Validation(platform)
-      .flatMap(v => {
+  override def defaultConfig: AMFConfiguration =
+    super.defaultConfig.withErrorHandlerProvider(() => IgnoringErrorHandler)
 
-        build("file://amf-client/shared/src/test/resources/invalids/error-response.yaml",
-              Oas20YamlHint,
-              validation = Some(v))
-      })
+  test("Invalid link to Response with ast") {
+    build("file://amf-client/shared/src/test/resources/invalids/error-response.oas", Oas20YamlHint)
       .map(unit => {
         val api      = unit.asInstanceOf[Document].encodes.asInstanceOf[WebApi]
         val response = api.endPoints.head.operations.head.responses.head
@@ -38,13 +38,8 @@ class InvalidsRefElementTest extends AsyncFunSuite with CompilerTestBuilder {
   }
 
   test("Invalid link to Trait with ast") {
-    Validation(platform)
-      .flatMap(v => {
 
-        build("file://amf-client/shared/src/test/resources/invalids/error-trait.raml",
-              Raml10YamlHint,
-              validation = Some(v))
-      })
+    build("file://amf-client/shared/src/test/resources/invalids/error-trait.raml", Raml10YamlHint)
       .map(unit => {
         val api      = unit.asInstanceOf[Document].encodes.asInstanceOf[WebApi]
         val badTrait = api.endPoints.head.operations.head.extend.head
@@ -62,13 +57,7 @@ class InvalidsRefElementTest extends AsyncFunSuite with CompilerTestBuilder {
   }
 
   test("Invalid link to resource type with ast") {
-    Validation(platform)
-      .flatMap(v => {
-
-        build("file://amf-client/shared/src/test/resources/invalids/error-resource-type.raml",
-              Raml10YamlHint,
-              validation = Some(v))
-      })
+    build("file://amf-client/shared/src/test/resources/invalids/error-resource-type.raml", Raml10YamlHint)
       .map(unit => {
         val api         = unit.asInstanceOf[Document].encodes.asInstanceOf[WebApi]
         val badResource = api.endPoints.head.extend.head
@@ -93,13 +82,7 @@ class InvalidsRefElementTest extends AsyncFunSuite with CompilerTestBuilder {
   }
 
   test("Invalid link to security scheme type with ast") {
-    Validation(platform)
-      .flatMap(v => {
-
-        build("file://amf-client/shared/src/test/resources/invalids/error-security-scheme.raml",
-              Raml10YamlHint,
-              validation = Some(v))
-      })
+    build("file://amf-client/shared/src/test/resources/invalids/error-security-scheme.raml", Raml10YamlHint)
       .map(unit => {
         val declaration = unit.asInstanceOf[Document].declares.head
         assert(declaration.isInstanceOf[SecurityScheme])
@@ -110,13 +93,8 @@ class InvalidsRefElementTest extends AsyncFunSuite with CompilerTestBuilder {
       })
   }
   test("Invalid link to named example with ast") {
-    Validation(platform)
-      .flatMap(v => {
 
-        build("file://amf-client/shared/src/test/resources/invalids/error-named-example.raml",
-              Raml10YamlHint,
-              validation = Some(v))
-      })
+    build("file://amf-client/shared/src/test/resources/invalids/error-named-example.raml", Raml10YamlHint)
       .map(unit => {
         val declaration = unit.asInstanceOf[Document].declares.head
         assert(declaration.isInstanceOf[AnyShape])

--- a/amf-client/shared/src/test/scala/amf/maker/ReferencesMakerTest.scala
+++ b/amf-client/shared/src/test/scala/amf/maker/ReferencesMakerTest.scala
@@ -1,5 +1,6 @@
 package amf.maker
 
+import amf.client.environment.WebAPIConfiguration
 import amf.common.AmfObjectTestMatcher
 import amf.compiler.CompilerTestBuilder
 import amf.core.model.document.{Document, Fragment}
@@ -32,8 +33,8 @@ class ReferencesMakerTest extends AsyncFunSuite with CompilerTestBuilder with Am
   private def assertFixture(rootFile: String, hint: Hint): Future[Assertion] = {
 
     val rootExpected = UnitsCreator(hint.vendor).usesDataType
-
-    build(rootFile, hint)
+    val amfConfig    = WebAPIConfiguration.WebAPI()
+    build(rootFile, hint, amfConfig, None)
       .map({
         case actual: Document => actual
       })

--- a/amf-client/shared/src/test/scala/amf/maker/WebApiMakerTest.scala
+++ b/amf-client/shared/src/test/scala/amf/maker/WebApiMakerTest.scala
@@ -1,5 +1,6 @@
 package amf.maker
 
+import amf.client.environment.WebAPIConfiguration
 import amf.common.AmfObjectTestMatcher
 import amf.compiler.CompilerTestBuilder
 import amf.core.metamodel.Field
@@ -667,8 +668,8 @@ trait WebApiMakerTest extends AsyncFunSuite with CompilerTestBuilder with ListAs
                             file: String,
                             hint: Hint,
                             overridedPath: Option[String] = None): Future[Assertion] = {
-
-    build(overridedPath.getOrElse(basePath) + file, hint)
+    val amfConfig = WebAPIConfiguration.WebAPI()
+    build(overridedPath.getOrElse(basePath) + file, hint, amfConfig, None)
       .map { unit =>
         val actual = unit.asInstanceOf[Document].encodes
         AmfObjectMatcher(expected).assert(actual)

--- a/amf-client/shared/src/test/scala/amf/parser/NumberFormatsTest.scala
+++ b/amf-client/shared/src/test/scala/amf/parser/NumberFormatsTest.scala
@@ -36,10 +36,10 @@ class NumberFormatsTest extends AsyncFunSuite with PlatformSecrets {
 
   cases.foreach { ex =>
     test(s"Test data type ${ex.literalType} format ${ex.format}") {
+      val client = RAMLConfiguration.RAML10().createClient()
       for {
-        validation <- Validation(platform)
-        unit       <- RAMLConfiguration.RAML10().createClient().parseContent(ex.api)
-        dumped     <- AMFRenderer(unit.bu, Raml10, RenderOptions()).renderToString
+        unit   <- client.parseContent(ex.api)
+        dumped <- client.render(unit.bu, Raml10.mediaType)
       } yield {
         unit.bu match {
           case f: Fragment =>

--- a/amf-client/shared/src/test/scala/amf/parser/SourceMapsAnnotationsTest.scala
+++ b/amf-client/shared/src/test/scala/amf/parser/SourceMapsAnnotationsTest.scala
@@ -1,7 +1,10 @@
 package amf.parser
 
 import amf.client.environment.{AsyncAPIConfiguration, WebAPIConfiguration}
+import amf.client.remod.{AMFParser, ParseConfiguration}
+import amf.core.AMFCompiler
 import amf.client.remod.ParseConfiguration
+import amf.core.AMFCompiler
 import amf.core.annotations.{Inferred, SourceAST, SynthesizedField, VirtualNode}
 import amf.core.metamodel.Field
 import amf.core.metamodel.document.DocumentModel
@@ -9,9 +12,7 @@ import amf.core.model.document.BaseUnit
 import amf.core.model.domain.{AmfArray, AmfElement, AmfObject}
 import amf.core.parser.{Annotations, FieldEntry}
 import amf.core.remote._
-import amf.core.services.RuntimeCompiler
 import amf.core.unsafe.PlatformSecrets
-import amf.facades.Validation
 import amf.plugins.document.webapi.parser.spec.raml.expression.ExpressionMember
 import org.mulesoft.lexer.InputRange
 import org.scalatest.{Assertion, AsyncFunSuite}
@@ -40,15 +41,14 @@ class SourceMapsAnnotationsTest extends AsyncFunSuite with PlatformSecrets {
   }
 
   test("Test Async 2.0 annotations") {
-    runTest("async2.yaml", AsyncYamlHint)
+    runTest("async2.yaml", Async20YamlHint)
   }
 
-  private def build(file: String, hint: Hint): Future[BaseUnit] =
-    Validation(platform).flatMap { _ =>
-      val url           = s"file://$directory$file"
-      val configuration = WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20())
-      RuntimeCompiler(url, None, Context(platform), Cache(), ParseConfiguration(configuration))
-    }
+  private def build(file: String, hint: Hint): Future[BaseUnit] = {
+    val url           = s"file://$directory$file"
+    val configuration = WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20())
+    AMFParser.parse(url, configuration).map(_.bu)
+  }
 
   private def runTest(file: String, hint: Hint): Future[Assertion] =
     build(file, hint).map { bu =>

--- a/amf-client/shared/src/test/scala/amf/recursive/shapes/RecursiveShapesTest.scala
+++ b/amf-client/shared/src/test/scala/amf/recursive/shapes/RecursiveShapesTest.scala
@@ -1,5 +1,6 @@
 package amf.recursive.shapes
 
+import amf.client.environment.AMFConfiguration
 import amf.client.parse.DefaultErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.remote.{Hint, Oas20, Raml10YamlHint}
@@ -54,5 +55,5 @@ class RecursiveShapesTest extends FunSuiteCycleTests with MultiPlatformReportGen
   }
 
   /** Method for transforming parsed unit. Override if necessary. */
-  override def transform(unit: BaseUnit, config: CycleConfig): BaseUnit = ValidationTransformationPipeline(Raml10Profile, unit, DefaultErrorHandler())
+  override def transform(unit: BaseUnit, config: CycleConfig, amfConfig:AMFConfiguration): BaseUnit = ValidationTransformationPipeline(Raml10Profile, unit, DefaultErrorHandler())
 }

--- a/amf-client/shared/src/test/scala/amf/resolution/Async20ResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/Async20ResolutionTest.scala
@@ -3,7 +3,7 @@ package amf.resolution
 import amf.client.remod.amfcore.config.RenderOptions
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit
-import amf.core.remote.{AsyncApi20, AsyncYamlHint, Vendor}
+import amf.core.remote.{AsyncApi20, Async20YamlHint, Vendor}
 import amf.core.remote.Vendor._
 import amf.core.resolution.pipelines.TransformationPipeline
 import amf.emit.AMFRenderer
@@ -20,7 +20,7 @@ class Async20ResolutionTest extends ResolutionTest {
     config =>
       cycle("message-example-propagation.yaml",
             config.golden,
-            AsyncYamlHint,
+            Async20YamlHint,
             target = AMF,
             renderOptions = Some(config.renderOptions))
   }
@@ -28,7 +28,7 @@ class Async20ResolutionTest extends ResolutionTest {
   multiGoldenTest("defaultContentType overrides message contentType", "content-type-override.%s") { config =>
     cycle("content-type-override.yaml",
           config.golden,
-          AsyncYamlHint,
+          Async20YamlHint,
           target = AMF,
           renderOptions = Some(config.renderOptions))
   }
@@ -36,7 +36,7 @@ class Async20ResolutionTest extends ResolutionTest {
   multiGoldenTest("Message traits are merged to message", "message-trait-merging.%s") { config =>
     cycle("message-trait-merging.yaml",
           config.golden,
-          AsyncYamlHint,
+          Async20YamlHint,
           target = AMF,
           renderOptions = Some(config.renderOptions))
   }
@@ -44,7 +44,7 @@ class Async20ResolutionTest extends ResolutionTest {
   multiGoldenTest("Operation traits are merged to operation", "operation-trait-merging.%s") { config =>
     cycle("operation-trait-merging.yaml",
           config.golden,
-          AsyncYamlHint,
+          Async20YamlHint,
           target = AMF,
           renderOptions = Some(config.renderOptions))
   }
@@ -54,7 +54,7 @@ class Async20ResolutionTest extends ResolutionTest {
     cycle(
       "message-trait-merging.yaml",
       config.golden,
-      AsyncYamlHint,
+      Async20YamlHint,
       target = AMF,
       renderOptions = Some(config.renderOptions),
       pipeline = Some(TransformationPipeline.DEFAULT_PIPELINE)
@@ -66,7 +66,7 @@ class Async20ResolutionTest extends ResolutionTest {
     cycle(
       "operation-trait-merging.yaml",
       config.golden,
-      AsyncYamlHint,
+      Async20YamlHint,
       target = AMF,
       renderOptions = Some(config.renderOptions),
       pipeline = Some(TransformationPipeline.DEFAULT_PIPELINE)
@@ -77,7 +77,7 @@ class Async20ResolutionTest extends ResolutionTest {
     config =>
       cycle("named-parameter-with-ref.yaml",
             config.golden,
-            AsyncYamlHint,
+            Async20YamlHint,
             target = AMF,
             renderOptions = Some(config.renderOptions))
   }
@@ -87,7 +87,7 @@ class Async20ResolutionTest extends ResolutionTest {
     cycle(
       "include-data-type-at-root-of-payload.yaml",
       config.golden,
-      AsyncYamlHint,
+      Async20YamlHint,
       target = AMF,
       directory = validationsPath + "raml-data-type-references/",
       renderOptions = Some(config.renderOptions)
@@ -99,7 +99,7 @@ class Async20ResolutionTest extends ResolutionTest {
       cycle(
         "include-data-type-with-chained-reference.yaml",
         config.golden,
-        AsyncYamlHint,
+        Async20YamlHint,
         target = AMF,
         directory = validationsPath + "raml-data-type-references/",
         renderOptions = Some(config.renderOptions)
@@ -110,7 +110,7 @@ class Async20ResolutionTest extends ResolutionTest {
     cycle(
       "ref-data-type-fragment.yaml",
       config.golden,
-      AsyncYamlHint,
+      Async20YamlHint,
       target = AMF,
       directory = validationsPath + "raml-data-type-references/",
       renderOptions = Some(config.renderOptions)
@@ -121,7 +121,7 @@ class Async20ResolutionTest extends ResolutionTest {
     cycle(
       "ref-type-in-library.yaml",
       config.golden,
-      AsyncYamlHint,
+      Async20YamlHint,
       target = AMF,
       directory = validationsPath + "raml-data-type-references/",
       renderOptions = Some(config.renderOptions)
@@ -133,7 +133,7 @@ class Async20ResolutionTest extends ResolutionTest {
       cycle(
         "ref-external-yaml.yaml",
         config.golden,
-        AsyncYamlHint,
+        Async20YamlHint,
         target = AMF,
         directory = validationsPath + "raml-data-type-references/",
         renderOptions = Some(config.renderOptions)
@@ -145,7 +145,7 @@ class Async20ResolutionTest extends ResolutionTest {
     cycle(
       "ref-data-type-fragment-invalid.yaml",
       config.golden,
-      AsyncYamlHint,
+      Async20YamlHint,
       target = AMF,
       directory = validationsPath + "raml-data-type-references/",
       renderOptions = Some(config.renderOptions)
@@ -157,7 +157,7 @@ class Async20ResolutionTest extends ResolutionTest {
     cycle(
       "type-forward-referencing.yaml",
       config.golden,
-      AsyncYamlHint,
+      Async20YamlHint,
       target = AMF,
       renderOptions = Some(config.renderOptions)
     )
@@ -168,7 +168,7 @@ class Async20ResolutionTest extends ResolutionTest {
       cycle(
         "valid-external-ref-message-trait.yaml",
         config.golden,
-        AsyncYamlHint,
+        Async20YamlHint,
         target = AMF,
         directory = validationsPath + "validations/external-reference/",
         renderOptions = Some(config.renderOptions)
@@ -179,7 +179,7 @@ class Async20ResolutionTest extends ResolutionTest {
     cycle(
       "valid-external-ref-operation-trait.yaml",
       config.golden,
-      AsyncYamlHint,
+      Async20YamlHint,
       target = AMF,
       directory = validationsPath + "validations/external-reference/",
       renderOptions = Some(config.renderOptions)
@@ -191,8 +191,4 @@ class Async20ResolutionTest extends ResolutionTest {
 
   override def defaultRenderOptions: RenderOptions =
     RenderOptions().withSourceMaps.withRawSourceMaps.withCompactUris.withPrettyPrint
-
-  override def render(unit: BaseUnit, config: CycleConfig, options: RenderOptions): Future[String] = {
-    new AMFRenderer(unit, config.target, options, config.syntax).renderToString
-  }
 }

--- a/amf-client/shared/src/test/scala/amf/resolution/CompatibilityCycleGoldenTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/CompatibilityCycleGoldenTest.scala
@@ -1,5 +1,6 @@
 package amf.resolution
 
+import amf.core.remote.Syntax.Json
 import amf.core.remote._
 import amf.core.resolution.pipelines.TransformationPipeline
 
@@ -33,7 +34,8 @@ class CompatibilityCycleGoldenTest extends ResolutionTest {
           "cycled-apis/oas30/no-operation-name.json",
           Raml10YamlHint,
           Oas30,
-          transformWith = Some(Oas30))
+          transformWith = Some(Oas30),
+          syntax = Some(Json))
   }
 
   test("RAML operations without names do not generate null_0 operationIds in OAS 2.0") {
@@ -83,7 +85,8 @@ class CompatibilityCycleGoldenTest extends ResolutionTest {
           "cycled-apis/oas30/library.json",
           Raml10YamlHint,
           Oas30,
-          transformWith = Some(Oas30))
+          transformWith = Some(Oas30),
+          syntax = Some(Json))
   }
 
   test("Unused OAS 3.0 examples are deleted and used ones inlined") {
@@ -131,7 +134,8 @@ class CompatibilityCycleGoldenTest extends ResolutionTest {
           "cycled-apis/oas30/raml-security-definitions.json",
           Raml10YamlHint,
           Oas30,
-          transformWith = Some(Oas30))
+          transformWith = Some(Oas30),
+          syntax = Some(Json))
   }
 
   test("OAS 3.0 nullable schemas are translated with union expression to raml") {

--- a/amf-client/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
@@ -808,11 +808,10 @@ class EditingResolutionTest extends ResolutionTest {
   }
 
   override def render(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): Future[String] = {
-    super.render(unit, config, amfConfig.withRenderOptions(defaultRenderOptions))
+    val configuration = amfConfig.withRenderOptions(
+      amfConfig.options.renderOptions.withRawSourceMaps.withSourceMaps.withCompactUris.withPrettyPrint)
+    super.render(unit, config, configuration)
   }
-
-  override def defaultRenderOptions: RenderOptions =
-    RenderOptions().withSourceMaps.withRawSourceMaps.withCompactUris.withPrettyPrint
 
   // This test hangs diff
   ignore("Emission of API with JSON Schema's schema as references") {

--- a/amf-client/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
@@ -1,5 +1,6 @@
 package amf.resolution
 
+import amf.client.environment.AMFConfiguration
 import amf.client.remod.amfcore.config.RenderOptions
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit
@@ -573,7 +574,7 @@ class EditingResolutionTest extends ResolutionTest {
   multiGoldenTest("References to message definitions", "message-references.%s") { config =>
     cycle("message-references.yaml",
           config.golden,
-          AsyncYamlHint,
+          Async20YamlHint,
           target = Amf,
           resolutionPath + "async20/",
           renderOptions = Some(config.renderOptions))
@@ -806,8 +807,8 @@ class EditingResolutionTest extends ResolutionTest {
     )
   }
 
-  override def render(unit: BaseUnit, config: CycleConfig, useAmfJsonldSerialization: Boolean): Future[String] = {
-    new AMFRenderer(unit, config.target, defaultRenderOptions, config.syntax).renderToString
+  override def render(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): Future[String] = {
+    super.render(unit, config, amfConfig.withRenderOptions(defaultRenderOptions))
   }
 
   override def defaultRenderOptions: RenderOptions =

--- a/amf-client/shared/src/test/scala/amf/resolution/ExamplesResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/ExamplesResolutionTest.scala
@@ -1,7 +1,7 @@
 package amf.resolution
 
 import amf.client.remod.amfcore.config.RenderOptions
-import amf.core.remote.{Amf, Oas20JsonHint, Oas20YamlHint, Raml10YamlHint}
+import amf.core.remote.{Amf, Oas20JsonHint, Oas20YamlHint, Raml10, Raml10YamlHint}
 
 /**
   *
@@ -15,16 +15,20 @@ class ExamplesResolutionTest extends ResolutionTest {
           config.golden,
           Oas20JsonHint,
           target = Amf,
-          renderOptions = Some(config.renderOptions))
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Response declarations with multiple media types oas to AMF",
                   "response-declarations-with-multiple-media-types.%s") { config =>
-    cycle("response-declarations-with-multiple-media-types.yaml",
-          config.golden,
-          Oas20YamlHint,
-          target = Amf,
-          renderOptions = Some(config.renderOptions))
+    cycle(
+      "response-declarations-with-multiple-media-types.yaml",
+      config.golden,
+      Oas20YamlHint,
+      target = Amf,
+      renderOptions = Some(config.renderOptions),
+      transformWith = Some(Raml10)
+    )
   }
 
   multiGoldenTest("Response examples raml to AMF", "response-examples.raml.%s") { config =>
@@ -32,27 +36,34 @@ class ExamplesResolutionTest extends ResolutionTest {
           config.golden,
           Raml10YamlHint,
           target = Amf,
-          renderOptions = Some(config.renderOptions))
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Typed external fragment as included example - Vocabulary", "examples/vocabulary-fragment/api.%s") {
     config =>
-      cycle("examples/vocabulary-fragment/api.raml",
-            config.golden,
-            Raml10YamlHint,
-            target = Amf,
-            directory = validationPath,
-            renderOptions = Some(config.renderOptions))
+      cycle(
+        "examples/vocabulary-fragment/api.raml",
+        config.golden,
+        Raml10YamlHint,
+        target = Amf,
+        directory = validationPath,
+        renderOptions = Some(config.renderOptions),
+        transformWith = Some(Raml10)
+      )
   }
 
   multiGoldenTest("Typed external fragment as included example - Dialect", "examples/dialect-fragment/api.%s") {
     config =>
-      cycle("examples/dialect-fragment/api.raml",
-            config.golden,
-            Raml10YamlHint,
-            target = Amf,
-            directory = validationPath,
-            renderOptions = Some(config.renderOptions))
+      cycle(
+        "examples/dialect-fragment/api.raml",
+        config.golden,
+        Raml10YamlHint,
+        target = Amf,
+        directory = validationPath,
+        renderOptions = Some(config.renderOptions),
+        transformWith = Some(Raml10)
+      )
   }
 
   override def defaultRenderOptions: RenderOptions = RenderOptions().withSourceMaps.withPrettyPrint

--- a/amf-client/shared/src/test/scala/amf/resolution/ExtendsResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/ExtendsResolutionTest.scala
@@ -19,7 +19,12 @@ trait ExtendsResolutionTest extends ResolutionTest {
   }
 
   multiGoldenTest("Simple extends resolution to Amf", "simple-merge.raml.%s") { config =>
-    cycle("simple-merge.raml", config.golden, Raml10YamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("simple-merge.raml",
+          config.golden,
+          Raml10YamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   test("Extends resolution with parameters resolution to Raml") {
@@ -27,7 +32,12 @@ trait ExtendsResolutionTest extends ResolutionTest {
   }
 
   multiGoldenTest("Extends resolution with parameters resolution to Amf", "parameters.raml.%s") { config =>
-    cycle("parameters.raml", config.golden, Raml10YamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("parameters.raml",
+          config.golden,
+          Raml10YamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   test("Extends resolution with parameter and transformation resolution to Raml") {
@@ -50,7 +60,8 @@ trait ExtendsResolutionTest extends ResolutionTest {
           config.golden,
           Raml10YamlHint,
           target = Amf,
-          renderOptions = Some(config.renderOptions))
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   test("Extends resolution with scalar collection to Raml") {
@@ -66,7 +77,8 @@ trait ExtendsResolutionTest extends ResolutionTest {
           config.golden,
           Raml10YamlHint,
           target = Amf,
-          renderOptions = Some(config.renderOptions))
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   test("Traits and resourceTypes with complex variables raml to raml test") {
@@ -110,16 +122,20 @@ trait ExtendsResolutionTest extends ResolutionTest {
           "trait-with-quoted-value.resolved.raml",
           Raml08YamlHint,
           Raml08,
-          basePath + "08/")
+          basePath + "08/",
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Trait application with quoted value to jsonld", "trait-with-quoted-value.resolved.%s") { config =>
-    cycle("trait-with-quoted-value.raml",
-          config.golden,
-          Raml08YamlHint,
-          target = Amf,
-          directory = basePath + "08/",
-          renderOptions = Some(config.renderOptions))
+    cycle(
+      "trait-with-quoted-value.raml",
+      config.golden,
+      Raml08YamlHint,
+      target = Amf,
+      directory = basePath + "08/",
+      renderOptions = Some(config.renderOptions),
+      transformWith = Some(Raml10)
+    )
   }
 
   test("Extension with library usage") {
@@ -213,7 +229,8 @@ trait ExtendsResolutionTest extends ResolutionTest {
       target = Amf,
       pipeline = Some(TransformationPipeline.DEFAULT_PIPELINE),
       renderOptions = Some(config.renderOptions.withoutSourceMaps),
-      directory = basePath + "extends-with-references-to-declares/trait/"
+      directory = basePath + "extends-with-references-to-declares/trait/",
+      transformWith = Some(Raml10)
     )
   }
 
@@ -225,7 +242,8 @@ trait ExtendsResolutionTest extends ResolutionTest {
       target = Amf,
       pipeline = Some(TransformationPipeline.DEFAULT_PIPELINE),
       renderOptions = Some(config.renderOptions.withoutSourceMaps),
-      directory = basePath + "extends-with-references-to-declares/resource-type/"
+      directory = basePath + "extends-with-references-to-declares/resource-type/",
+      transformWith = Some(Raml10)
     )
   }
 
@@ -237,7 +255,8 @@ trait ExtendsResolutionTest extends ResolutionTest {
       target = Amf,
       pipeline = Some(TransformationPipeline.DEFAULT_PIPELINE),
       renderOptions = Some(config.renderOptions.withoutSourceMaps),
-      directory = basePath + "extends-with-references-to-declares/merging/"
+      directory = basePath + "extends-with-references-to-declares/merging/",
+      transformWith = Some(Raml10)
     )
   }
 
@@ -246,9 +265,4 @@ trait ExtendsResolutionTest extends ResolutionTest {
   }
 
   override def defaultRenderOptions: RenderOptions = RenderOptions().withSourceMaps.withPrettyPrint
-
-  override def render(unit: BaseUnit, config: CycleConfig, useAmfJsonldSerialization: Boolean): Future[String] = {
-    val target = config.target
-    new AMFRenderer(unit, target, defaultRenderOptions, config.syntax).renderToString
-  }
 }

--- a/amf-client/shared/src/test/scala/amf/resolution/ExtensionResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/ExtensionResolutionTest.scala
@@ -26,12 +26,15 @@ class ExtensionResolutionTest extends ResolutionTest {
   }
 
   multiGoldenTest("Extension with traits to Amf", "output.%s") { config =>
-    cycle("input.raml",
-          config.golden,
-          Raml10YamlHint,
-          target = Amf,
-          directory = s"${basePath}traits/",
-          renderOptions = Some(config.renderOptions))
+    cycle(
+      "input.raml",
+      config.golden,
+      Raml10YamlHint,
+      target = Amf,
+      directory = s"${basePath}traits/",
+      renderOptions = Some(config.renderOptions),
+      transformWith = Some(Raml10)
+    )
   }
 
   test("Extension chain to Raml") {
@@ -43,8 +46,4 @@ class ExtensionResolutionTest extends ResolutionTest {
   }
 
   override def defaultRenderOptions: RenderOptions = RenderOptions().withSourceMaps.withPrettyPrint
-
-  override def render(unit: BaseUnit, config: CycleConfig, options: RenderOptions): Future[String] = {
-    new AMFRenderer(unit, config.target, options, config.syntax).renderToString
-  }
 }

--- a/amf-client/shared/src/test/scala/amf/resolution/ExternalSourceResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/ExternalSourceResolutionTest.scala
@@ -1,7 +1,7 @@
 package amf.resolution
 
 import amf.client.remod.amfcore.config.RenderOptions
-import amf.core.remote.{Amf, Raml10YamlHint}
+import amf.core.remote.{Amf, Raml10, Raml10YamlHint}
 
 /**
   *
@@ -10,19 +10,39 @@ class ExternalSourceResolutionTest extends ResolutionTest {
   override val basePath = "amf-client/shared/src/test/resources/resolution/externalfragment/"
 
   multiGoldenTest("Xml schema raml to amf", "xmlschema.raml.%s") { config =>
-    cycle("xmlschema.raml", config.golden, Raml10YamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("xmlschema.raml",
+          config.golden,
+          Raml10YamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Json schema raml to amf", "jsonschema.raml.%s") { config =>
-    cycle("jsonschema.raml", config.golden, Raml10YamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("jsonschema.raml",
+          config.golden,
+          Raml10YamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Xml example raml to amf", "xmlexample.raml.%s") { config =>
-    cycle("xmlexample.raml", config.golden, Raml10YamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("xmlexample.raml",
+          config.golden,
+          Raml10YamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Json example raml to amf", "jsonexample.raml.%s") { config =>
-    cycle("jsonexample.raml", config.golden, Raml10YamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("jsonexample.raml",
+          config.golden,
+          Raml10YamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   override def defaultRenderOptions: RenderOptions = RenderOptions().withSourceMaps.withPrettyPrint

--- a/amf-client/shared/src/test/scala/amf/resolution/MediaTypeResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/MediaTypeResolutionTest.scala
@@ -1,17 +1,27 @@
 package amf.resolution
 
 import amf.client.remod.amfcore.config.RenderOptions
-import amf.core.remote.{Amf, Oas20, Oas20JsonHint, Raml10YamlHint}
+import amf.core.remote.{Amf, Oas20, Oas20JsonHint, Oas30, Raml10, Raml10YamlHint}
 
 class MediaTypeResolutionTest extends ResolutionTest {
   override val basePath = "amf-client/shared/src/test/resources/resolution/media-type/"
 
   multiGoldenTest("One mediaType raml to AMF", "media-type.raml.%s") { config =>
-    cycle("media-type.raml", config.golden, Raml10YamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("media-type.raml",
+          config.golden,
+          Raml10YamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Multiple mediaTypes raml to AMF", "media-types.raml.%s") { config =>
-    cycle("media-types.raml", config.golden, Raml10YamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("media-types.raml",
+          config.golden,
+          Raml10YamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Override mediaType raml to AMF", "media-type-override.raml.%s") { config =>
@@ -19,15 +29,26 @@ class MediaTypeResolutionTest extends ResolutionTest {
           config.golden,
           Raml10YamlHint,
           target = Amf,
-          renderOptions = Some(config.renderOptions))
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("One mediaType oas to AMF", "media-type.json.%s") { config =>
-    cycle("media-type.json", config.golden, Oas20JsonHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("media-type.json",
+          config.golden,
+          Oas20JsonHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Multiple mediaTypes oas to AMF", "media-types.json.%s") { config =>
-    cycle("media-types.json", config.golden, Oas20JsonHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("media-types.json",
+          config.golden,
+          Oas20JsonHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Override mediaType oas to AMF", "media-type-override.json.%s") { config =>
@@ -35,7 +56,8 @@ class MediaTypeResolutionTest extends ResolutionTest {
           config.golden,
           Oas20JsonHint,
           target = Amf,
-          renderOptions = Some(config.renderOptions))
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   // Different target, should keep accepts and consumes fields as they are required in OAS.

--- a/amf-client/shared/src/test/scala/amf/resolution/OverlayResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/OverlayResolutionTest.scala
@@ -1,5 +1,7 @@
 package amf.resolution
 
+import amf.client.environment.AMFConfiguration
+import amf.client.remod.AMFGraphConfiguration
 import amf.client.remod.amfcore.config.RenderOptions
 import amf.core.model.document.BaseUnit
 import amf.core.remote.{Raml10, Raml10YamlHint}
@@ -70,8 +72,9 @@ class OverlayResolutionTest extends ResolutionTest {
     }
   }
 
-  override def render(unit: BaseUnit, config: CycleConfig, useAmfJsonldSerialization: Boolean): Future[String] = {
-    val target = config.target
-    new AMFRenderer(unit, target, RenderOptions().withSourceMaps.withPrettyPrint, config.syntax).renderToString
+  override def render(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): Future[String] = {
+    super.render(unit,
+                 config,
+                 amfConfig.withRenderOptions(amfConfig.options.renderOptions.withSourceMaps.withPrettyPrint))
   }
 }

--- a/amf-client/shared/src/test/scala/amf/resolution/ProductionResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/ProductionResolutionTest.scala
@@ -1,5 +1,6 @@
 package amf.resolution
 
+import amf.client.remod.amfcore.config.RenderOptions
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.Document
 import amf.core.remote._
@@ -14,13 +15,17 @@ class ProductionResolutionTest extends RamlResolutionTest {
   val productionRaml10  = "amf-client/shared/src/test/resources/production/raml10/"
   val productionRaml08  = "amf-client/shared/src/test/resources/production/raml08/"
 
+  override def renderOptions() = RenderOptions().withPrettyPrint.withSourceMaps
   multiGoldenTest("Test declared type with facet added", "add-facet.raml.%s") { config =>
-    cycle("add-facet.raml",
-          config.golden,
-          Raml10YamlHint,
-          renderOptions = Some(config.renderOptions),
-          target = Amf,
-          directory = basePath + "inherits-resolution-declares/")
+    cycle(
+      "add-facet.raml",
+      config.golden,
+      Raml10YamlHint,
+      renderOptions = Some(config.renderOptions),
+      target = Amf,
+      directory = basePath + "inherits-resolution-declares/",
+      transformWith = Some(Raml10)
+    )
   }
 
   multiGoldenTest("Test inline type from includes", "test-ramlfragment.raml.%s") { config =>
@@ -30,7 +35,8 @@ class ProductionResolutionTest extends RamlResolutionTest {
       Raml10YamlHint,
       renderOptions = Some(config.renderOptions),
       target = Amf,
-      directory = basePath + "inherits-resolution-declares/"
+      directory = basePath + "inherits-resolution-declares/",
+      transformWith = Some(Raml10)
     )
   }
 
@@ -44,11 +50,14 @@ class ProductionResolutionTest extends RamlResolutionTest {
   // TODO: diff of final result is too slow
   multiGoldenTest("Resolves googleapis.compredictionv1.2swagger.raml to jsonld",
                   "googleapis.compredictionv1.2swagger.raml.resolved.%s") { config =>
-    cycle("googleapis.compredictionv1.2swagger.raml",
-          config.golden,
-          Raml10YamlHint,
-          renderOptions = Some(config.renderOptions),
-          target = Amf)
+    cycle(
+      "googleapis.compredictionv1.2swagger.raml",
+      config.golden,
+      Raml10YamlHint,
+      renderOptions = Some(config.renderOptions),
+      target = Amf,
+      transformWith = Some(Raml10)
+    )
   }
 
   multiGoldenTest("azure_blob_service raml to jsonld", "microsoft_azure_blob_service.raml.resolved.%s") { config =>
@@ -56,7 +65,8 @@ class ProductionResolutionTest extends RamlResolutionTest {
           config.golden,
           Raml10YamlHint,
           renderOptions = Some(config.renderOptions),
-          target = Amf)
+          target = Amf,
+          transformWith = Some(Raml10))
   }
 
   test("test definition_loops input") {
@@ -185,15 +195,15 @@ class ProductionResolutionTest extends RamlResolutionTest {
 
     val config                    = CycleConfig(source, golden, hint, target, directory, syntax, None)
     val useAmfJsonldSerialization = true
-
+    val amfConfig                 = buildConfig(None, None)
     for {
-      simpleModel <- build(config, validation, useAmfJsonldSerialization).map(
+      simpleModel <- build(config, amfConfig).map(
         TransformationPipelineRunner(UnhandledErrorHandler).run(_, AmfEditingPipeline()))
-      a <- render(simpleModel, config, useAmfJsonldSerialization)
-      doubleModel <- build(config, validation, useAmfJsonldSerialization).map(
+      a <- render(simpleModel, config, amfConfig)
+      doubleModel <- build(config, amfConfig).map(
         TransformationPipelineRunner(UnhandledErrorHandler).run(_, AmfEditingPipeline()))
-      _ <- render(doubleModel, config, useAmfJsonldSerialization)
-      b <- render(doubleModel, config, useAmfJsonldSerialization)
+      _ <- render(doubleModel, config, amfConfig)
+      b <- render(doubleModel, config, amfConfig)
     } yield {
       val simpleDeclares =
         simpleModel.asInstanceOf[Document].declares
@@ -224,12 +234,24 @@ class ProductionResolutionTest extends RamlResolutionTest {
 
   // TODO migrate to multiGoldenTest
   test("Test complex recursions in type inheritance 1") {
-    cycle("healthcare_reduced_v1.raml", "healthcare_reduced_v1.raml.resolved", Raml10YamlHint, Amf, validationPath)
+    cycle("healthcare_reduced_v1.raml",
+          "healthcare_reduced_v1.raml.resolved",
+          Raml10YamlHint,
+          Amf,
+          validationPath,
+          transformWith = Some(Raml10))
   }
 
   // TODO migrate to multiGoldenTest
   test("Test complex recursions in type inheritance 2") {
-    cycle("healthcare_reduced_v2.raml", "healthcare_reduced_v2.raml.resolved", Raml10YamlHint, Amf, validationPath)
+    cycle(
+      "healthcare_reduced_v2.raml",
+      "healthcare_reduced_v2.raml.resolved",
+      Raml10YamlHint,
+      Amf,
+      validationPath,
+      renderOptions = Some(RenderOptions().withPrettyPrint.withSourceMaps)
+    )
   }
 
   // TODO migrate to multiGoldenTest

--- a/amf-client/shared/src/test/scala/amf/resolution/QueryStringResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/QueryStringResolutionTest.scala
@@ -1,7 +1,7 @@
 package amf.resolution
 
 import amf.client.remod.amfcore.config.RenderOptions
-import amf.core.remote.{Amf, Oas20JsonHint, Raml10YamlHint}
+import amf.core.remote.{Amf, Oas20JsonHint, Raml10, Raml10YamlHint}
 
 /**
   *
@@ -10,11 +10,21 @@ class QueryStringResolutionTest extends ResolutionTest {
   override val basePath = "amf-client/shared/src/test/resources/resolution/queryString/"
 
   multiGoldenTest("QueryString raml to AMF", "query-string.raml.%s") { config =>
-    cycle("query-string.raml", config.golden, Raml10YamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("query-string.raml",
+          config.golden,
+          Raml10YamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("QueryString oas to AMF", "query-string.json.%s") { config =>
-    cycle("query-string.json", config.golden, Oas20JsonHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("query-string.json",
+          config.golden,
+          Oas20JsonHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Security Scheme with Query String oas to AMF", "security-with-query-string.json.%s") { config =>
@@ -22,7 +32,8 @@ class QueryStringResolutionTest extends ResolutionTest {
           config.golden,
           Oas20JsonHint,
           target = Amf,
-          renderOptions = Some(config.renderOptions))
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Security Scheme with Query String raml to AMF", "security-with-query-string.raml.%s") { config =>
@@ -30,7 +41,8 @@ class QueryStringResolutionTest extends ResolutionTest {
           config.golden,
           Raml10YamlHint,
           target = Amf,
-          renderOptions = Some(config.renderOptions))
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   override def defaultRenderOptions: RenderOptions = RenderOptions().withSourceMaps.withPrettyPrint

--- a/amf-client/shared/src/test/scala/amf/resolution/Raml08ResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/Raml08ResolutionTest.scala
@@ -1,7 +1,7 @@
 package amf.resolution
 
 import amf.core.errorhandling.UnhandledErrorHandler
-import amf.core.remote.{Amf, Raml08, Raml08YamlHint}
+import amf.core.remote.{Amf, Raml08, Raml08YamlHint, Raml10}
 
 class Raml08ResolutionTest extends RamlResolutionTest {
   override val basePath: String =

--- a/amf-client/shared/src/test/scala/amf/resolution/RamlResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/RamlResolutionTest.scala
@@ -10,7 +10,4 @@ abstract class RamlResolutionTest extends ResolutionTest {
 
   override def defaultRenderOptions: RenderOptions = RenderOptions().withSourceMaps.withPrettyPrint
 
-  override def render(unit: BaseUnit, config: CycleConfig, useAmfJsonldSerialization: Boolean): Future[String] = {
-    new AMFRenderer(unit, config.target, defaultRenderOptions, config.syntax).renderToString
-  }
 }

--- a/amf-client/shared/src/test/scala/amf/resolution/ReferencesResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/ReferencesResolutionTest.scala
@@ -1,7 +1,7 @@
 package amf.resolution
 
 import amf.client.remod.amfcore.config.RenderOptions
-import amf.core.remote.{Amf, Oas20, Oas20YamlHint, Raml10YamlHint}
+import amf.core.remote.{Amf, Oas20, Oas20YamlHint, Raml10, Raml10YamlHint}
 
 class ReferencesResolutionTest extends ResolutionTest {
   override val basePath: String = "amf-client/shared/src/test/resources/upanddown/"
@@ -12,7 +12,8 @@ class ReferencesResolutionTest extends ResolutionTest {
           config.golden,
           Raml10YamlHint,
           target = Amf,
-          renderOptions = Some(config.renderOptions))
+          renderOptions = Some(config.renderOptions),
+          transformWith = Some(Raml10))
   }
 
   multiGoldenTest("Oas direct type alias - All objects case - Default pipeline", "all-objects-case.%s") { config =>

--- a/amf-client/shared/src/test/scala/amf/resolution/ResolutionCapabilities.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/ResolutionCapabilities.scala
@@ -1,5 +1,7 @@
 package amf.resolution
 
+import amf.client.environment.AMFConfiguration
+import amf.client.remod.amfcore.resolution.PipelineName
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.remote._
@@ -8,12 +10,14 @@ import amf.core.services.RuntimeResolver
 import amf.plugins.document.webapi.resolution.pipelines.{AmfEditingPipeline, AmfTransformationPipeline}
 
 trait ResolutionCapabilities {
-  protected def transform(unit: BaseUnit, pipeline: String, vendor: Vendor): BaseUnit = vendor match {
-    case AsyncApi | AsyncApi20 | Raml08 | Raml10 | Oas20 | Oas30 =>
-      RuntimeResolver.resolve(vendor.name, unit, pipeline, UnhandledErrorHandler)
-    case Amf    => TransformationPipelineRunner(UnhandledErrorHandler).run(unit, UnhandledAmfPipeline(pipeline))
-    case target => throw new Exception(s"Cannot resolve $target")
-    //    case _ => unit
+  protected def transform(unit: BaseUnit, pipeline: String, vendor: Vendor, amfConfig: AMFConfiguration): BaseUnit = {
+    vendor match {
+      case AsyncApi | AsyncApi20 | Raml08 | Raml10 | Oas20 | Oas30 =>
+        amfConfig.createClient().transform(unit, PipelineName.from(vendor.name, pipeline)).bu
+      case Amf    => TransformationPipelineRunner(UnhandledErrorHandler).run(unit, UnhandledAmfPipeline(pipeline))
+      case target => throw new Exception(s"Cannot resolve $target")
+      //    case _ => unit
+    }
   }
 
   object UnhandledAmfPipeline {

--- a/amf-client/shared/src/test/scala/amf/resolution/ResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/ResolutionTest.scala
@@ -1,5 +1,6 @@
 package amf.resolution
 
+import amf.client.environment.AMFConfiguration
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.remote._
@@ -13,9 +14,9 @@ abstract class ResolutionTest extends FunSuiteCycleTests with ResolutionCapabili
   val defaultPipelineToUse: String  = TransformationPipeline.DEFAULT_PIPELINE
   val defaultVendor: Option[Vendor] = None
 
-  override def transform(unit: BaseUnit, config: CycleConfig): BaseUnit = {
+  override def transform(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): BaseUnit = {
     val pipeline = config.pipeline.getOrElse(defaultPipelineToUse)
     val vendor   = config.transformWith.orElse(defaultVendor).getOrElse(config.target)
-    transform(unit, pipeline, vendor)
+    transform(unit, pipeline, vendor, amfConfig)
   }
 }

--- a/amf-client/shared/src/test/scala/amf/resolution/SecurityResolutionTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/SecurityResolutionTest.scala
@@ -1,7 +1,7 @@
 package amf.resolution
 
 import amf.client.remod.amfcore.config.RenderOptions
-import amf.core.remote.{Amf, Oas20JsonHint, Raml10YamlHint}
+import amf.core.remote.{Amf, Oas20, Oas20JsonHint, Raml10, Raml10YamlHint}
 
 class SecurityResolutionTest extends ResolutionTest {
 

--- a/amf-client/shared/src/test/scala/amf/validation/Async20MultiPlatformValidationsTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/Async20MultiPlatformValidationsTest.scala
@@ -1,13 +1,13 @@
 package amf.validation
 
 import amf.Async20Profile
-import amf.core.remote.{AsyncYamlHint, Hint}
+import amf.core.remote.{Async20YamlHint, Hint}
 import org.scalatest.Matchers
 
 class Async20MultiPlatformValidationsTest extends MultiPlatformReportGenTest with Matchers {
   override val basePath: String    = "file://amf-client/shared/src/test/resources/validations/async20/validations/"
   override val reportsPath: String = "amf-client/shared/src/test/resources/validations/reports/async20/"
-  override val hint: Hint          = AsyncYamlHint
+  override val hint: Hint          = Async20YamlHint
 
   test("Draft 7 - conditional sub schemas validations") {
     validate("draft-7-validations.yaml", Some("draft-7-validations.report"), Async20Profile)

--- a/amf-client/shared/src/test/scala/amf/validation/Async20UniquePlatformUnitValidationsTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/Async20UniquePlatformUnitValidationsTest.scala
@@ -1,14 +1,14 @@
 package amf.validation
 
 import amf.Async20Profile
-import amf.core.remote.{AsyncJsonHint, AsyncYamlHint, Hint}
+import amf.core.remote.{Async20JsonHint, Async20YamlHint, Hint}
 import org.scalatest.Matchers
 
 class Async20UniquePlatformUnitValidationsTest extends UniquePlatformReportGenTest with Matchers {
   val asyncPath: String            = "file://amf-client/shared/src/test/resources/validations/async20/"
   override val basePath: String    = asyncPath + "validations/"
   override val reportsPath: String = "amf-client/shared/src/test/resources/validations/reports/async20/"
-  override val hint: Hint          = AsyncYamlHint
+  override val hint: Hint          = Async20YamlHint
 
   test("Required channel object") {
     validate("required-channels.yaml", Some("required-channels.report"), Async20Profile)
@@ -245,7 +245,10 @@ class Async20UniquePlatformUnitValidationsTest extends UniquePlatformReportGenTe
   }
 
   test("JSON with duplicate keys") {
-    validate("duplicate-keys.json", Some("duplicate-keys.report"), Async20Profile, overridedHint = Some(AsyncJsonHint))
+    validate("duplicate-keys.json",
+             Some("duplicate-keys.report"),
+             Async20Profile,
+             overridedHint = Some(Async20JsonHint))
   }
 
   test("Components must use keys with certain regex") {

--- a/amf-client/shared/src/test/scala/amf/validation/BuilderModelValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/BuilderModelValidationTest.scala
@@ -49,8 +49,7 @@ class BuilderModelValidationTest extends AsyncFunSuite with FileAssertionTest wi
     val fragment = PayloadFragment(scalar, "application/yaml")
 
     for {
-      _ <- Validation(platform) // in order to initialize
-      s <- new AMFSerializer(fragment, "application/amf+yaml", WebAPIConfiguration.WebAPI().renderConfiguration).renderToString
+      s <- new AMFSerializer(fragment, "application/payload+yaml", WebAPIConfiguration.WebAPI().renderConfiguration).renderToString
     } yield {
       s should be("1\n") // without cuotes
     }

--- a/amf-client/shared/src/test/scala/amf/validation/FromJsonLDPayloadValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/FromJsonLDPayloadValidationTest.scala
@@ -2,7 +2,7 @@ package amf.validation
 
 import amf.core.unsafe.PlatformSecrets
 import amf.facades.Validation
-import amf.plugins.features.validation.PlatformValidator
+import amf.plugins.features.validation.{AMFValidatorPlugin, PlatformValidator}
 import amf.plugins.features.validation.emitters.{JSLibraryEmitter, ShaclJsonLdShapeGraphEmitter}
 import amf.{AmfProfile, Oas20Profile, Oas30Profile, Raml10Profile}
 import org.scalatest.AsyncFunSuite
@@ -57,8 +57,8 @@ class FromJsonLDPayloadValidationTest extends AsyncFunSuite with PlatformSecrets
     platform.resolve(path + file).flatMap { data =>
       val model = data.stream.toString
       Validation(platform).flatMap { validation =>
-        val effectiveValidations = validation.computeValidations(expectedReport.profile)
-        val shapes               = validation.shapesGraph(effectiveValidations)
+        val effectiveValidations = AMFValidatorPlugin.computeValidations(expectedReport.profile)
+        val shapes               = AMFValidatorPlugin.shapesGraph(effectiveValidations)
         val jsLibrary            = new JSLibraryEmitter(None).emitJS(effectiveValidations.effective.values.toSeq)
 
         jsLibrary match {

--- a/amf-client/shared/src/test/scala/amf/validation/GenericPayloadValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/GenericPayloadValidationTest.scala
@@ -73,9 +73,8 @@ class GenericPayloadValidationTest extends AsyncFunSuite with PlatformSecrets {
       val config = RAMLConfiguration.RAML10().withErrorHandlerProvider(() => UnhandledErrorHandler)
       val client = config.createClient()
       val candidates: Future[Seq[ValidationCandidate]] = for {
-        validation <- Validation(platform)
-        library    <- client.parse(payloadsPath + libraryFile).map(_.bu)
-        payload    <- client.parse(payloadsPath + payloadFile).map(_.bu)
+        library <- client.parse(payloadsPath + libraryFile).map(_.bu)
+        payload <- client.parse(payloadsPath + payloadFile, hint.vendor.mediaType).map(_.bu)
       } yield {
         // todo check with antonio, i removed the canonical shape from validation, so i need to resolve here
         ValidationTransformationPipeline(AmfProfile, library, UnhandledErrorHandler)

--- a/amf-client/shared/src/test/scala/amf/validation/JapaneseCycleTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/JapaneseCycleTest.scala
@@ -1,6 +1,7 @@
 package amf.validation
 
 import amf.client.remod.amfcore.config.RenderOptions
+import amf.core.remote.Syntax.Json
 import amf.core.remote._
 import amf.io.FunSuiteCycleTests
 
@@ -31,7 +32,7 @@ class JapaneseCycleTest extends FunSuiteCycleTests {
   }
 
   multiSourceTest("Json-LD resolves to OAS30", "oas30api.%s") { config =>
-    cycle(config.source, "cycled-oas30api.json", AmfJsonHint, Oas30)
+    cycle(config.source, "cycled-oas30api.json", AmfJsonHint, Oas30, syntax = Some(Json))
   }
 
   override def defaultRenderOptions: RenderOptions = RenderOptions().withSourceMaps.withPrettyPrint

--- a/amf-client/shared/src/test/scala/amf/validation/JsonSchemaUniquePlatformUnitValidationsTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/JsonSchemaUniquePlatformUnitValidationsTest.scala
@@ -2,6 +2,8 @@ package amf.validation
 
 import amf.client.parse.IgnoringErrorHandler
 import amf.client.remod.{AMFGraphConfiguration, AMFResult}
+import amf.client.environment.AMFConfiguration
+import amf.client.remod.AMFResult
 import amf.core.errorhandling.AMFErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.remote.{Hint, Oas20YamlHint}
@@ -27,8 +29,9 @@ class JsonSchemaUniquePlatformUnitValidationsTest extends UniquePlatformReportGe
     validate("unused-validation-facets.json", Some("unused-validation-facets.report"))
   }
 
-  override protected def parse(path: String, conf: AMFGraphConfiguration, finalHint: Hint): Future[AMFResult] = {
+  override protected def parse(path: String, conf: AMFConfiguration, finalHint: Hint): Future[AMFResult] = {
     // uses IgnoringErrorHandler as this was the previous (possibly unintentional) behaviour, but now made explicit
-    Future.successful(parseSchema(platform, path, "application/json", IgnoringErrorHandler()))
+    Future.successful(
+      parseSchema(platform, path, "application/json", conf.withErrorHandlerProvider(() => IgnoringErrorHandler)))
   }
 }

--- a/amf-client/shared/src/test/scala/amf/validation/UniquePlatformReportGenTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/UniquePlatformReportGenTest.scala
@@ -2,15 +2,17 @@ package amf.validation
 
 import _root_.org.scalatest.{Assertion, AsyncFunSuite}
 import amf._
-import amf.client.environment.{AsyncAPIConfiguration, WebAPIConfiguration}
+import amf.client.environment.{AMFConfiguration, AsyncAPIConfiguration, WebAPIConfiguration}
 import amf.client.parse.DefaultErrorHandler
+import amf.client.remod.{AMFGraphConfiguration, AMFResult}
+import amf.client.remod.amfcore.plugins.validate.ValidationConfiguration
 import amf.client.remod.{AMFGraphConfiguration, AMFResult}
 import amf.core.errorhandling.{AMFErrorHandler, AmfReportBuilder}
 import amf.core.remote.Syntax.Yaml
 import amf.core.remote._
 import amf.core.resolution.pipelines.TransformationPipelineRunner
 import amf.core.validation.AMFValidationReport
-import amf.facades.{AMFCompiler, Validation}
+import amf.facades.Validation
 import amf.io.FileAssertionTest
 import amf.plugins.document.webapi.resolution.pipelines.ValidationTransformationPipeline
 
@@ -58,7 +60,6 @@ sealed trait AMFValidationReportGenTest extends AsyncFunSuite with FileAssertion
     val initialConfig = WebAPIConfiguration.WebAPI().merge(AsyncAPIConfiguration.Async20())
     val finalHint     = overridedHint.getOrElse(hint)
     for {
-      validation <- Validation(platform) // see AMFPluginRegistry.dataNodeValidatorPluginForMediaType
       withProfile <- if (profileFile.isDefined)
         initialConfig.withCustomValidationsEnabled.flatMap(_.withCustomProfile(directory + profileFile.get))
       else Future.successful(initialConfig)
@@ -75,7 +76,7 @@ sealed trait AMFValidationReportGenTest extends AsyncFunSuite with FileAssertion
     }
   }
 
-  protected def parse(path: String, conf: AMFGraphConfiguration, finalHint: Hint): Future[AMFResult] = {
+  protected def parse(path: String, conf: AMFConfiguration, finalHint: Hint): Future[AMFResult] = {
     val client = conf.createClient()
     client.parse(path, finalHint.vendor.mediaType)
   }

--- a/amf-client/shared/src/test/scala/amf/validation/ValidAsyncModelParserTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/ValidAsyncModelParserTest.scala
@@ -1,7 +1,7 @@
 package amf.validation
 
 import amf.Async20Profile
-import amf.core.remote.{AsyncYamlHint, Hint}
+import amf.core.remote.{Async20YamlHint, Hint}
 
 class ValidAsyncModelParserTest extends ValidModelTest {
 
@@ -106,5 +106,5 @@ class ValidAsyncModelParserTest extends ValidModelTest {
   }
 
   override val basePath: String = "file://amf-client/shared/src/test/resources/validations/async20/"
-  override val hint: Hint       = AsyncYamlHint
+  override val hint: Hint       = Async20YamlHint
 }

--- a/amf-client/shared/src/test/scala/amf/validation/ValidationTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/ValidationTest.scala
@@ -4,14 +4,12 @@ import _root_.org.scalatest.AsyncFunSuite
 import amf._
 import amf.client.environment.{OASConfiguration, RAMLConfiguration, WebAPIConfiguration}
 import amf.client.parse.DefaultErrorHandler
+import amf.client.environment.{OASConfiguration, RAMLConfiguration}
 import amf.client.remod.AMFGraphConfiguration
 import amf.client.remod.amfcore.plugins.validate.ValidationConfiguration
 import amf.client.remod.amfcore.resolution.PipelineName
-import amf.core.AMFSerializer
-import amf.core.emitter.RenderOptions
 import amf.core.remote._
 import amf.core.resolution.pipelines.TransformationPipeline
-import amf.core.services.RuntimeResolver
 import amf.core.unsafe.PlatformSecrets
 import amf.core.validation.{AMFValidationReport, SeverityLevels}
 import amf.facades.Validation
@@ -283,9 +281,8 @@ class ValidationTest extends AsyncFunSuite with PlatformSecrets {
   private def parseAndValidate(url: String,
                                profileName: ProfileName,
                                config: => AMFGraphConfiguration): Future[AMFValidationReport] = {
+    val client = config.createClient()
     for {
-      validation  <- Validation(platform)
-      client      <- Future.successful(config.createClient())
       parseResult <- client.parse(url)
       report      <- client.validate(parseResult.bu, profileName)
     } yield {

--- a/amf-webapi/shared/src/main/scala/amf/client/convert/WebApiRegister.scala
+++ b/amf-webapi/shared/src/main/scala/amf/client/convert/WebApiRegister.scala
@@ -4,6 +4,7 @@ import amf.client.model.document._
 import amf.client.model.domain._
 import amf.core.metamodel.document.PayloadFragmentModel
 import amf.core.remote.Platform
+import amf.core.unsafe.PlatformSecrets
 import amf.plugins.document.webapi.metamodel.FragmentsTypesModels._
 import amf.plugins.document.webapi.model
 import amf.plugins.domain.{shapes, webapi}
@@ -22,7 +23,10 @@ import amf.validations.{
 
 /** Shared WebApi registrations. */
 // TODO: could be renamed to ApiRegister??
-object WebApiRegister {
+object WebApiRegister extends PlatformSecrets {
+
+  // TODO ARM remove when APIMF-3000 is done
+  def register(): Unit = register(platform)
 
   def register(platform: Platform): Unit = {
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/AdaptedWebApiPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/AdaptedWebApiPlugin.scala
@@ -1,20 +1,26 @@
 package amf.plugins.document.webapi
 
+import amf.client.remod.amfcore.plugins.{LowPriority, PluginPriority}
 import amf.client.remod.amfcore.plugins.parse.AMFParsePluginAdapter
 import amf.client.remod.amfcore.plugins.render.AMFRenderPluginAdapter
+import amf.core.Root
 
-object Async20ParsePlugin              extends AMFParsePluginAdapter(Async20Plugin)
-object Oas20ParsePlugin                extends AMFParsePluginAdapter(Oas20Plugin)
-object Oas30ParsePlugin                extends AMFParsePluginAdapter(Oas30Plugin)
-object Raml08ParsePlugin               extends AMFParsePluginAdapter(Raml08Plugin)
-object Raml10ParsePlugin               extends AMFParsePluginAdapter(Raml10Plugin)
-object PayloadParsePlugin              extends AMFParsePluginAdapter(PayloadPlugin)
+object Async20ParsePlugin extends AMFParsePluginAdapter(Async20Plugin)
+object Oas20ParsePlugin   extends AMFParsePluginAdapter(Oas20Plugin)
+object Oas30ParsePlugin   extends AMFParsePluginAdapter(Oas30Plugin)
+object Raml08ParsePlugin  extends AMFParsePluginAdapter(Raml08Plugin)
+object Raml10ParsePlugin  extends AMFParsePluginAdapter(Raml10Plugin)
+object PayloadParsePlugin extends AMFParsePluginAdapter(PayloadPlugin) {
+  override def priority: PluginPriority =
+    PluginPriority(10) // TODO ARM hack to give priority to External Fragment Plugin when vendor is note defined
+}
+
 object JsonSchemaParsePlugin           extends AMFParsePluginAdapter(JsonSchemaPlugin)
 object ExternalJsonYamlRefsParsePlugin extends AMFParsePluginAdapter(ExternalJsonYamlRefsPlugin)
 
 object Async20RenderPlugin    extends AMFRenderPluginAdapter(Async20Plugin, "application/yaml")
 object Oas20RenderPlugin      extends AMFRenderPluginAdapter(Oas20Plugin, "application/json")
-object Oas30RenderPlugin      extends AMFRenderPluginAdapter(Oas30Plugin, "application/yaml")
+object Oas30RenderPlugin      extends AMFRenderPluginAdapter(Oas30Plugin, "application/json") // TODO ARM Should be application/yaml??
 object Raml08RenderPlugin     extends AMFRenderPluginAdapter(Raml08Plugin, "application/yaml")
 object Raml10RenderPlugin     extends AMFRenderPluginAdapter(Raml10Plugin, "application/yaml")
 object PayloadRenderPlugin    extends AMFRenderPluginAdapter(PayloadPlugin, "application/json")

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/AsyncPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/AsyncPlugin.scala
@@ -79,15 +79,11 @@ object Async20Plugin extends AsyncPlugin {
   override def specContext(options: RenderOptions, errorHandler: AMFErrorHandler): AsyncSpecEmitterContext =
     new Async20SpecEmitterContext(errorHandler)
 
-  override protected def vendor: Vendor = AsyncApi20
+  override val vendors = Seq("application/asyncapi20", "application/asyncapi20+json", "application/asyncapi20+yaml")
 
-  /**
-    * List of media types used to encode serialisations of
-    * this domain
-    */
-  override def documentSyntaxes: Seq[String] = AsyncApi20.mediaType +: super.documentSyntaxes
-
-  override def validVendorsToReference: Seq[String] = super.validVendorsToReference :+ Raml10.name
+  override def validVendorsToReference: Seq[String] =
+    super.validVendorsToReference :+ "application/raml10+yaml" :+
+      "application/raml10"
 
   override val validationProfile: ProfileName = Async20Profile
 
@@ -139,4 +135,6 @@ object Async20Plugin extends AsyncPlugin {
 
   // TODO: Temporary, should be erased until synchronous validation profile building for dialects is implemented
   override def domainValidationProfiles: Seq[ValidationProfile] = Seq(Async20ValidationProfile)
+
+  override protected def vendor: Vendor = AsyncApi20
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/BaseWebApiPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/BaseWebApiPlugin.scala
@@ -34,7 +34,7 @@ trait BaseWebApiPlugin extends AMFDocumentPlugin with AMFValidationPlugin with P
     ExternalJsonYamlRefsPlugin
   )
 
-  def validVendorsToReference: Seq[String] = List(ExternalJsonYamlRefsPlugin.ID)
+  def validVendorsToReference: Seq[String] = List("application/refs+json")
 
   def specContext(options: RenderOptions, errorHandler: AMFErrorHandler): SpecEmitterContext
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/CrossSpecRestriction.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/CrossSpecRestriction.scala
@@ -14,7 +14,7 @@ trait CrossSpecRestriction { this: AMFDocumentPlugin =>
       implicit errorHandler: AMFErrorHandler): Unit = {
     val possibleReferencedVendors = vendors ++ validVendorsToReference
     optionalReferencedVendor.foreach { referencedVendor =>
-      if (!possibleReferencedVendors.contains(referencedVendor.name)) {
+      if (!possibleReferencedVendors.contains(referencedVendor.mediaType)) {
         referenceNodes(reference).foreach(node =>
           errorHandler.violation(InvalidCrossSpec, "", "Cannot reference fragments of another spec", node))
       }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/ExternalJsonYamlRefsPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/ExternalJsonYamlRefsPlugin.scala
@@ -84,7 +84,8 @@ class ExternalJsonYamlRefsPlugin extends JsonSchemaPlugin {
 
   override val ID: String = "JSON + Refs"
 
-  override val vendors: Seq[String] = Seq(ID)
+  override val vendors: Seq[String] =
+    Seq("application/json", "application/refs+json", "application/yaml", "application/refs+yaml")
 
   override def modelEntities: Seq[Obj] = Nil
 
@@ -94,7 +95,8 @@ class ExternalJsonYamlRefsPlugin extends JsonSchemaPlugin {
     * List of media types used to encode serialisations of
     * this domain
     */
-  override def documentSyntaxes: Seq[String] = Seq("application/json", "application/yaml")
+  override def documentSyntaxes: Seq[String] =
+    Seq("application/json", "application/refs+json", "application/yaml", "application/refs+yaml")
 
   /**
     * Parses an accepted document returning an optional BaseUnit

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/JsonSchemaPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/JsonSchemaPlugin.scala
@@ -24,7 +24,7 @@ import org.yaml.model._
 import scala.concurrent.{ExecutionContext, Future}
 
 class JsonSchemaPlugin extends AMFDocumentPlugin with PlatformSecrets {
-  override val vendors: Seq[String] = Seq(JsonSchema.name)
+  override val vendors: Seq[String] = Seq(JsonSchema.mediaType)
 
   override def modelEntities: Seq[Obj] = Nil
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/OasPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/OasPlugin.scala
@@ -149,13 +149,18 @@ object Oas20Plugin extends OasPlugin {
   // TODO: Temporary, should be erased until synchronous validation profile building for dialects is implemented
   override def domainValidationProfiles: Seq[ValidationProfile] = Seq(Oas20ValidationProfile)
 
-  override val vendors: Seq[String] = Seq(vendor.name)
+  override val vendors: Seq[String] = Seq(
+    "application/oas20+json",
+    "application/oas20+yaml",
+    "application/oas20",
+    "application/swagger+json",
+    "application/swagger20+json",
+    "application/swagger+yaml",
+    "application/swagger20+yaml",
+    "application/swagger",
+    "application/swagger20"
+  )
 
-  /**
-    * List of media types used to encode serialisations of
-    * this domain
-    */
-  override def documentSyntaxes: Seq[String] = Oas20.mediaType +: super.documentSyntaxes
 }
 
 object Oas30Plugin extends OasPlugin {
@@ -224,5 +229,12 @@ object Oas30Plugin extends OasPlugin {
   // TODO: Temporary, should be erased until synchronous validation profile building for dialects is implemented
   override def domainValidationProfiles: Seq[ValidationProfile] = Seq(ApiValidationProfiles.Oas30ValidationProfile)
 
-  override val vendors: Seq[String] = Seq(vendor.name)
+  override val vendors: Seq[String] = Seq(
+    "application/oas30+json",
+    "application/oas30+yaml",
+    "application/oas30",
+    "application/openapi30",
+    "application/openapi30+yaml",
+    "application/openapi30+json"
+  )
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/PayloadPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/PayloadPlugin.scala
@@ -22,7 +22,7 @@ object PayloadPlugin extends AMFDocumentPlugin {
 
   override val ID: String = Payload.name
 
-  val vendors: Seq[String] = Seq(Payload.name)
+  val vendors: Seq[String] = Seq(Payload.mediaType, "application/payload+json", "application/payload+yaml")
 
   override def modelEntities: Nil.type = Nil
 

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/RamlPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/RamlPlugin.scala
@@ -148,21 +148,6 @@ sealed trait RamlPlugin extends BaseWebApiPlugin with CrossSpecRestriction {
       }
     }
   }
-
-  /**
-    * List of media types used to encode serialisations of
-    * this domain
-    */
-  override def documentSyntaxes: Seq[String] = Seq(
-    "application/raml",
-    "application/raml+json",
-    "application/raml+yaml",
-    "text/yaml",
-    "text/x-yaml",
-    "application/yaml",
-    "application/x-yaml",
-    "text/vnd.yaml"
-  )
 }
 
 object Raml08Plugin extends RamlPlugin {
@@ -229,9 +214,16 @@ object Raml08Plugin extends RamlPlugin {
 
   override def domainValidationProfiles: Seq[ValidationProfile] = Seq(Raml08ValidationProfile)
 
-  override val vendors: Seq[String] = Seq(vendor.name)
+  override val vendors: Seq[String] = Seq("application/raml08", "application/raml08+yaml")
 
-  override def documentSyntaxes: Seq[String] = core.remote.Raml08.mediaType +: super.documentSyntaxes
+  /**
+    * List of media types used to encode serialisations of
+    * this domain
+    */
+  override def documentSyntaxes: Seq[String] = Seq(
+    "application/raml08",
+    "application/raml08+yaml"
+  )
 }
 
 object Raml10Plugin extends RamlPlugin {
@@ -299,11 +291,17 @@ object Raml10Plugin extends RamlPlugin {
 
   override def domainValidationProfiles: Seq[ValidationProfile] = Seq(Raml10ValidationProfile, AmfValidationProfile)
 
-  override val vendors: Seq[String] = Seq(vendor.name)
+  override val vendors: Seq[String] =
+    Seq("application/raml10", "application/raml10+yaml", "application/raml", "application/raml+yaml")
 
   /**
     * List of media types used to encode serialisations of
     * this domain
     */
-  override def documentSyntaxes: Seq[String] = core.remote.Raml10.mediaType +: super.documentSyntaxes
+  override def documentSyntaxes: Seq[String] = Seq(
+    "application/raml10",
+    "application/raml10+yaml",
+    "application/raml",
+    "application/raml+yaml"
+  )
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/references/RamlReferenceHandler.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/references/RamlReferenceHandler.scala
@@ -96,7 +96,7 @@ class RamlReferenceHandler(plugin: AMFParsePlugin) extends WebApiReferenceHandle
   }
 
   private def isRamlOrYaml(encodes: ExternalDomainElement) =
-    Raml10Plugin.documentSyntaxes.contains(encodes.mediaType.value())
+    encodes.mediaType.option().exists(_.contains("yaml"))
 
   private def hasDocumentAST(other: BaseUnit) =
     other.annotations.find(classOf[SourceAST]).exists(_.ast.isInstanceOf[YDocument])

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/stages/ExtendsResolutionStage.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/stages/ExtendsResolutionStage.scala
@@ -143,7 +143,7 @@ class ExtendsResolutionStage(profile: ProfileName, val keepEditingInfo: Boolean,
 
         val branches = ListBuffer[BranchContainer]()
 
-        val operationTree = OperationTreeBuilder(operation)(IgnoringErrorHandler()).build()
+        val operationTree = OperationTreeBuilder(operation)(IgnoringErrorHandler).build()
         val branchesObj   = Branches()(extendsContext)
 
         // Method branch

--- a/amf-webapi/shared/src/main/scala/amf/plugins/domain/webapi/resolution/ExtendsHelper.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/domain/webapi/resolution/ExtendsHelper.scala
@@ -298,6 +298,6 @@ object ExtendsHelper {
 }
 
 class CustomRaml08WebApiContext
-    extends Raml08WebApiContext("", Nil, ParserContext(config = ParseConfiguration(IgnoringErrorHandler())))
+    extends Raml08WebApiContext("", Nil, ParserContext(config = ParseConfiguration(IgnoringErrorHandler)))
 class CustomRaml10WebApiContext
-    extends Raml10WebApiContext("", Nil, ParserContext(config = ParseConfiguration(IgnoringErrorHandler())))
+    extends Raml10WebApiContext("", Nil, ParserContext(config = ParseConfiguration(IgnoringErrorHandler)))

--- a/amf-webapi/shared/src/test/scala/amf/plugins/document/webapi/parser/spec/jsonschema/AstIndexTest.scala
+++ b/amf-webapi/shared/src/test/scala/amf/plugins/document/webapi/parser/spec/jsonschema/AstIndexTest.scala
@@ -1,5 +1,6 @@
 package amf.plugins.document.webapi.parser.spec.jsonschema
 
+import amf.client.environment.WebAPIConfiguration
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.parser.{ParserContext, YMapOps}
 import amf.core.unsafe.PlatformSecrets
@@ -166,7 +167,13 @@ trait IndexHelper extends PlatformSecrets {
   def obtainIndex(pathToFile: String, version: JSONSchemaVersion): AstIndex = {
     val content = platform.fs.syncFile(pathToFile).read()
     val doc     = JsonParser(content).document()
-    val ctx     = new Async20WebApiContext("loc", Seq(), ParserContext(eh = UnhandledErrorHandler))
+    val ctx =
+      new Async20WebApiContext(
+        "loc",
+        Seq(),
+        ParserContext(
+          config =
+            WebAPIConfiguration.WebAPI().withErrorHandlerProvider(() => UnhandledErrorHandler).parseConfiguration))
     AstIndexBuilder.buildAst(doc.node, AliasCounter(), version)(WebApiShapeParserContextAdapter(ctx))
   }
 }


### PR DESCRIPTION
Depends on:
- https://github.com/aml-org/amf-aml/pull/280

Failing suits:
- UniqueAmfGraphSyamlConversionExceptionTest: changes on ids and profile name (profile comes empty on parsing errors, because are collected at code, any constraint of profile was applied).
- ProductionResolutionTest: big apis that changes on jsonlds flattened goldens (missing source maps).
- InvalidsRefElementTest: Throws file not found, and the files doesn't exists
- OasInterSpecRefsReportTest error changes
- Raml10CycleTestByDirectory: vendor mediatype changed for external fragments (looks ok). New annotations appears (on external fragment would be ok, but other cases are weird).
- MultiAmfGraphSyamlConversionExceptionTest : validation profile is not present at the report, as are parsing reports.
- RamlInterSpecRefsReportTest: the diff or the report is the profile name, looks ok.
- JsonSchemaUniquePlatformUnitValidationsTest: only fails when all the suits are run.

Discussion topics:
- Profile field of the validation report on parsing and transformation results. What we should do? left it empty? use the source vendor matching profile?
