### PR TITLE
(delta fix) avoid converting value of key to string in abstract declarations

### DIFF
--- a/amf-client/shared/src/test/resources/validations/raml/trait-definition-numeric-name.raml
+++ b/amf-client/shared/src/test/resources/validations/raml/trait-definition-numeric-name.raml
@@ -1,0 +1,9 @@
+#%RAML 1.0
+
+title: Some API
+
+traits:
+  403:
+    responses:
+      403:
+        description: Access forbidden now to access the resource.

--- a/amf-client/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
@@ -275,5 +275,9 @@ class ValidRamlModelParserTest extends ValidModelTest {
     checkValid("/raml/api-with-includes-with-spaces/api.raml")
   }
 
+  test("Trait definition with numeric name") {
+    checkValid("/raml/trait-definition-numeric-name.raml")
+  }
+
   override val hint: Hint = RamlYamlHint
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/AbstractDeclarationParsers.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/AbstractDeclarationParsers.scala
@@ -102,7 +102,7 @@ case class AbstractDeclarationParser(declaration: AbstractDeclaration, parent: S
 
   private def named(declaration: AbstractDeclaration): Unit = {
     map.key.foreach { key =>
-      val element = ScalarNode(key).string()
+      val element = ScalarNode(key).text()
       declaration.set(AbstractDeclarationModel.Name, element, element.annotations)
     }
   }


### PR DESCRIPTION
Before the annotations PR the value of the key was obtained with `_.as[YScalar].text`, while `ScalarNode(key).string()` on the other hand interprets the value of the YScalar as a string and fails with a violation if it is numeric.
`ScalarNode(key).text()` uses the previous behaviour obtaining the string through the text value of the YScalar.