### PR TITLE
Save unlinked shape ids in `InheritedShapes`

### DIFF
--- a/amf-webapi/shared/src/main/scala/amf/plugins/domain/shapes/resolution/stages/shape_normalization/ShapeCanonizer.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/domain/shapes/resolution/stages/shape_normalization/ShapeCanonizer.scala
@@ -124,7 +124,7 @@ sealed case class ShapeCanonizer()(implicit val context: NormalizationContext) e
       val superTypes = shape.inherits
       val oldInherits: Seq[Shape] = if (context.keepEditingInfo) shape.inherits.collect {
         case rec: RecursiveShape => rec
-        case shape: Shape        => shape.link(shape.name.value()).asInstanceOf[Shape]
+        case shape: Shape        => shape
       } else Nil
       shape.fields.removeField(ShapeModel.Inherits) // i need to remove the resolved type without inhertis, because later it will be added to cache once it will be fully resolved
       var accShape: Shape                             = normalizeWithoutCaching(shape)


### PR DESCRIPTION
Fixes #967 (somewhat)

Saving the original unlinked shape ids in `InheritedShapes` allows them to be correctly translated during resolve, and therefore can be found in the final resolved document.

Without this change the link ids that are stored in `InheritedShapes` cannot be found in the final resolved document.