### PR TITLE
APIMF-3097: fix multiple uses pointing to same file

### DIFF
--- a/amf-client/shared/src/test/resources/validations/multiple-uses/library.raml
+++ b/amf-client/shared/src/test/resources/validations/multiple-uses/library.raml
@@ -1,0 +1,2 @@
+#%RAML 1.0 Library
+

--- a/amf-client/shared/src/test/resources/validations/multiple-uses/multiple-uses.raml
+++ b/amf-client/shared/src/test/resources/validations/multiple-uses/multiple-uses.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0
+title: test-multiple-uses-pointing-to-same-file
+version: 1.0
+
+uses:
+  first: library.raml
+  second: library.raml

--- a/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -594,4 +594,8 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
   test("RAML union type with nil when applying extension") {
     validate("valid-extension/extension.raml")
   }
+
+  test("multiple uses objects pointing to the same library file") {
+    validate("multiple-uses/multiple-uses.raml")
+  }
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/RamlPlugin.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/RamlPlugin.scala
@@ -1,9 +1,10 @@
 package amf.plugins.document.webapi
 
 import amf._
-import amf.core.client.ParsingOptions
 import amf.client.remod.amfcore.config.RenderOptions
 import amf.client.remod.amfcore.plugins.parse.AMFParsePluginAdapter
+import amf.core.Root
+import amf.core.client.ParsingOptions
 import amf.core.errorhandling.ErrorHandler
 import amf.core.exception.InvalidDocumentHeaderException
 import amf.core.model.document._
@@ -15,13 +16,11 @@ import amf.core.parser.{
   ParsedReference,
   ParserContext,
   RefContainer,
-  ReferenceKind,
   UnspecifiedReference
 }
 import amf.core.remote.{Platform, Raml, Vendor}
 import amf.core.resolution.pipelines.ResolutionPipeline
 import amf.core.validation.core.ValidationProfile
-import amf.core.{CompilerContext, Root}
 import amf.plugins.document.webapi.contexts.emitter.raml.{
   Raml08SpecEmitterContext,
   Raml10SpecEmitterContext,
@@ -108,7 +107,7 @@ sealed trait RamlPlugin extends BaseWebApiPlugin with CrossSpecRestriction {
   private def validateReferencesToLibraries(reference: ParsedReference, ctx: ParserContext): Unit = {
     val refs: Seq[RefContainer] = reference.origin.refs
     val allKinds                = refs.map(_.linkType)
-    val definedKind             = if (allKinds.size > 1) UnspecifiedReference else allKinds.head
+    val definedKind             = if (allKinds.distinct.size > 1) UnspecifiedReference else allKinds.head
     val nodes                   = refs.map(_.node)
     reference.unit match {
       case _: Module => // if is a library, kind should be LibraryReference

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/async/AsyncApiDocumentParser.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/async/AsyncApiDocumentParser.scala
@@ -11,7 +11,7 @@ import amf.plugins.document.webapi.contexts.parser.async.AsyncWebApiContext
 import amf.plugins.document.webapi.parser.spec.async.parser._
 import amf.plugins.document.webapi.parser.spec.common._
 import amf.plugins.document.webapi.parser.spec.declaration.{
-  AsycnReferencesParser,
+  AsyncReferencesParser,
   OasLikeCreativeWorkParser,
   OasLikeTagsParser
 }
@@ -49,7 +49,7 @@ abstract class AsyncApiDocumentParser(root: Root)(implicit val ctx: AsyncWebApiC
     val map = root.parsed.asInstanceOf[SyamlParsedDocument].document.as[YMap]
     ctx.setJsonSchemaAST(map)
 
-    val references = AsycnReferencesParser(root.references).parse()
+    val references = AsyncReferencesParser(root.references).parse()
     parseDeclarations(map)
 
     val api = parseApi(map).add(SourceVendor(ctx.vendor))

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/ReferencesParsers.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/parser/spec/declaration/ReferencesParsers.scala
@@ -95,7 +95,7 @@ case class ReferencesParser(baseUnit: BaseUnit, id: String, key: String, map: YM
   }
 }
 
-case class AsycnReferencesParser(references: Seq[ParsedReference])(implicit ctx: WebApiContext)
+case class AsyncReferencesParser(references: Seq[ParsedReference])(implicit ctx: WebApiContext)
     extends CommonReferencesParser(references) {
   override protected def parseLibraries(declarations: ReferenceCollector[BaseUnit]): Unit = Unit
 }


### PR DESCRIPTION
- fixed case where multiple objects of the `uses:` facet point to the same file (fixes [APIMF-3097](https://www.mulesoft.org/jira/browse/APIMF-3097))
- renamed method with `Asycn` typo
