### PR TITLE
APIMF-3203: refactor ParseConfiguration to avoid using predefined configs

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/ExtendsHelper.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/ExtendsHelper.scala
@@ -14,7 +14,7 @@ import amf.core.client.scala.parse.document.ParserContext
 import amf.core.client.scala.transform.stages.ReferenceResolutionStage
 import amf.core.client.scala.transform.stages.helpers.ResolvedNamedEntity
 import amf.core.internal.annotations.{Aliases, LexicalInformation, SourceAST, SourceLocation}
-import amf.core.internal.parser.ParseConfiguration
+import amf.core.internal.parser.{LimitedParseConfig, CompilerConfiguration}
 import amf.core.internal.parser.domain.{Annotations, FragmentRef}
 import amf.core.internal.render.SpecOrdering
 import amf.core.internal.validation.CoreValidations
@@ -241,7 +241,7 @@ case class ExtendsHelper(profile: ProfileName,
       case m: DeclaresModel =>
         model.annotations.find(classOf[Aliases]).getOrElse(Aliases(Set())).aliases.foreach {
           case (alias, (fullUrl, _)) if m.id == fullUrl =>
-            val nestedCtx = new Raml10WebApiContext("", Nil, ParserContext(config = ParseConfiguration(ctx.eh)))
+            val nestedCtx = new Raml10WebApiContext("", Nil, ParserContext(config = LimitedParseConfig(ctx.eh)))
             m.declares.foreach { declaration =>
               extractDeclarationToContextWithLocalAndRootName(declaration, m)(nestedCtx)
             }
@@ -298,6 +298,6 @@ object ExtendsHelper {
 }
 
 class CustomRaml08WebApiContext
-    extends Raml08WebApiContext("", Nil, ParserContext(config = ParseConfiguration(IgnoringErrorHandler)))
+    extends Raml08WebApiContext("", Nil, ParserContext(config = LimitedParseConfig(IgnoringErrorHandler)))
 class CustomRaml10WebApiContext
-    extends Raml10WebApiContext("", Nil, ParserContext(config = ParseConfiguration(IgnoringErrorHandler)))
+    extends Raml10WebApiContext("", Nil, ParserContext(config = LimitedParseConfig(IgnoringErrorHandler)))

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlEndpointParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlEndpointParser.scala
@@ -26,7 +26,7 @@ import amf.core.client.scala.model.domain.{AmfArray, AmfScalar, DataNode, Shape,
 import amf.core.client.scala.parse.document.ParserContext
 import amf.core.internal.annotations.{LexicalInformation, VirtualElement}
 import amf.core.internal.parser.domain.Annotations
-import amf.core.internal.parser.{ParseConfiguration, YMapOps}
+import amf.core.internal.parser.{CompilerConfiguration, YMapOps}
 import amf.core.internal.utils.{AmfStrings, IdCounter, TemplateUri}
 import amf.shapes.client.scala.model.domain.ScalarShape
 import amf.shapes.internal.spec.RamlWebApiContextType
@@ -134,14 +134,14 @@ abstract class RamlEndpointParser(entry: YMapEntry,
             case _: Raml08WebApiContext =>
               new Raml08WebApiContext(ctx.loc,
                                       ctx.refs,
-                                      ParserContext(config = ParseConfiguration(ctx.eh)),
+                                      ParserContext(config = ctx.wrapped.config),
                                       Some(ctx.declarations),
                                       ctx.contextType,
                                       ctx.options)
             case _ =>
               new Raml10WebApiContext(ctx.loc,
                                       ctx.refs,
-                                      ParserContext(config = ParseConfiguration(ctx.eh)),
+                                      ParserContext(config = ctx.wrapped.config),
                                       Some(ctx.declarations),
                                       ctx.contextType,
                                       ctx.options)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtendsResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtendsResolutionStage.scala
@@ -21,7 +21,7 @@ import amf.core.client.scala.parse.document.ParserContext
 import amf.core.client.scala.transform.stages.{ReferenceResolutionStage, TransformationStep}
 import amf.core.internal.annotations.{ErrorDeclaration, SourceAST}
 import amf.core.internal.metamodel.domain.DomainElementModel
-import amf.core.internal.parser.{ParseConfiguration, YNodeLikeOps}
+import amf.core.internal.parser.{LimitedParseConfig, CompilerConfiguration, YNodeLikeOps}
 import amf.core.internal.render.SpecOrdering
 import amf.core.internal.unsafe.PlatformSecrets
 import amf.core.internal.utils.AliasCounter
@@ -54,8 +54,8 @@ class ExtendsResolutionStage(profile: ProfileName, val keepEditingInfo: Boolean,
     /** Default to raml10 context. */
     def ctx(): RamlWebApiContext = profile match {
       case Raml08Profile =>
-        new Raml08WebApiContext("", Nil, ParserContext(config = ParseConfiguration(errorHandler)))
-      case _ => new Raml10WebApiContext("", Nil, ParserContext(config = ParseConfiguration(errorHandler)))
+        new Raml08WebApiContext("", Nil, ParserContext(config = LimitedParseConfig(errorHandler)))
+      case _ => new Raml10WebApiContext("", Nil, ParserContext(config = LimitedParseConfig(errorHandler)))
     }
 
     def resolve[T <: BaseUnit](model: T): T =

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtensionsResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtensionsResolutionStage.scala
@@ -20,7 +20,7 @@ import amf.core.internal.metamodel.document.BaseUnitModel
 import amf.core.internal.metamodel.domain.common.{DescriptionField, DisplayNameField, NameFieldSchema, NameFieldShacl}
 import amf.core.internal.metamodel.domain.{DomainElementModel, ShapeModel}
 import amf.core.internal.metamodel.{Field, Type}
-import amf.core.internal.parser.ParseConfiguration
+import amf.core.internal.parser.LimitedParseConfig
 import amf.core.internal.unsafe.PlatformSecrets
 import amf.core.internal.validation.CoreValidations.ResolutionValidation
 import amf.shapes.internal.domain.metamodel.common.{DocumentationField, ExamplesField}
@@ -89,8 +89,8 @@ abstract class ExtensionLikeResolutionStage[T <: ExtensionLike[_ <: DomainElemen
 
   /** Default to raml10 context. */
   implicit val ctx: RamlWebApiContext = profile match {
-    case Raml08Profile => new Raml08WebApiContext("", Nil, ParserContext(config = ParseConfiguration(errorHandler)))
-    case _             => new Raml10WebApiContext("", Nil, ParserContext(config = ParseConfiguration(errorHandler)))
+    case Raml08Profile => new Raml08WebApiContext("", Nil, ParserContext(config = LimitedParseConfig(errorHandler)))
+    case _             => new Raml10WebApiContext("", Nil, ParserContext(config = LimitedParseConfig(errorHandler)))
   }
 
   def removeExtends(document: Document): BaseUnit = {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/InferredOverlayTypeExampleTransform.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/InferredOverlayTypeExampleTransform.scala
@@ -5,7 +5,7 @@ import amf.apicontract.internal.spec.raml.parser.context.Raml10WebApiContext
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.domain.{DomainElement, Shape}
 import amf.core.client.scala.parse.document.ParserContext
-import amf.core.internal.parser.ParseConfiguration
+import amf.core.internal.parser.LimitedParseConfig
 import amf.core.internal.parser.domain.FieldEntry
 import amf.core.internal.render.SpecOrdering
 import amf.shapes.client.scala.model.domain.ScalarShape
@@ -39,7 +39,7 @@ class InferredOverlayTypeExampleTransform(implicit val errorHandler: AMFErrorHan
     }).node
     // TODO: should be able to configure wether the DataNodeParser uses a ctx or not. Removing WebApiContext dependency from DataNodeParser is not a simple refactor.
     val dummyCtx =
-      new Raml10WebApiContext("", Seq(), ParserContext(config = ParseConfiguration(errorHandler)))
+      new Raml10WebApiContext("", Seq(), ParserContext(config = LimitedParseConfig(errorHandler)))
     val result = NodeDataNodeParser(node, example.id, quiet = true)(WebApiShapeParserContextAdapter(dummyCtx)).parse()
     result.dataNode.foreach { dataNode =>
       example.set(ExampleModel.StructuredValue, dataNode, example.structuredValue.annotations)

--- a/amf-api-contract/shared/src/test/scala/amf/shapes/internal/spec/jsonschema/ref/AstIndexTest.scala
+++ b/amf-api-contract/shared/src/test/scala/amf/shapes/internal/spec/jsonschema/ref/AstIndexTest.scala
@@ -5,7 +5,7 @@ import amf.apicontract.internal.spec.async.parser.context.Async20WebApiContext
 import amf.apicontract.internal.spec.common.parser.WebApiShapeParserContextAdapter
 import amf.core.client.scala.errorhandling.UnhandledErrorHandler
 import amf.core.client.scala.parse.document.ParserContext
-import amf.core.internal.parser.YMapOps
+import amf.core.internal.parser.{LimitedParseConfig, YMapOps}
 import amf.core.internal.unsafe.PlatformSecrets
 import amf.core.internal.utils.AliasCounter
 import amf.shapes.internal.spec.common.parser.YMapEntryLike
@@ -169,12 +169,7 @@ trait IndexHelper extends PlatformSecrets {
     val content = platform.fs.syncFile(pathToFile).read()
     val doc     = JsonParser(content).document()
     val ctx =
-      new Async20WebApiContext(
-        "loc",
-        Seq(),
-        ParserContext(
-          config =
-            WebAPIConfiguration.WebAPI().withErrorHandlerProvider(() => UnhandledErrorHandler).parseConfiguration))
+      new Async20WebApiContext("loc", Seq(), ParserContext(config = LimitedParseConfig(UnhandledErrorHandler)))
     AstIndexBuilder.buildAst(doc.node, AliasCounter(), version)(WebApiShapeParserContextAdapter(ctx))
   }
 }

--- a/amf-cli/shared/src/main/scala/amf/cli/internal/commands/CommandHelper.scala
+++ b/amf-cli/shared/src/main/scala/amf/cli/internal/commands/CommandHelper.scala
@@ -9,7 +9,7 @@ import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.common.transform._
 import amf.core.client.scala.transform.pipelines.TransformationPipeline
-import amf.core.internal.parser.{AMFCompiler, ParseConfiguration}
+import amf.core.internal.parser.{AMFCompiler, CompilerConfiguration}
 import amf.core.internal.remote.{Cache, Context, Platform, Vendor}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -65,7 +65,7 @@ trait CommandHelper {
         Option(effectiveMediaType(config.inputMediaType, config.inputFormat)),
         Context(platform),
         cache = Cache(),
-        ParseConfiguration(configuration)
+        CompilerConfiguration(configuration)
       ).build()
       parsed map { parsed =>
         configClient.transform(parsed, PipelineName.from(vendorMediaType, PipelineId.Default)).bu

--- a/amf-cli/shared/src/test/scala/amf/compiler/ApikitApiSyncCasesTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/compiler/ApikitApiSyncCasesTest.scala
@@ -7,7 +7,7 @@ import amf.core.client.common.validation.Raml10Profile
 import amf.core.client.scala.AMFGraphConfiguration
 import amf.core.client.scala.errorhandling.DefaultErrorHandler
 import amf.core.client.scala.resource.ResourceLoader
-import amf.core.internal.parser.{AMFCompiler, ParseConfiguration}
+import amf.core.internal.parser.{AMFCompiler, CompilerConfiguration}
 import amf.core.internal.remote.{Cache, Context, FileNotFound}
 import amf.core.internal.unsafe.PlatformSecrets
 import org.mulesoft.common.test.AsyncBeforeAndAfterEach
@@ -35,7 +35,7 @@ class ApikitApiSyncCasesTest extends AsyncBeforeAndAfterEach with PlatformSecret
         None,
         base = Context(platform),
         cache = Cache(),
-        ParseConfiguration(
+        CompilerConfiguration(
           WebAPIConfiguration
             .WebAPI()
             .withResourceLoaders(List(new URNResourceLoader(mappings)))

--- a/amf-cli/shared/src/test/scala/amf/compiler/CompilerTestBuilder.scala
+++ b/amf-cli/shared/src/test/scala/amf/compiler/CompilerTestBuilder.scala
@@ -30,7 +30,7 @@ trait CompilerTestBuilder extends PlatformSecrets {
       url,
       Some(hint.vendor.mediaType + "+" + hint.syntax.extension),
       cache = cache.getOrElse(Cache()),
-      parserConfig = amfConfig.parseConfiguration,
+      parserConfig = amfConfig.compilerConfiguration,
       base = Context(platform)
     )
 

--- a/amf-cli/shared/src/test/scala/amf/cycle/JsonSchemaSuite.scala
+++ b/amf-cli/shared/src/test/scala/amf/cycle/JsonSchemaSuite.scala
@@ -8,7 +8,7 @@ import amf.core.client.scala.AMFResult
 import amf.core.client.scala.config.ParsingOptions
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.parse.document.{ParserContext, SchemaReference, SyamlParsedDocument}
-import amf.core.internal.parser.{ParseConfiguration, Root}
+import amf.core.internal.parser.{LimitedParseConfig, CompilerConfiguration, Root}
 import amf.core.internal.remote.Platform
 import amf.shapes.client.scala.model.domain.AnyShape
 import amf.shapes.internal.spec.ShapeParserContext
@@ -49,7 +49,7 @@ trait JsonSchemaSuite {
   private def getBogusParserCtx(location: String, options: ParsingOptions, eh: AMFErrorHandler): ShapeParserContext = {
     val ctx = new JsonSchemaWebApiContext(location,
                                           Seq(),
-                                          ParserContext(config = ParseConfiguration(eh)),
+                                          ParserContext(config = LimitedParseConfig(eh)),
                                           None,
                                           options,
                                           JSONSchemaDraft7SchemaVersion)

--- a/amf-cli/shared/src/test/scala/amf/emit/ExampleToJsonTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/emit/ExampleToJsonTest.scala
@@ -7,7 +7,7 @@ import amf.core.client.scala.errorhandling.{DefaultErrorHandler, UnhandledErrorH
 import amf.core.client.scala.model.document.{BaseUnit, ExternalFragment}
 import amf.core.client.scala.parse.document.ParserContext
 import amf.core.internal.annotations.SourceAST
-import amf.core.internal.parser.ParseConfiguration
+import amf.core.internal.parser.{LimitedParseConfig, CompilerConfiguration}
 import amf.io.FileAssertionTest
 import amf.shapes.client.scala.model.domain.Example
 import amf.shapes.client.scala.model.domain.{AnyShape, Example}
@@ -83,7 +83,7 @@ class ExampleToJsonTest extends AsyncFunSuite with FileAssertionTest {
         case Some(a) =>
           val ast = a.ast.asInstanceOf[YDocument].as[YMap]
           val context =
-            new Raml10WebApiContext("", Nil, ParserContext(config = ParseConfiguration(DefaultErrorHandler())))
+            new Raml10WebApiContext("", Nil, ParserContext(config = LimitedParseConfig(DefaultErrorHandler())))
           val anyShape = AnyShape()
           RamlExamplesParser(ast, "example", "examples", anyShape, DefaultExampleOptions)(
             WebApiShapeParserContextAdapter(context)).parse()

--- a/amf-cli/shared/src/test/scala/amf/resolution/TypeResolutionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/TypeResolutionTest.scala
@@ -10,7 +10,7 @@ import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.Shape
 import amf.core.client.scala.parse.document.ParserContext
 import amf.core.client.scala.vocabulary.Namespace
-import amf.core.internal.parser.ParseConfiguration
+import amf.core.internal.parser.{LimitedParseConfig, CompilerConfiguration}
 import amf.core.internal.remote.{Raml10, Raml10YamlHint}
 import amf.io.FunSuiteCycleTests
 import amf.shapes.client.scala.model.domain.UnionShape
@@ -24,7 +24,7 @@ class TypeResolutionTest extends FunSuiteCycleTests with CompilerTestBuilder {
     val adopt: Shape => Unit = shape => { shape.adopted("/test") }
 
     val ramlCtx: Raml10WebApiContext =
-      new Raml10WebApiContext("", Nil, ParserContext(config = ParseConfiguration(UnhandledErrorHandler)))
+      new Raml10WebApiContext("", Nil, ParserContext(config = LimitedParseConfig(UnhandledErrorHandler)))
 
     implicit val ctx: ShapeParserContext = WebApiShapeParserContextAdapter(ramlCtx)
 

--- a/amf-cli/shared/src/test/scala/amf/resolution/merge/JsonMergePatchTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/merge/JsonMergePatchTest.scala
@@ -13,7 +13,7 @@ import amf.core.client.scala.model.document.Document
 import amf.core.client.scala.model.domain.{DataNode, ScalarNode}
 import amf.core.client.scala.parse.document.ParserContext
 import amf.core.internal.convert.BaseUnitConverter
-import amf.core.internal.parser.{ParseConfiguration, _}
+import amf.core.internal.parser.{CompilerConfiguration, _}
 import amf.core.internal.remote.Vendor.AMF
 import amf.core.internal.render.BaseEmitters.traverse
 import amf.core.internal.render.SpecOrdering
@@ -129,7 +129,7 @@ class JsonMergePatchTest extends MultiJsonldAsyncFunSuite with Matchers with Fil
     def getMerger: JsonMergePatch = AsyncJsonMergePatch()
 
     def getBogusParserCtx: AsyncWebApiContext =
-      new Async20WebApiContext("loc", Seq(), ParserContext(config = ParseConfiguration(DefaultErrorHandler())))
+      new Async20WebApiContext("loc", Seq(), ParserContext(config = LimitedParseConfig(DefaultErrorHandler())))
 
     def renderToString(document: Document, renderOptions: RenderOptions = defaultRenderOptions): String =
       new AMFRenderer(document, AMF, renderOptions, None).renderToString

--- a/amf-cli/shared/src/test/scala/amf/resolution/stages/DomainElementMergingTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/stages/DomainElementMergingTest.scala
@@ -3,7 +3,7 @@ package amf.resolution.stages
 import amf.apicontract.client.scala.model.domain.EndPoint
 import amf.core.client.scala.errorhandling.UnhandledErrorHandler
 import amf.core.client.scala.parse.document.ParserContext
-import amf.core.internal.parser.ParseConfiguration
+import amf.core.internal.parser.{LimitedParseConfig, CompilerConfiguration}
 import amf.apicontract.client.scala.model.domain.templates.{ParametrizedTrait, Trait}
 import amf.apicontract.internal.spec.common.transformation.stage.DomainElementMerging
 import amf.apicontract.internal.spec.raml.parser.context.Raml10WebApiContext
@@ -105,6 +105,6 @@ class DomainElementMergingTest extends FunSuite {
   }
 
   private def ctx: Raml10WebApiContext = {
-    new Raml10WebApiContext("", Nil, ParserContext(config = ParseConfiguration(UnhandledErrorHandler)))
+    new Raml10WebApiContext("", Nil, ParserContext(config = LimitedParseConfig(UnhandledErrorHandler)))
   }
 }


### PR DESCRIPTION
When simplifing the interface of ParseConfiguration, there is no need to provide an execution context and therefor the global context is avoided during resolution.

depends on https://github.com/aml-org/amf-aml/pull/328 and https://github.com/aml-org/amf-core/pull/292