### PR TITLE
Changed 'non-inclusive' language. Adopted amf-core 4.1.222

### DIFF
--- a/amf-webapi.versions
+++ b/amf-webapi.versions
@@ -1,4 +1,4 @@
 amf.webapi=4.8.0-SNAPSHOT
-amf.core=4.2.219
+amf.core=4.2.222
 amf.custom.validations=5.2.0-SNAPSHOT
 amf.model=3.1.0

--- a/amf-webapi/shared/src/main/scala/amf/plugins/domain/webapi/resolution/stages/DomainElementMerging.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/domain/webapi/resolution/stages/DomainElementMerging.scala
@@ -84,11 +84,11 @@ case class DomainElementMerging()(implicit ctx: RamlWebApiContext) {
     }
   }
 
-  val whiteListFields = List(DomainElementModel.CustomDomainProperties, OperationModel.Optional)
+  val allowedListFields = List(DomainElementModel.CustomDomainProperties, OperationModel.Optional)
 
   private def isValidToAdd(main: DomainElement, field: Field): Boolean =
     main match {
-      case ScalarShape(_, _) | NodeShape(_, _) => (whiteListFields ::: main.meta.fields).contains(field)
+      case ScalarShape(_, _) | NodeShape(_, _) => (allowedListFields ::: main.meta.fields).contains(field)
       case _                                   => true
     }
 


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-core/pull/285