### PR TITLE
APIMF-2994: delete legacy parsing/rendering options with additional refactors

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/plugins/document/apicontract/contexts/emitter/oas/OasSpecEmitterContext.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/plugins/document/apicontract/contexts/emitter/oas/OasSpecEmitterContext.scala
@@ -143,8 +143,7 @@ case class Oas3SpecEmitterFactory(override val spec: OasSpecEmitterContext) exte
 
 abstract class OasSpecEmitterContext(eh: AMFErrorHandler,
                                      refEmitter: RefEmitter = OasRefEmitter,
-                                     options: ShapeRenderOptions = ShapeRenderOptions(),
-                                     val compactEmission: Boolean = true)
+                                     options: ShapeRenderOptions = ShapeRenderOptions())
     extends OasLikeSpecEmitterContext(eh, refEmitter, options)
     with CompactableEmissionContext {
 
@@ -161,9 +160,8 @@ abstract class OasSpecEmitterContext(eh: AMFErrorHandler,
 
 class Oas3SpecEmitterContext(eh: AMFErrorHandler,
                              refEmitter: RefEmitter = OasRefEmitter,
-                             options: ShapeRenderOptions = ShapeRenderOptions(),
-                             compactEmission: Boolean = true)
-    extends OasSpecEmitterContext(eh, refEmitter, options, compactEmission) {
+                             options: ShapeRenderOptions = ShapeRenderOptions())
+    extends OasSpecEmitterContext(eh, refEmitter, options) {
   override val anyOfKey: String                = "anyOf"
   val schemaVersion: SchemaVersion             = OAS30SchemaVersion(Schema)
   override val factory: OasSpecEmitterFactory  = Oas3SpecEmitterFactory(this)
@@ -173,9 +171,8 @@ class Oas3SpecEmitterContext(eh: AMFErrorHandler,
 
 class Oas2SpecEmitterContext(eh: AMFErrorHandler,
                              refEmitter: RefEmitter = OasRefEmitter,
-                             options: ShapeRenderOptions = ShapeRenderOptions(),
-                             compactEmission: Boolean = true)
-    extends OasSpecEmitterContext(eh, refEmitter, options, compactEmission) {
+                             options: ShapeRenderOptions = ShapeRenderOptions())
+    extends OasSpecEmitterContext(eh, refEmitter, options) {
   val schemaVersion: SchemaVersion             = OAS20SchemaVersion(Schema)
   override val factory: OasSpecEmitterFactory  = new Oas2SpecEmitterFactory(this)
   override val vendor: Vendor                  = Oas20

--- a/amf-api-contract/shared/src/main/scala/amf/plugins/document/apicontract/parser/spec/common/emitters/factory/OasDomainElementEmitterFactory.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/plugins/document/apicontract/parser/spec/common/emitters/factory/OasDomainElementEmitterFactory.scala
@@ -1,5 +1,6 @@
 package amf.plugins.document.apicontract.parser.spec.common.emitters.factory
 
+import amf.client.remod.amfcore.config.ShapeRenderOptions
 import amf.core.annotations.{DeclaredElement, DeclaredHeader, SynthesizedField}
 import amf.core.emitter.{PartEmitter, SpecOrdering}
 import amf.core.errorhandling.AMFErrorHandler
@@ -90,7 +91,7 @@ case class Oas20EmitterFactory()(implicit val ctx: Oas2SpecEmitterContext) exten
 
 object Oas20EmitterFactory {
   def apply(eh: AMFErrorHandler): Oas20EmitterFactory =
-    Oas20EmitterFactory()(new Oas2SpecEmitterContext(eh, compactEmission = false))
+    Oas20EmitterFactory()(new Oas2SpecEmitterContext(eh, options = ShapeRenderOptions().withoutCompactedEmission))
 }
 
 case class Oas30EmitterFactory()(implicit val ctx: Oas3SpecEmitterContext) extends OasEmitterFactory {
@@ -119,7 +120,7 @@ case class Oas30EmitterFactory()(implicit val ctx: Oas3SpecEmitterContext) exten
 
 object Oas30EmitterFactory {
   def apply(eh: AMFErrorHandler): Oas30EmitterFactory =
-    Oas30EmitterFactory()(new Oas3SpecEmitterContext(eh, compactEmission = false))
+    Oas30EmitterFactory()(new Oas3SpecEmitterContext(eh, options = ShapeRenderOptions().withoutCompactedEmission))
 }
 
 trait OasEmitterFactory extends OasLikeEmitterFactory {

--- a/amf-api-contract/shared/src/main/scala/amf/plugins/document/apicontract/parser/spec/declaration/emitters/OasLikeShapeEmitterContextAdapter.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/plugins/document/apicontract/parser/spec/declaration/emitters/OasLikeShapeEmitterContextAdapter.scala
@@ -66,9 +66,4 @@ case class OasLikeShapeEmitterContextAdapter(spec: OasLikeSpecEmitterContext)
                             pointer: Seq[String],
                             schemaPath: Seq[(String, String)]): Seq[Emitter] =
     spec.factory.typeEmitters(shape, ordering, ignored, references, pointer, schemaPath)
-
-  override def compactEmission: Boolean = spec match {
-    case oasCtx: OasSpecEmitterContext => oasCtx.compactEmission
-    case _                             => options.compactedEmission
-  }
 }

--- a/amf-api-contract/shared/src/main/scala/amf/plugins/render/Oas20RenderPlugin.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/plugins/render/Oas20RenderPlugin.scala
@@ -35,5 +35,5 @@ object Oas20RenderPlugin extends OasRenderPlugin {
   override def priority: PluginPriority = NormalPriority
 
   private def specContext(options: RenderOptions, errorHandler: AMFErrorHandler): OasSpecEmitterContext =
-    new Oas2SpecEmitterContext(errorHandler, compactEmission = options.isWithCompactedEmission)
+    new Oas2SpecEmitterContext(errorHandler, compactEmission = options.shapeRenderOptions.isWithCompactedEmission)
 }

--- a/amf-api-contract/shared/src/main/scala/amf/plugins/render/Oas20RenderPlugin.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/plugins/render/Oas20RenderPlugin.scala
@@ -35,5 +35,5 @@ object Oas20RenderPlugin extends OasRenderPlugin {
   override def priority: PluginPriority = NormalPriority
 
   private def specContext(options: RenderOptions, errorHandler: AMFErrorHandler): OasSpecEmitterContext =
-    new Oas2SpecEmitterContext(errorHandler, compactEmission = options.shapeRenderOptions.isWithCompactedEmission)
+    new Oas2SpecEmitterContext(errorHandler, options = options.shapeRenderOptions)
 }

--- a/amf-api-contract/shared/src/main/scala/amf/plugins/render/Oas30RenderPlugin.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/plugins/render/Oas30RenderPlugin.scala
@@ -35,5 +35,5 @@ object Oas30RenderPlugin extends OasRenderPlugin {
     }
 
   private def specContext(options: RenderOptions, errorHandler: AMFErrorHandler): Oas3SpecEmitterContext =
-    new Oas3SpecEmitterContext(errorHandler, compactEmission = options.isWithCompactedEmission)
+    new Oas3SpecEmitterContext(errorHandler, compactEmission = options.shapeRenderOptions.isWithCompactedEmission)
 }

--- a/amf-api-contract/shared/src/main/scala/amf/plugins/render/Oas30RenderPlugin.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/plugins/render/Oas30RenderPlugin.scala
@@ -35,5 +35,5 @@ object Oas30RenderPlugin extends OasRenderPlugin {
     }
 
   private def specContext(options: RenderOptions, errorHandler: AMFErrorHandler): Oas3SpecEmitterContext =
-    new Oas3SpecEmitterContext(errorHandler, compactEmission = options.shapeRenderOptions.isWithCompactedEmission)
+    new Oas3SpecEmitterContext(errorHandler, options = options.shapeRenderOptions)
 }

--- a/amf-cli/shared/src/main/scala/amf/facades/AMFCompiler.scala
+++ b/amf-cli/shared/src/main/scala/amf/facades/AMFCompiler.scala
@@ -1,12 +1,8 @@
 package amf.facades
 
-import amf.client.remod.amfcore.config.ParsingOptionsConverter
 import amf.client.remod.{AMFGraphConfiguration, ParseConfiguration}
-import amf.core.client.ParsingOptions
-import amf.core.errorhandling.AMFErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.parser.ParserContext
-import amf.core.registries.AMFPluginsRegistry
 import amf.core.remote.Syntax.{Json, PlainText, Yaml}
 import amf.core.remote._
 import amf.core.{CompilerContext, CompilerContextBuilder, Root, AMFCompiler => ModularCompiler}

--- a/amf-cli/shared/src/test/scala/amf/cycle/JsonSchemaCycle.scala
+++ b/amf-cli/shared/src/test/scala/amf/cycle/JsonSchemaCycle.scala
@@ -194,7 +194,7 @@ object JsonSchemaTestEmitters {
 case class JsonSchemaTestEmitter(to: JSONSchemaVersion) extends SchemaEmitter {
 
   private val options =
-    ImmutableShapeRenderOptions().withSchemaVersion(SchemaVersion.toClientOptions(to)).withCompactedEmission
+    ImmutableShapeRenderOptions().withSchemaVersion(SchemaVersion.toClientOptions(to))
 
   override def emitSchema(fragment: DataTypeFragment)(implicit executionContext: ExecutionContext): String = {
     val shape     = fragment.encodes

--- a/amf-cli/shared/src/test/scala/amf/emit/ShapeToJsonSchemaTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/emit/ShapeToJsonSchemaTest.scala
@@ -2,6 +2,7 @@ package amf.emit
 
 import amf.client.environment.WebAPIConfiguration
 import amf.client.remod.AMFGraphConfiguration
+import amf.client.remod.amfcore.config.{RenderOptions, ShapeRenderOptions}
 import amf.client.remod.amfcore.resolution.PipelineName
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.{BaseUnit, Document, Module}
@@ -146,7 +147,9 @@ class ShapeToJsonSchemaTest extends AsyncFunSuite with FileAssertionTest {
                     findShapeFunc: BaseUnit => Option[AnyShape],
                     renderFn: AnyShape => String = toJsonSchema,
                     hint: Hint = Raml10YamlHint): Future[Assertion] = {
-    val config = WebAPIConfiguration.WebAPI()
+    val config = WebAPIConfiguration
+      .WebAPI()
+      .withRenderOptions(RenderOptions().withShapeRenderOptions(ShapeRenderOptions().withoutCompactedEmission))
     val jsonSchema: Future[String] = for {
       unit <- parse(file, config)
     } yield {

--- a/amf-cli/shared/src/test/scala/amf/io/BuildCycleTests.scala
+++ b/amf-cli/shared/src/test/scala/amf/io/BuildCycleTests.scala
@@ -7,8 +7,7 @@ import amf.client.errorhandling.DefaultErrorHandler
 import amf.client.remod.AMFGraphConfiguration
 import amf.client.remod.amfcore.config.RenderOptions
 import amf.core.errorhandling.AMFErrorHandler
-import amf.client.remod.amfcore.config.{ParsingOptionsConverter, RenderOptions}
-import amf.core.client.ParsingOptions
+import amf.client.remod.amfcore.config.RenderOptions
 import amf.core.errorhandling.{AMFErrorHandler, UnhandledErrorHandler}
 import amf.core.model.document.BaseUnit
 import amf.core.rdf.RdfModel

--- a/amf-cli/shared/src/test/scala/amf/javaparser/org/raml/json_schema/TypeToJsonSchemaTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/javaparser/org/raml/json_schema/TypeToJsonSchemaTest.scala
@@ -38,22 +38,22 @@ trait TypeToJsonSchemaTest extends ModelValidationTest {
 }
 
 class RamlTypeToNormalJsonSchemaTest extends TypeToJsonSchemaTest {
-  override def path: String                         = "amf-cli/shared/src/test/resources/org/raml/json_schema/"
-  override def inputFileName: String                = "input.raml"
-  override def outputFileName: String               = "output.json"
-  override def renderShape(shape: AnyShape): String = toJsonSchema(shape, WebAPIConfiguration.WebAPI())
-}
-
-class RamlTypeToCompactJsonSchemaTest extends TypeToJsonSchemaTest {
   override def path: String           = "amf-cli/shared/src/test/resources/org/raml/json_schema/"
   override def inputFileName: String  = "input.raml"
-  override def outputFileName: String = "compact-output.json"
+  override def outputFileName: String = "output.json"
   override def renderShape(shape: AnyShape): String =
-    buildJsonSchema(
+    toJsonSchema(
       shape,
       WebAPIConfiguration
         .WebAPI()
-        .withRenderOptions(RenderOptions().withShapeRenderOptions(ShapeRenderOptions().withCompactedEmission)))
+        .withRenderOptions(RenderOptions().withShapeRenderOptions(ShapeRenderOptions().withoutCompactedEmission)))
+}
+
+class RamlTypeToCompactJsonSchemaTest extends TypeToJsonSchemaTest {
+  override def path: String                         = "amf-cli/shared/src/test/resources/org/raml/json_schema/"
+  override def inputFileName: String                = "input.raml"
+  override def outputFileName: String               = "compact-output.json"
+  override def renderShape(shape: AnyShape): String = buildJsonSchema(shape, WebAPIConfiguration.WebAPI())
 }
 
 // Uncomment to add suite
@@ -68,15 +68,9 @@ class RamlTypeToCompactJsonSchemaTest extends TypeToJsonSchemaTest {
 //
 
 trait OasTypeToCompactJsonSchemaTest extends TypeToJsonSchemaTest {
-  override def inputFileName: String  = "input.json"
-  override def outputFileName: String = "compact-output.json"
-  override def renderShape(shape: AnyShape): String = {
-    buildJsonSchema(
-      shape,
-      WebAPIConfiguration
-        .WebAPI()
-        .withRenderOptions(RenderOptions().withShapeRenderOptions(ShapeRenderOptions().withCompactedEmission)))
-  }
+  override def inputFileName: String                = "input.json"
+  override def outputFileName: String               = "compact-output.json"
+  override def renderShape(shape: AnyShape): String = buildJsonSchema(shape, WebAPIConfiguration.WebAPI())
 }
 
 case class Oas20TypeToCompactJsonSchemaTest() extends OasTypeToCompactJsonSchemaTest {

--- a/amf-cli/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
@@ -1,7 +1,7 @@
 package amf.resolution
 
 import amf.client.environment.AMFConfiguration
-import amf.client.remod.amfcore.config.RenderOptions
+import amf.client.remod.amfcore.config.{RenderOptions, ShapeRenderOptions}
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.remote.Syntax.Yaml
@@ -936,7 +936,7 @@ class EditingResolutionTest extends ResolutionTest {
       Oas30JsonHint,
       Oas30,
       directory = cyclePath + "oas3/",
-      renderOptions = Some(RenderOptions().withoutCompactedEmission),
+      renderOptions = Some(RenderOptions().withShapeRenderOptions(ShapeRenderOptions().withoutCompactedEmission)),
       transformWith = Some(Oas30)
     )
   }
@@ -948,7 +948,7 @@ class EditingResolutionTest extends ResolutionTest {
       Oas20JsonHint,
       Oas20,
       directory = cyclePath + "cycle/oas20/json/",
-      renderOptions = Some(RenderOptions().withoutCompactedEmission),
+      renderOptions = Some(RenderOptions().withShapeRenderOptions(ShapeRenderOptions().withoutCompactedEmission)),
       transformWith = Some(Oas20)
     )
   }

--- a/amf-shapes/shared/src/main/scala/amf/plugins/document/apicontract/contexts/emitter/oas/OasCompactEmitterFactory.scala
+++ b/amf-shapes/shared/src/main/scala/amf/plugins/document/apicontract/contexts/emitter/oas/OasCompactEmitterFactory.scala
@@ -15,9 +15,10 @@ import amf.plugins.document.apicontract.parser.spec.declaration.emitters.schema.
 trait OasCompactEmitterFactory {
 
   protected implicit val shapeCtx: OasLikeShapeEmitterContext
+  lazy val compactEmissionEnabled: Boolean = shapeCtx.options.compactedEmission
 
   def declaredTypesEmitter: (Seq[Shape], Seq[BaseUnit], SpecOrdering) => EntryEmitter =
-    if (shapeCtx.compactEmission)
+    if (compactEmissionEnabled)
       CompactOasTypesEmitters.apply
     else
       OasDeclaredTypesEmitters.apply
@@ -28,7 +29,7 @@ trait OasCompactEmitterFactory {
                    references: Seq[BaseUnit],
                    pointer: Seq[String],
                    schemaPath: Seq[(String, String)]): Seq[Emitter] = {
-    if (shapeCtx.compactEmission)
+    if (compactEmissionEnabled)
       CompactOasTypeEmitter(shape, ordering, ignored, references, pointer, schemaPath).emitters()
     else
       OasTypeEmitter(shape, ordering, ignored, references, pointer, schemaPath).emitters()
@@ -37,7 +38,7 @@ trait OasCompactEmitterFactory {
   def recursiveShapeEmitter(shape: RecursiveShape,
                             ordering: SpecOrdering,
                             schemaPath: Seq[(String, String)]): EntryEmitter =
-    if (shapeCtx.compactEmission)
+    if (compactEmissionEnabled)
       new CompactOasRecursiveShapeEmitter(shape, ordering, schemaPath)
     else
       OasRecursiveShapeEmitter(shape, ordering, schemaPath)

--- a/amf-shapes/shared/src/main/scala/amf/plugins/document/apicontract/parser/spec/common/JsonSchemaSerializer.scala
+++ b/amf-shapes/shared/src/main/scala/amf/plugins/document/apicontract/parser/spec/common/JsonSchemaSerializer.scala
@@ -1,29 +1,12 @@
 package amf.plugins.document.apicontract.parser.spec.common
 
-import amf.client.execution.BaseExecutionEnvironment
 import amf.client.remod.AMFGraphConfiguration
-import amf.client.remod.amfcore.config.{ShapeRenderOptions => ImmutableShapeRenderOptions}
 import amf.core.AMFSerializer
-import amf.core.emitter.BaseEmitters._
-import amf.core.emitter.{EntryEmitter, ShapeRenderOptions, SpecOrdering}
-import amf.core.errorhandling.AMFErrorHandler
 import amf.core.model.document.Document
-import amf.core.model.domain.{DomainElement, Shape}
-import amf.core.parser.Position
 import amf.core.remote.JsonSchema
 import amf.core.unsafe.PlatformSecrets
 import amf.plugins.document.apicontract.annotations.{GeneratedJSONSchema, JSONSchemaRoot, ParsedJSONSchema}
-import amf.plugins.document.apicontract.parser.spec.declaration.{
-  JSONSchemaDraft4SchemaVersion,
-  JSONSchemaUnspecifiedVersion,
-  JSONSchemaVersion,
-  SchemaVersion
-}
 import amf.plugins.domain.shapes.models.AnyShape
-import org.yaml.model.YDocument
-import org.yaml.model.YDocument.EntryBuilder
-
-import scala.concurrent.ExecutionContext
 
 trait JsonSchemaSerializer extends PlatformSecrets {
   // todo, check if its resolved?

--- a/amf-shapes/shared/src/main/scala/amf/plugins/document/apicontract/parser/spec/declaration/SchemaVersion.scala
+++ b/amf-shapes/shared/src/main/scala/amf/plugins/document/apicontract/parser/spec/declaration/SchemaVersion.scala
@@ -1,6 +1,9 @@
 package amf.plugins.document.apicontract.parser.spec.declaration
 
-import amf.client.render.{JSONSchemaVersion => ClientJSONSchemaVersion, JSONSchemaVersions => ClientJSONSchemaVersions}
+import amf.client.exported.config.{
+  JSONSchemaVersion => ClientJSONSchemaVersion,
+  JSONSchemaVersions => ClientJSONSchemaVersions
+}
 import amf.plugins.document.apicontract.parser.spec.declaration.SchemaPosition.Position
 
 abstract class SchemaVersion(val name: String) {

--- a/amf-shapes/shared/src/main/scala/amf/plugins/document/apicontract/validation/remote/PlatformSchemaValidator.scala
+++ b/amf-shapes/shared/src/main/scala/amf/plugins/document/apicontract/validation/remote/PlatformSchemaValidator.scala
@@ -150,7 +150,7 @@ abstract class PlatformPayloadValidator(shape: Shape, override val configuration
   }
 
   private def generateSchemaString(shape: Shape, validationProcessor: ValidationProcessor): Option[CharSequence] = {
-    val renderOptions = ShapeRenderOptions().withoutDocumentation.withCompactedEmission
+    val renderOptions = ShapeRenderOptions().withoutDocumentation
       .withSchemaVersion(JsonSchemaDraft7)
       .withEmitWarningForUnsupportedValidationFacets(true)
     val declarations = List(shape)

--- a/amf-shapes/shared/src/main/scala/amf/plugins/document/apicontract/validation/remote/PlatformSchemaValidator.scala
+++ b/amf-shapes/shared/src/main/scala/amf/plugins/document/apicontract/validation/remote/PlatformSchemaValidator.scala
@@ -1,10 +1,9 @@
 package amf.plugins.document.apicontract.validation.remote
 
+import amf.client.exported.config.JsonSchemaDraft7
 import amf.client.plugins.{ScalarRelaxedValidationMode, ValidationMode}
-import amf.client.remod.amfcore.config.ShapeRenderOptions
+import amf.client.remod.amfcore.config.{ParsingOptions, ShapeRenderOptions}
 import amf.client.remod.amfcore.plugins.validate.ValidationConfiguration
-import amf.client.render.JsonSchemaDraft7
-import amf.core.client.ParsingOptions
 import amf.core.errorhandling.{AMFErrorHandler, UnhandledErrorHandler}
 import amf.core.model.DataType
 import amf.core.model.document.PayloadFragment

--- a/amf-shapes/shared/src/main/scala/amf/remod/ClientJsonSchemaShapeSerializer.scala
+++ b/amf-shapes/shared/src/main/scala/amf/remod/ClientJsonSchemaShapeSerializer.scala
@@ -4,9 +4,6 @@ import amf.client.convert.shapeconverters.ShapeClientConverters._
 import amf.client.execution.BaseExecutionEnvironment
 import amf.client.exported.AMFGraphConfiguration
 import amf.client.model.domain.AnyShape
-import amf.client.render.ShapeRenderOptions
-import amf.core.emitter.ShapeRenderOptions.toImmutable
-import amf.core.emitter.{ShapeRenderOptions => CoreShapeRenderOptions}
 import amf.plugins.document.apicontract.parser.spec.common.JsonSchemaSerializer
 
 object ClientJsonSchemaShapeSerializer extends JsonSchemaSerializer {


### PR DESCRIPTION
- move compactEmission parameter exclusively to ShapeRenderOptions (this implies changing default value for compactEmission in ShapeRenderOptions)
- clean up compact emission context to only use shape render options value.