### PR TITLE
APIMF-2996: scala and platform interface cleanup

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/platform/AMFConfiguration.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/platform/AMFConfiguration.scala
@@ -66,6 +66,11 @@ class AMFConfiguration private[amf] (private[amf] override val _internal: scala.
 
   def withDialect(path: String): ClientFuture[AMFConfiguration] = _internal.withDialect(path).asClient
 
+  def forInstance(url: String): ClientFuture[AMFConfiguration] = _internal.forInstance(url).asClient
+
+  def forInstance(url: String, mediaType: String): ClientFuture[AMFConfiguration] =
+    _internal.forInstance(url, Some(mediaType)).asClient
+
   override def withShapePayloadPlugin(plugin: AMFShapePayloadValidationPlugin): AMFConfiguration =
     _internal.withPlugin(PayloadValidationPluginMatcher.asInternal(plugin))
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/platform/AMFElementClient.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/platform/AMFElementClient.scala
@@ -13,7 +13,7 @@ import amf.core.client.platform.model.document.BaseUnit
 import amf.core.client.platform.model.domain.DomainElement
 import amf.core.internal.convert.ClientErrorHandlerConverter._
 import amf.shapes.client.platform.model.domain.AnyShape
-import amf.shapes.client.platform.render.JsonSchemaShapeRenderer
+import amf.shapes.client.platform.render.{JsonSchemaShapeRenderer, RamlShapeRenderer}
 import org.yaml.builder.DocBuilder
 
 import scala.scalajs.js.annotation.JSExportAll
@@ -33,6 +33,8 @@ class AMFElementClient private[amf] (private val _internal: InternalAMFElementCl
 
   def toJsonSchema(element: AnyShape): String    = JsonSchemaShapeRenderer.toJsonSchema(element, getConfiguration())
   def buildJsonSchema(element: AnyShape): String = JsonSchemaShapeRenderer.buildJsonSchema(element, getConfiguration())
+
+  def toRamlDatatype(element: AnyShape): String = RamlShapeRenderer.toRamlDatatype(element, getConfiguration())
 
   def renderToBuilder[T](element: DomainElement, mediaType: String, builder: DocBuilder[T]): Unit =
     ApiDomainElementEmitter.emitToBuilder(element, mediaType, obtainEH, builder)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/platform/model/domain/Message.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/platform/model/domain/Message.scala
@@ -1,7 +1,6 @@
 package amf.apicontract.client.platform.model.domain
 
 import amf.apicontract.client.platform.model.domain.bindings.MessageBindings
-import amf.apicontract.client.scala.model.domain
 import amf.apicontract.internal.convert.ApiClientConverters._
 import amf.core.client.platform.model.domain.{DomainElement, Linkable, NamedDomainElement}
 import amf.core.client.platform.model.{BoolField, StrField}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/AMFConfiguration.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/AMFConfiguration.scala
@@ -206,13 +206,13 @@ class AMFConfiguration private[amf] (override private[amf] val resolvers: AMFRes
   override def withPlugins(plugins: List[AMFPlugin[_]]): AMFConfiguration =
     super._withPlugins(plugins)
 
-  override def withEntities(entities: Map[String, ModelDefaultBuilder]): AMFConfiguration =
+  private[amf] override def withEntities(entities: Map[String, ModelDefaultBuilder]): AMFConfiguration =
     super._withEntities(entities)
 
-  override def withAnnotations(annotations: Map[String, AnnotationGraphLoader]): AMFConfiguration =
+  private[amf] override def withAnnotations(annotations: Map[String, AnnotationGraphLoader]): AMFConfiguration =
     super._withAnnotations(annotations)
 
-  override def withValidationProfile(profile: ValidationProfile): AMFConfiguration =
+  private[amf] override def withValidationProfile(profile: ValidationProfile): AMFConfiguration =
     super._withValidationProfile(profile)
 
   override def withTransformationPipeline(pipeline: TransformationPipeline): AMFConfiguration =

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/AMFConfiguration.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/AMFConfiguration.scala
@@ -34,7 +34,7 @@ import amf.core.client.scala.errorhandling.ErrorHandlerProvider
 import amf.core.client.scala.execution.ExecutionEnvironment
 import amf.core.client.scala.model.domain.AnnotationGraphLoader
 import amf.core.client.scala.resource.ResourceLoader
-import amf.core.client.scala.transform.pipelines.TransformationPipeline
+import amf.core.client.scala.transform.TransformationPipeline
 import amf.core.internal.metamodel.ModelDefaultBuilder
 import amf.core.internal.plugins.AMFPlugin
 import amf.core.internal.registries.AMFRegistry

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/AMFElementClient.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/AMFElementClient.scala
@@ -9,7 +9,7 @@ import amf.core.client.common.validation.{ProfileName, Raml10Profile}
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.{DataNode, DomainElement}
 import amf.shapes.client.scala.model.domain.AnyShape
-import amf.shapes.client.scala.render.JsonSchemaShapeRenderer
+import amf.shapes.client.scala.render.{JsonSchemaShapeRenderer, RamlShapeRenderer}
 import org.yaml.model.{YMapEntry, YNode}
 
 class AMFElementClient private[amf] (override protected val configuration: AMFConfiguration)
@@ -19,6 +19,8 @@ class AMFElementClient private[amf] (override protected val configuration: AMFCo
 
   def toJsonSchema(element: AnyShape): String    = JsonSchemaShapeRenderer.toJsonSchema(element, configuration)
   def buildJsonSchema(element: AnyShape): String = JsonSchemaShapeRenderer.buildJsonSchema(element, configuration)
+
+  def toRamlDatatype(element: AnyShape): String = RamlShapeRenderer.toRamlDatatype(element, configuration)
 
   def renderElement(element: DomainElement, mediaType: String): YNode =
     ApiDomainElementEmitter.emit(element, mediaType, configuration.errorHandlerProvider.errorHandler())

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Callback.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Callback.scala
@@ -30,7 +30,7 @@ case class Callback(fields: Fields, annotations: Annotations) extends NamedDomai
   override def meta: CallbackModel.type = CallbackModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String =
+  private[amf] override def componentId: String =
     "/" + name.option().getOrElse("default-callback").urlComponentEncoded +
       s"/${expression.option().getOrElse("default-expression").urlComponentEncoded}"
   override def nameField: Field = Name

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/CorrelationId.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/CorrelationId.scala
@@ -17,8 +17,8 @@ class CorrelationId(override val fields: Fields, override val annotations: Annot
   def withDescription(description: String): this.type = set(CorrelationIdModel.Description, description)
   def withIdLocation(idLocation: String): this.type   = set(CorrelationIdModel.Location, idLocation)
 
-  override def meta: CorrelationIdModel.type = CorrelationIdModel
-  override def componentId: String           = "/" + name.option().getOrElse("default-id")
+  override def meta: CorrelationIdModel.type    = CorrelationIdModel
+  private[amf] override def componentId: String = "/" + name.option().getOrElse("default-id")
 
   override def nameField: Field = CorrelationIdModel.Name
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Encoding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Encoding.scala
@@ -36,7 +36,8 @@ case class Encoding(fields: Fields, annotations: Annotations) extends DomainElem
   override def meta: EncodingModel.type = EncodingModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + propertyName.option().getOrElse("default-encoding").urlComponentEncoded
+  private[amf] override def componentId: String =
+    "/" + propertyName.option().getOrElse("default-encoding").urlComponentEncoded
 }
 
 object Encoding {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/EndPoint.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/EndPoint.scala
@@ -76,8 +76,8 @@ class EndPoint(override val fields: Fields, override val annotations: Annotation
   override def meta: EndPointModel.type = EndPointModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/end-points/" + path.value().urlComponentEncoded
-  override def nameField: Field    = Name
+  private[amf] override def componentId: String = "/end-points/" + path.value().urlComponentEncoded
+  override def nameField: Field                 = Name
 }
 
 object EndPoint {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/License.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/License.scala
@@ -20,7 +20,7 @@ case class License(fields: Fields, annotations: Annotations) extends NamedDomain
   override def meta = LicenseModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/license"
+  private[amf] override def componentId: String = "/license"
 
   override def nameField: Field = Name
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Message.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Message.scala
@@ -57,7 +57,7 @@ class Message(override val fields: Fields, override val annotations: Annotations
 
   override def nameField: Field = MessageModel.Name
 
-  override def componentId: String = "/" + name.option().getOrElse("message").urlComponentEncoded
+  private[amf] override def componentId: String = "/" + name.option().getOrElse("message").urlComponentEncoded
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement =

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Operation.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Operation.scala
@@ -102,8 +102,9 @@ case class Operation(fields: Fields, annotations: Annotations)
   override def meta: OperationModel.type = OperationModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + method.option().getOrElse("default-operation").urlComponentEncoded
-  override def nameField: Field    = Name
+  private[amf] override def componentId: String =
+    "/" + method.option().getOrElse("default-operation").urlComponentEncoded
+  override def nameField: Field = Name
 
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement = Operation.apply
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Organization.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Organization.scala
@@ -22,7 +22,7 @@ case class Organization(fields: Fields, annotations: Annotations) extends NamedD
   override def meta = OrganizationModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/organization"
+  private[amf] override def componentId: String = "/organization"
 
   override def nameField: Field = Name
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Parameter.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Parameter.scala
@@ -104,7 +104,7 @@ class Parameter(override val fields: Fields, override val annotations: Annotatio
   override def meta: ParameterModel.type = ParameterModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String =
+  private[amf] override def componentId: String =
     s"/parameter/${encoded(binding, "default-binding")}/${encoded(name, "default-name")}"
 
   private def encoded(value: StrField, default: String) = value.option().map(_.urlComponentEncoded).getOrElse(default)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Payload.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Payload.scala
@@ -80,7 +80,7 @@ case class Payload(fields: Fields, annotations: Annotations)
   override def meta: PayloadModel.type = PayloadModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String =
+  private[amf] override def componentId: String =
     "/" + mediaType
       .option()
       .getOrElse(name.option().getOrElse("default"))

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Request.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Request.scala
@@ -53,7 +53,7 @@ class Request(override val fields: Fields, override val annotations: Annotations
   override def meta: RequestModel.type = RequestModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + name.option().getOrElse("request").urlComponentEncoded
+  private[amf] override def componentId: String = "/" + name.option().getOrElse("request").urlComponentEncoded
 
   override def linkCopy(): Request = Request().withId(id)
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Response.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Response.scala
@@ -68,7 +68,7 @@ class Response(override val fields: Fields, override val annotations: Annotation
   override def linkCopy(): Response = Response().withId(id)
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + name.option().getOrElse("default-response").urlComponentEncoded
+  private[amf] override def componentId: String = "/" + name.option().getOrElse("default-response").urlComponentEncoded
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement = Response.apply

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Server.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Server.scala
@@ -39,7 +39,7 @@ case class Server(fields: Fields, annotations: Annotations) extends SecuredEleme
   override def meta: DomainElementModel = ServerModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + url.option().orNull.urlComponentEncoded
+  private[amf] override def componentId: String = "/" + url.option().orNull.urlComponentEncoded
 }
 
 object Server {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Tag.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/Tag.scala
@@ -29,8 +29,8 @@ case class Tag(fields: Fields, annotations: Annotations) extends NamedDomainElem
   override def meta: TagModel.type = TagModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/tag/" + name.option().getOrElse("default-type").urlComponentEncoded
-  override def nameField: Field    = Name
+  private[amf] override def componentId: String = "/tag/" + name.option().getOrElse("default-type").urlComponentEncoded
+  override def nameField: Field                 = Name
 }
 
 object Tag {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/TemplatedLink.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/TemplatedLink.scala
@@ -38,7 +38,7 @@ case class TemplatedLink(fields: Fields, annotations: Annotations) extends Named
   }
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String =
+  private[amf] override def componentId: String =
     s"/templatedLink/${name.option().getOrElse("UnknownTemplatedLink").urlComponentEncoded}"
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/api/Api.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/api/Api.scala
@@ -93,7 +93,7 @@ abstract class Api(fields: Fields, annotations: Annotations)
   def sourceVendor: Option[Vendor] = annotations.find(classOf[SourceVendor]).map(a => a.vendor)
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "#/api"
+  private[amf] override def componentId: String = "#/api"
 
   override def nameField: Field = Name
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/api/AsyncApi.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/api/AsyncApi.scala
@@ -8,7 +8,7 @@ case class AsyncApi(fields: Fields, annotations: Annotations) extends Api(fields
   override def meta: AsyncApiModel.type = AsyncApiModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "#/async-api"
+  private[amf] override def componentId: String = "#/async-api"
 }
 
 object AsyncApi {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/api/WebApi.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/api/WebApi.scala
@@ -8,7 +8,7 @@ case class WebApi(fields: Fields, annotations: Annotations) extends Api(fields: 
   override def meta: WebApiModel.type = WebApiModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "#/web-api"
+  private[amf] override def componentId: String = "#/web-api"
 }
 
 object WebApi {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/ChannelBindings.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/ChannelBindings.scala
@@ -18,7 +18,7 @@ case class ChannelBindings(fields: Fields, annotations: Annotations) extends Nam
   override def nameField: Field = Name
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String =
+  private[amf] override def componentId: String =
     "/" + name.option().getOrElse("channel-bindings").urlComponentEncoded
 
   override def linkCopy(): ChannelBindings = {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/EmptyBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/EmptyBinding.scala
@@ -23,8 +23,8 @@ class EmptyBinding(override val fields: Fields, override val annotations: Annota
 
   def withType(`type`: String): this.type = set(Type, `type`)
 
-  override def componentId: String      = "/" + `type`.option().getOrElse("empty-binding").urlComponentEncoded
-  override def linkCopy(): EmptyBinding = EmptyBinding().withId(id)
+  private[amf] override def componentId: String = "/" + `type`.option().getOrElse("empty-binding").urlComponentEncoded
+  override def linkCopy(): EmptyBinding         = EmptyBinding().withId(id)
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement = EmptyBinding.apply

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/MessageBindings.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/MessageBindings.scala
@@ -18,7 +18,7 @@ case class MessageBindings(fields: Fields, annotations: Annotations) extends Nam
   override def nameField: Field = Name
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String =
+  private[amf] override def componentId: String =
     "/" + name.option().getOrElse("message-bindings").urlComponentEncoded
 
   override def linkCopy(): MessageBindings = {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/OperationBindings.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/OperationBindings.scala
@@ -18,7 +18,7 @@ case class OperationBindings(fields: Fields, annotations: Annotations) extends N
   override def nameField: Field = Name
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String =
+  private[amf] override def componentId: String =
     "/" + name.option().getOrElse("operation-bindings").urlComponentEncoded
 
   override def linkCopy(): OperationBindings = {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/ServerBindings.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/ServerBindings.scala
@@ -18,7 +18,7 @@ case class ServerBindings(fields: Fields, annotations: Annotations) extends Name
   override def nameField: Field = Name
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String =
+  private[amf] override def componentId: String =
     "/" + name.option().getOrElse("server-bindings").urlComponentEncoded
 
   override def linkCopy(): ServerBindings = {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/amqp/Amqp091ChannelBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/amqp/Amqp091ChannelBinding.scala
@@ -20,7 +20,7 @@ class Amqp091ChannelBinding(override val fields: Fields, override val annotation
 
   override def meta: Amqp091ChannelBindingModel.type = Amqp091ChannelBindingModel
 
-  override def componentId: String = "/amqp091-channel"
+  private[amf] override def componentId: String = "/amqp091-channel"
 
   override def key: StrField = fields.field(Amqp091ChannelBindingModel.key)
 
@@ -65,7 +65,7 @@ class Amqp091ChannelExchange(override val fields: Fields, override val annotatio
   def withAutoDelete(autoDelete: Boolean): this.type = set(ChannelExchange.AutoDelete, autoDelete)
   def withVHost(vHost: String): this.type            = set(ChannelExchange.VHost, vHost)
 
-  override def componentId: String = "/amqp091-exchange"
+  private[amf] override def componentId: String = "/amqp091-exchange"
 }
 
 object Amqp091ChannelExchange {
@@ -95,7 +95,7 @@ class Amqp091Queue(override val fields: Fields, override val annotations: Annota
   def withAutoDelete(autoDelete: Boolean): this.type = set(QueueModel.AutoDelete, autoDelete)
   def withVHost(vHost: String): this.type            = set(QueueModel.VHost, vHost)
 
-  override def componentId: String = "/amqp091-queue"
+  private[amf] override def componentId: String = "/amqp091-queue"
 }
 
 object Amqp091Queue {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/amqp/Amqp091MessageBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/amqp/Amqp091MessageBinding.scala
@@ -23,7 +23,7 @@ class Amqp091MessageBinding(override val fields: Fields, override val annotation
   def withContentEncoding(contentEncoding: String): this.type = set(ContentEncoding, contentEncoding)
   def withMessageType(messageType: String): this.type         = set(MessageType, messageType)
 
-  override def componentId: String               = "/amqp091-message"
+  private[amf] override def componentId: String  = "/amqp091-message"
   override def linkCopy(): Amqp091MessageBinding = Amqp091MessageBinding().withId(id)
 
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement =

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/amqp/Amqp091OperationBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/amqp/Amqp091OperationBinding.scala
@@ -15,17 +15,17 @@ class Amqp091OperationBinding(override val fields: Fields, override val annotati
   override protected def bindingVersionField: Field    = BindingVersion
   override def meta: Amqp091OperationBindingModel.type = Amqp091OperationBindingModel
 
-  override def componentId: String = "/amqp091-operation"
-  def expiration: IntField         = fields.field(Expiration)
-  def userId: StrField             = fields.field(UserId)
-  def cc: Seq[StrField]            = fields.field(CC)
-  def priority: IntField           = fields.field(Priority)
-  def deliveryMode: IntField       = fields.field(DeliveryMode)
-  def mandatory: BoolField         = fields.field(Mandatory)
-  def bcc: Seq[StrField]           = fields.field(BCC)
-  def replyTo: StrField            = fields.field(ReplyTo)
-  def timestamp: BoolField         = fields.field(Timestamp)
-  def ack: BoolField               = fields.field(Ack)
+  private[amf] override def componentId: String = "/amqp091-operation"
+  def expiration: IntField                      = fields.field(Expiration)
+  def userId: StrField                          = fields.field(UserId)
+  def cc: Seq[StrField]                         = fields.field(CC)
+  def priority: IntField                        = fields.field(Priority)
+  def deliveryMode: IntField                    = fields.field(DeliveryMode)
+  def mandatory: BoolField                      = fields.field(Mandatory)
+  def bcc: Seq[StrField]                        = fields.field(BCC)
+  def replyTo: StrField                         = fields.field(ReplyTo)
+  def timestamp: BoolField                      = fields.field(Timestamp)
+  def ack: BoolField                            = fields.field(Ack)
 
   def withExpiration(expiration: Int): this.type     = set(Expiration, expiration)
   def withUserId(userId: String): this.type          = set(UserId, userId)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/http/HttpMessageBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/http/HttpMessageBinding.scala
@@ -20,7 +20,7 @@ class HttpMessageBinding(override val fields: Fields, override val annotations: 
 
   def withHeaders(headers: Shape): this.type = set(Headers, headers)
 
-  override def componentId: String = "/http-message"
+  private[amf] override def componentId: String = "/http-message"
 
   override protected def bindingVersionField: Field = BindingVersion
   override def linkCopy(): HttpMessageBinding       = HttpMessageBinding().withId(id)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/http/HttpOperationBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/http/HttpOperationBinding.scala
@@ -26,7 +26,7 @@ class HttpOperationBinding(override val fields: Fields, override val annotations
   def withMethod(method: String): this.type        = set(Method, method)
   def withQuery(query: Shape): this.type           = set(Query, query)
 
-  override def componentId: String = "/http-operation"
+  private[amf] override def componentId: String = "/http-operation"
 
   override def linkCopy(): HttpOperationBinding = HttpOperationBinding().withId(id)
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/kafka/KafkaMessageBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/kafka/KafkaMessageBinding.scala
@@ -21,7 +21,7 @@ class KafkaMessageBinding(override val fields: Fields, override val annotations:
 
   override def key: StrField = fields.field(KafkaMessageBindingModel.key)
 
-  override def componentId: String = "/kafka-message"
+  private[amf] override def componentId: String = "/kafka-message"
 
   override def linkCopy(): KafkaMessageBinding = KafkaMessageBinding()
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/kafka/KafkaOperationBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/kafka/KafkaOperationBinding.scala
@@ -18,7 +18,7 @@ class KafkaOperationBinding(override val fields: Fields, override val annotation
 
   override def meta: KafkaOperationBindingModel.type = KafkaOperationBindingModel
 
-  override def componentId: String = "/kafka-operation"
+  private[amf] override def componentId: String = "/kafka-operation"
 
   override val key: StrField = fields.field(KafkaOperationBindingModel.key)
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/mqtt/MqttMessageBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/mqtt/MqttMessageBinding.scala
@@ -17,8 +17,8 @@ class MqttMessageBinding(override val fields: Fields, override val annotations: 
 
   override val key: StrField = fields.field(MqttMessageBindingModel.key)
 
-  override def componentId: String            = "/mqtt-message"
-  override def linkCopy(): MqttMessageBinding = MqttMessageBinding().withId(id)
+  private[amf] override def componentId: String = "/mqtt-message"
+  override def linkCopy(): MqttMessageBinding   = MqttMessageBinding().withId(id)
 
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement =
     MqttMessageBinding.apply

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/mqtt/MqttOperationBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/mqtt/MqttOperationBinding.scala
@@ -23,7 +23,7 @@ class MqttOperationBinding(override val fields: Fields, override val annotations
 
   override def key: StrField = fields.field(MqttOperationBindingModel.key)
 
-  override def componentId: String              = "/mqtt-operation"
+  private[amf] override def componentId: String = "/mqtt-operation"
   override def linkCopy(): MqttOperationBinding = MqttOperationBinding().withId(id)
 
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement =

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/mqtt/MqttServerBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/mqtt/MqttServerBinding.scala
@@ -26,8 +26,8 @@ class MqttServerBinding(override val fields: Fields, override val annotations: A
   def withLastWill(lastWill: MqttServerLastWill): this.type = set(LastWill, lastWill)
   def withKeepAlive(keepAlive: Int): this.type              = set(KeepAlive, keepAlive)
 
-  override def componentId: String           = "/mqtt-server"
-  override def linkCopy(): MqttServerBinding = MqttServerBinding().withId(id)
+  private[amf] override def componentId: String = "/mqtt-server"
+  override def linkCopy(): MqttServerBinding    = MqttServerBinding().withId(id)
 
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement =
     MqttServerBinding.apply
@@ -57,7 +57,7 @@ class MqttServerLastWill(override val fields: Fields, override val annotations: 
   def withRetain(retain: Boolean): this.type  = set(Retain, retain)
   def withMessage(message: String): this.type = set(Message, message)
 
-  override def componentId: String = "/mqtt-last-will"
+  private[amf] override def componentId: String = "/mqtt-last-will"
 }
 
 object MqttServerLastWill {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/websockets/WebSocketsChannelBinding.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/bindings/websockets/WebSocketsChannelBinding.scala
@@ -27,7 +27,7 @@ class WebSocketsChannelBinding(override val fields: Fields, override val annotat
   def withHeaders(headers: Shape): this.type = set(Headers, headers)
   def withType(`type`: String): this.type    = set(Type, `type`)
 
-  override def componentId: String                  = "/web-socket-channel"
+  private[amf] override def componentId: String     = "/web-socket-channel"
   override def linkCopy(): WebSocketsChannelBinding = WebSocketsChannelBinding().withId(id)
 
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement =

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/OAuth2Flow.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/OAuth2Flow.scala
@@ -24,7 +24,7 @@ case class OAuth2Flow(fields: Fields, annotations: Annotations) extends DomainEl
   override def meta: OAuth2FlowModel.type = OAuth2FlowModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + flow.option().getOrElse("default-flow").urlComponentEncoded
+  private[amf] override def componentId: String = "/" + flow.option().getOrElse("default-flow").urlComponentEncoded
 }
 
 object OAuth2Flow {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/ParametrizedSecurityScheme.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/ParametrizedSecurityScheme.scala
@@ -7,7 +7,10 @@ import amf.core.internal.metamodel.Field
 import amf.core.internal.parser.domain.{Annotations, Fields}
 import amf.core.internal.utils.AmfStrings
 import amf.apicontract.internal.metamodel.domain.security.ParametrizedSecuritySchemeModel
-import amf.apicontract.internal.metamodel.domain.security.ParametrizedSecuritySchemeModel.{Settings => SettingsField, _}
+import amf.apicontract.internal.metamodel.domain.security.ParametrizedSecuritySchemeModel.{
+  Settings => SettingsField,
+  _
+}
 import org.yaml.model.YPart
 
 case class ParametrizedSecurityScheme(fields: Fields, annotations: Annotations)
@@ -70,7 +73,8 @@ case class ParametrizedSecurityScheme(fields: Fields, annotations: Annotations)
   override def meta: ParametrizedSecuritySchemeModel.type = ParametrizedSecuritySchemeModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + name.option().getOrElse("default-parametrized").urlComponentEncoded
+  private[amf] override def componentId: String =
+    "/" + name.option().getOrElse("default-parametrized").urlComponentEncoded
 }
 
 object ParametrizedSecurityScheme {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/Scope.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/Scope.scala
@@ -29,7 +29,7 @@ case class Scope(fields: Fields, annotations: Annotations) extends DomainElement
   override def meta = ScopeModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + name.option().getOrElse("default-scope").urlComponentEncoded
+  private[amf] override def componentId: String = "/" + name.option().getOrElse("default-scope").urlComponentEncoded
 }
 
 object Scope {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/SecurityRequirement.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/SecurityRequirement.scala
@@ -30,7 +30,8 @@ case class SecurityRequirement(fields: Fields, annotations: Annotations) extends
   override def meta: SecurityRequirementModel.type = SecurityRequirementModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + name.option().getOrElse("default-requirement").urlComponentEncoded
+  private[amf] override def componentId: String =
+    "/" + name.option().getOrElse("default-requirement").urlComponentEncoded
 }
 
 object SecurityRequirement {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/SecurityScheme.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/SecurityScheme.scala
@@ -162,7 +162,7 @@ class SecurityScheme(override val fields: Fields, override val annotations: Anno
   override def meta: SecuritySchemeModel.type = SecuritySchemeModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = name.option().getOrElse("fragment").urlComponentEncoded
+  private[amf] override def componentId: String = name.option().getOrElse("fragment").urlComponentEncoded
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement = SecurityScheme.apply

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/Settings.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/model/domain/security/Settings.scala
@@ -5,7 +5,10 @@ import amf.core.client.scala.model.{StrField, domain}
 import amf.core.internal.parser.domain.{Annotations, Fields}
 import amf.apicontract.internal.metamodel.domain.security.ApiKeySettingsModel._
 import amf.apicontract.internal.metamodel.domain.security.HttpSettingsModel._
-import amf.apicontract.internal.metamodel.domain.security.OAuth1SettingsModel.{AuthorizationUri => AuthorizationUri1, _}
+import amf.apicontract.internal.metamodel.domain.security.OAuth1SettingsModel.{
+  AuthorizationUri => AuthorizationUri1,
+  _
+}
 import amf.apicontract.internal.metamodel.domain.security.OAuth2SettingsModel._
 import amf.apicontract.internal.metamodel.domain.security.OpenIdConnectSettingsModel._
 import amf.apicontract.internal.metamodel.domain.security.SettingsModel._
@@ -48,7 +51,7 @@ class Settings(val fields: Fields, val annotations: Annotations) extends DomainE
   override def meta: SettingsModel = SettingsModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/settings/default"
+  private[amf] override def componentId: String = "/settings/default"
 }
 
 object Settings {
@@ -77,7 +80,7 @@ case class OAuth1Settings(override val fields: Fields, override val annotations:
   override def meta: OAuth1SettingsModel.type = OAuth1SettingsModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/settings/oauth1"
+  private[amf] override def componentId: String = "/settings/oauth1"
 }
 
 object OAuth1Settings {
@@ -107,7 +110,7 @@ case class OAuth2Settings(override val fields: Fields, override val annotations:
   override def meta: OAuth2SettingsModel.type = OAuth2SettingsModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/settings/oauth2"
+  private[amf] override def componentId: String = "/settings/oauth2"
 }
 
 object OAuth2Settings {
@@ -129,7 +132,7 @@ case class ApiKeySettings(override val fields: Fields, override val annotations:
   override def meta: ApiKeySettingsModel.type = ApiKeySettingsModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/settings/api-key"
+  private[amf] override def componentId: String = "/settings/api-key"
 }
 
 object ApiKeySettings {
@@ -151,7 +154,7 @@ case class HttpApiKeySettings(override val fields: Fields, override val annotati
   override def meta: HttpApiKeySettingsModel.type = HttpApiKeySettingsModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/settings/http-api-key"
+  private[amf] override def componentId: String = "/settings/http-api-key"
 }
 
 object HttpApiKeySettings {
@@ -173,7 +176,7 @@ case class HttpSettings(override val fields: Fields, override val annotations: A
   override def meta: HttpSettingsModel.type = HttpSettingsModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/settings/http"
+  private[amf] override def componentId: String = "/settings/http"
 }
 
 object HttpSettings {
@@ -195,7 +198,7 @@ case class OpenIdConnectSettings(override val fields: Fields, override val annot
   override def meta: OpenIdConnectSettingsModel.type = OpenIdConnectSettingsModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/settings/open-id-connect"
+  private[amf] override def componentId: String = "/settings/open-id-connect"
 }
 
 object OpenIdConnectSettings {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/parser/domain/AsyncMessageParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/parser/domain/AsyncMessageParser.scala
@@ -20,7 +20,7 @@ import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.{Annotations, ScalarNode, SearchScope}
 import amf.core.internal.utils.IdCounter
 import amf.core.internal.validation.CoreValidations
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.client.scala.model.domain.NodeShape
 import amf.shapes.client.scala.model.domain.{Example, NodeShape}
 import amf.shapes.internal.spec.common.JSONSchemaDraft7SchemaVersion

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/transformation/AsyncContentTypeResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/transformation/AsyncContentTypeResolutionStage.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.spec.async.transformation
 import amf.apicontract.client.scala.model.domain.api.Api
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class AsyncContentTypeResolutionStage() extends TransformationStep() {
   override def transform(model: BaseUnit, errorHandler: AMFErrorHandler): BaseUnit = model match {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/transformation/AsyncExamplePropagationResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/transformation/AsyncExamplePropagationResolutionStage.scala
@@ -6,7 +6,7 @@ import amf.apicontract.internal.metamodel.domain.MessageModel
 import amf.apicontract.internal.spec.common.transformation.stage.ExamplePropagationHelper
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class AsyncExamplePropagationResolutionStage() extends TransformationStep with ExamplePropagationHelper {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/transformation/JsonMergePatchStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/transformation/JsonMergePatchStage.scala
@@ -8,7 +8,7 @@ import amf.apicontract.internal.spec.common.transformation.stage.CustomMerge
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.{AmfElement, AmfObject, DomainElement}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.metamodel.Field
 import amf.core.internal.metamodel.domain.DomainElementModel
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/transformation/ServerVariableExampleResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/transformation/ServerVariableExampleResolutionStage.scala
@@ -4,7 +4,7 @@ import amf.apicontract.client.scala.model.domain.api.Api
 import amf.apicontract.internal.spec.common.transformation.stage.ExamplePropagationHelper
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class ServerVariableExampleResolutionStage() extends TransformationStep with ExamplePropagationHelper {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/parser/ParameterParsers.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/parser/ParameterParsers.scala
@@ -22,7 +22,7 @@ import amf.core.internal.utils.{AmfStrings, IdCounter, UriUtils}
 import amf.core.internal.validation.CoreValidations.UnresolvedReference
 import amf.core.internal.validation.core.ValidationSpecification
 import amf.shapes.internal.annotations.ExternalReferenceUrl
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.client.scala.model.domain.NodeShape
 import amf.shapes.client.scala.model.domain.{AnyShape, Example, FileShape, NodeShape}
 import amf.shapes.internal.spec.common.{OAS20SchemaVersion, OAS30SchemaVersion, SchemaPosition}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/ExtendsHelper.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/ExtendsHelper.scala
@@ -11,8 +11,8 @@ import amf.core.client.scala.errorhandling.{AMFErrorHandler, IgnoringErrorHandle
 import amf.core.client.scala.model.document.{BaseUnit, DeclaresModel, Fragment, Module}
 import amf.core.client.scala.model.domain.{AmfElement, DataNode, DomainElement, NamedDomainElement}
 import amf.core.client.scala.parse.document.ParserContext
-import amf.core.client.scala.transform.stages.ReferenceResolutionStage
-import amf.core.client.scala.transform.stages.helpers.ResolvedNamedEntity
+import amf.core.internal.transform.stages.ReferenceResolutionStage
+import amf.core.internal.transform.stages.helpers.ResolvedNamedEntity
 import amf.core.internal.annotations.{Aliases, LexicalInformation, SourceAST, SourceLocation}
 import amf.core.internal.parser.{LimitedParseConfig, CompilerConfiguration}
 import amf.core.internal.parser.domain.{Annotations, FragmentRef}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/AnnotationRemovalStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/AnnotationRemovalStage.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.spec.common.transformation.stage
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document, FieldsFilter}
 import amf.core.client.scala.model.domain.Annotation
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.client.scala.traversal.iterator.InstanceCollector
 import amf.shapes.internal.annotations.{ExternalJsonSchemaShape, ExternalReferenceUrl}
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/DomainElementMerging.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/DomainElementMerging.scala
@@ -21,7 +21,7 @@ import amf.apicontract.internal.annotations.AnnotationSyntax._
 import amf.apicontract.internal.spec.raml.parser.context.RamlWebApiContext
 import amf.apicontract.internal.validation.definitions.ParserSideValidations.UnusedBaseUriParameter
 import amf.apicontract.internal.validation.definitions.ResolutionSideValidations.UnequalMediaTypeDefinitionsInExtendsPayloads
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.client.scala.model.domain.ScalarShape
 import amf.shapes.client.scala.model.domain.{AnyShape, NodeShape, ScalarShape}
 import amf.shapes.internal.domain.metamodel.AnyShapeModel.Examples

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/MediaTypeResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/MediaTypeResolutionStage.scala
@@ -13,7 +13,8 @@ import amf.core.client.scala.model.domain.{AmfScalar, DomainElement, Shape}
 import amf.core.client.scala.transform.stages.TransformationStep
 import amf.core.internal.metamodel.Field
 import amf.shapes.client.scala.model.domain.NodeShape
-import amf.shapes.client.scala.model.domain.{ExampleTracking, FileShape, NodeShape}
+import amf.shapes.client.scala.model.domain.{FileShape, NodeShape}
+import amf.shapes.internal.domain.resolution.ExampleTracking
 
 /** Apply root and operation mime types to payloads.
   *

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/MediaTypeResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/MediaTypeResolutionStage.scala
@@ -10,7 +10,7 @@ import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.extensions.PropertyShape
 import amf.core.client.scala.model.domain.{AmfScalar, DomainElement, Shape}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.metamodel.Field
 import amf.shapes.client.scala.model.domain.NodeShape
 import amf.shapes.client.scala.model.domain.{FileShape, NodeShape}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/ParametersNormalizationStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/ParametersNormalizationStage.scala
@@ -8,7 +8,7 @@ import amf.core.client.common.validation.{AmfProfile, Oas20Profile, ProfileName}
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.AmfArray
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.annotations.SynthesizedField
 
 /**

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/PathDescriptionNormalizationStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/PathDescriptionNormalizationStage.scala
@@ -7,7 +7,7 @@ import amf.core.client.common.validation.{Async20Profile, Oas30Profile, ProfileN
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.AmfScalar
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.metamodel.Field
 
 /**

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/PayloadAndParameterResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/PayloadAndParameterResolutionStage.scala
@@ -6,7 +6,7 @@ import amf.core.client.common.validation._
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.AmfObject
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.{AnyShape, Example}
 import amf.shapes.internal.domain.metamodel.common.ExamplesField
 import amf.shapes.internal.domain.resolution.ExampleTracking

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/PayloadAndParameterResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/PayloadAndParameterResolutionStage.scala
@@ -7,9 +7,9 @@ import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.AmfObject
 import amf.core.client.scala.transform.stages.TransformationStep
-import amf.shapes.client.scala.model.domain.ExampleTracking
-import amf.shapes.client.scala.model.domain.{AnyShape, Example, ExampleTracking}
+import amf.shapes.client.scala.model.domain.{AnyShape, Example}
 import amf.shapes.internal.domain.metamodel.common.ExamplesField
+import amf.shapes.internal.domain.resolution.ExampleTracking
 
 /**
   * Propagate examples defined in parameters and payloads onto their corresponding shape so they are validated

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/RequestParamsLinkStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/RequestParamsLinkStage.scala
@@ -4,9 +4,9 @@ import amf.apicontract.client.scala.model.domain.Request
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.{DomainElement, Linkable}
-import amf.core.client.scala.transform.stages.TransformationStep
-import amf.core.client.scala.transform.stages.elements.resolution.ReferenceResolution
-import amf.core.client.scala.transform.stages.selectors.{LinkSelector, Selector}
+import amf.core.client.scala.transform.TransformationStep
+import amf.core.internal.transform.stages.elements.resolution.ReferenceResolution
+import amf.core.internal.transform.stages.selectors.{LinkSelector, Selector}
 
 object RequestParamsLinkStage extends TransformationStep {
   override def transform(model: BaseUnit, errorHandler: AMFErrorHandler): BaseUnit =

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/ResponseExamplesResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/ResponseExamplesResolutionStage.scala
@@ -9,7 +9,7 @@ import amf.apicontract.internal.validation.definitions.ResolutionSideValidations
 }
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.{AnyShape, Example}
 import amf.shapes.internal.domain.resolution.ExampleTracking
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/ResponseExamplesResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/ResponseExamplesResolutionStage.scala
@@ -10,8 +10,8 @@ import amf.apicontract.internal.validation.definitions.ResolutionSideValidations
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.transform.stages.TransformationStep
-import amf.shapes.client.scala.model.domain.ExampleTracking
-import amf.shapes.client.scala.model.domain.{AnyShape, Example, ExampleTracking}
+import amf.shapes.client.scala.model.domain.{AnyShape, Example}
+import amf.shapes.internal.domain.resolution.ExampleTracking
 
 /** Apply response examples to payloads schemas matching by media type
   *

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/SecurityResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/SecurityResolutionStage.scala
@@ -7,7 +7,7 @@ import amf.apicontract.internal.metamodel.domain.{EndPointModel, OperationModel}
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.DomainElement
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.metamodel.Field
 
 class SecurityResolutionStage() extends TransformationStep() {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/ServersNormalizationStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/ServersNormalizationStage.scala
@@ -5,7 +5,7 @@ import amf.apicontract.client.scala.model.domain.{Server, ServerContainer}
 import amf.core.client.common.validation.{Oas30Profile, ProfileName}
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 /**
   * Place server models in the right locations according to OAS 3.0 and our own criterium for AMF

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/document/OasDocumentParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/document/OasDocumentParser.scala
@@ -33,7 +33,7 @@ import amf.core.internal.parser.domain.{Annotations, ArrayNode, ScalarNode, Sear
 import amf.core.internal.parser.{Root, YMapOps}
 import amf.core.internal.utils.{AmfStrings, IdCounter}
 import amf.core.internal.validation.CoreValidations.DeclarationNotFound
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.client.scala.model.domain.CreativeWork
 import amf.shapes.internal.spec.ShapeParserContext
 import amf.shapes.internal.spec.common.parser.{

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/Oas20RequestParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/Oas20RequestParser.scala
@@ -16,7 +16,7 @@ import amf.core.client.scala.model.domain.AmfArray
 import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.Annotations
 import amf.core.internal.utils.Lazy
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.internal.spec.raml.parser.Raml10TypeParser
 import org.yaml.model.{YMap, YMapEntry, YNode}
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasContentParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasContentParser.scala
@@ -8,7 +8,7 @@ import amf.core.client.scala.model.domain.AmfArray
 import amf.core.internal.annotations.TrackedElement
 import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.{Annotations, ScalarNode}
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.internal.domain.metamodel.ExampleModel
 import amf.shapes.internal.spec.common.parser.{AnnotationParser, OasExamplesParser}
 import amf.shapes.internal.spec.oas.parser.OasTypeParser

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasHeaderParametersParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasHeaderParametersParser.scala
@@ -15,7 +15,7 @@ import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.{Annotations, ScalarNode, SearchScope}
 import amf.core.internal.validation.CoreValidations
 import amf.shapes.internal.annotations.ExternalReferenceUrl
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.client.scala.model.domain.Example
 import amf.shapes.internal.spec.common.{OAS20SchemaVersion, SchemaPosition}
 import amf.shapes.internal.spec.common.parser.{AnnotationParser, OasExamplesParser, YMapEntryLike}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasPayloadParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasPayloadParser.scala
@@ -6,7 +6,7 @@ import amf.apicontract.internal.spec.common.parser.{SpecParserOps, WebApiShapePa
 import amf.apicontract.internal.spec.oas.parser.context.OasWebApiContext
 import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.{Annotations, ScalarNode}
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.internal.spec.common.parser.AnnotationParser
 import amf.shapes.internal.spec.oas.parser.OasTypeParser
 import org.yaml.model.{YMap, YNode}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasResponseParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasResponseParser.scala
@@ -14,7 +14,7 @@ import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.{Annotations, ScalarNode, SearchScope}
 import amf.core.internal.validation.CoreValidations
 import amf.shapes.internal.annotations.ExternalReferenceUrl
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.internal.spec.common.parser.AnnotationParser
 import amf.shapes.internal.spec.oas.parser.OasTypeParser
 import org.yaml.model.YMap

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/document/RamlDocumentParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/document/RamlDocumentParser.scala
@@ -33,7 +33,7 @@ import amf.core.internal.parser.domain.{Annotations, ArrayNode, ScalarNode, Sear
 import amf.core.internal.parser.{Root, YMapOps, YScalarYRead}
 import amf.core.internal.utils._
 import amf.core.internal.validation.CoreValidations.DeclarationNotFound
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.client.scala.model.domain.CreativeWork
 import amf.shapes.internal.spec.RamlWebApiContextType
 import amf.shapes.internal.spec.common.parser.{AnnotationParser, RamlCreativeWorkParser, RamlScalarNode, YMapEntryLike}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlPayloadParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlPayloadParser.scala
@@ -10,7 +10,7 @@ import amf.core.internal.annotations.ExplicitField
 import amf.core.internal.metamodel.domain.extensions.PropertyShapeModel
 import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.{Annotations, ScalarNode}
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.client.scala.model.domain.NodeShape
 import amf.shapes.client.scala.model.domain.{AnyShape, NodeShape}
 import amf.shapes.internal.domain.metamodel.NodeShapeModel

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlRequestParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlRequestParser.scala
@@ -10,7 +10,7 @@ import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.Annotations
 import amf.core.internal.utils.{AmfStrings, Lazy}
 import amf.core.internal.validation.CoreParserValidations.UnsupportedExampleMediaTypeErrorSpecification
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.internal.spec.raml.parser.{AnyDefaultType, DefaultType, Raml10TypeParser}
 import amf.shapes.internal.validation.definitions.ShapeParserSideValidations.ExclusivePropertiesSpecification
 import org.yaml.model.{YMap, YMapEntry, YScalar, YType}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlResponseParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlResponseParser.scala
@@ -12,7 +12,7 @@ import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.{Annotations, ScalarNode, SearchScope}
 import amf.core.internal.utils.AmfStrings
 import amf.core.internal.validation.CoreParserValidations.UnsupportedExampleMediaTypeErrorSpecification
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.internal.spec.common.parser.AnnotationParser
 import amf.shapes.internal.spec.raml.parser.{AnyDefaultType, DefaultType}
 import amf.shapes.internal.vocabulary.VocabularyMappings

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlSecuritySchemeParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlSecuritySchemeParser.scala
@@ -20,7 +20,7 @@ import amf.core.client.scala.model.domain.{AmfArray, AmfScalar}
 import amf.core.internal.annotations.{ExternalFragmentRef, LexicalInformation}
 import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.{Annotations, SearchScope}
-import amf.shapes.client.scala.model.domain.ExampleTracking.tracking
+import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
 import amf.shapes.internal.spec.common.parser.AnnotationParser
 import amf.shapes.internal.spec.raml.parser.Raml10TypeParser
 import amf.shapes.internal.validation.definitions.ShapeParserSideValidations.ExclusivePropertiesSpecification

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/AmfEditingPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/AmfEditingPipeline.scala
@@ -4,8 +4,8 @@ import amf.apicontract.internal.spec.common.transformation.stage._
 import amf.apicontract.internal.transformation.stages.{ExtensionsResolutionStage, WebApiReferenceResolutionStage}
 import amf.core.client.common.transform._
 import amf.core.client.common.validation.{AmfProfile, ProfileName}
-import amf.core.client.scala.transform.pipelines.TransformationPipeline
-import amf.core.client.scala.transform.stages.{TransformationStep, UrlShortenerStage}
+import amf.core.client.scala.transform.{TransformationPipeline, TransformationStep}
+import amf.core.internal.transform.stages.UrlShortenerStage
 import amf.shapes.internal.domain.resolution.ShapeNormalizationStage
 
 class AmfEditingPipeline private[amf] (urlShortening: Boolean = true, override val name: String)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/AmfTransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/AmfTransformationPipeline.scala
@@ -4,13 +4,8 @@ import amf.apicontract.internal.spec.common.transformation.stage._
 import amf.apicontract.internal.transformation.stages.{ExtensionsResolutionStage, WebApiReferenceResolutionStage}
 import amf.core.client.common.transform._
 import amf.core.client.common.validation.{AmfProfile, ProfileName}
-import amf.core.client.scala.transform.pipelines.TransformationPipeline
-import amf.core.client.scala.transform.stages.{
-  CleanReferencesStage,
-  DeclarationsRemovalStage,
-  ExternalSourceRemovalStage,
-  TransformationStep
-}
+import amf.core.client.scala.transform.{TransformationPipeline, TransformationStep}
+import amf.core.internal.transform.stages.{CleanReferencesStage, DeclarationsRemovalStage, ExternalSourceRemovalStage}
 import amf.shapes.internal.domain.resolution.ShapeNormalizationStage
 
 class AmfTransformationPipeline private[amf] (override val name: String) extends TransformationPipeline() {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Async20EditingPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Async20EditingPipeline.scala
@@ -15,7 +15,7 @@ import amf.apicontract.internal.spec.common.transformation.stage.{
 import amf.apicontract.internal.transformation.stages.WebApiReferenceResolutionStage
 import amf.core.client.common.transform._
 import amf.core.client.common.validation.{Async20Profile, ProfileName}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.remote.AsyncApi20
 import amf.shapes.internal.domain.resolution.ShapeNormalizationStage
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Async20TransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Async20TransformationPipeline.scala
@@ -13,13 +13,8 @@ import amf.apicontract.internal.spec.common.transformation.stage.{
 import amf.apicontract.internal.transformation.stages.WebApiReferenceResolutionStage
 import amf.core.client.common.transform._
 import amf.core.client.common.validation.Async20Profile
-import amf.core.client.scala.transform.pipelines.TransformationPipeline
-import amf.core.client.scala.transform.stages.{
-  CleanReferencesStage,
-  DeclarationsRemovalStage,
-  ExternalSourceRemovalStage,
-  TransformationStep
-}
+import amf.core.client.scala.transform.{TransformationPipeline, TransformationStep}
+import amf.core.internal.transform.stages.{CleanReferencesStage, DeclarationsRemovalStage, ExternalSourceRemovalStage}
 import amf.core.internal.remote.AsyncApi20
 import amf.shapes.internal.domain.resolution.ShapeNormalizationStage
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas30TransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas30TransformationPipeline.scala
@@ -8,7 +8,7 @@ import amf.apicontract.internal.spec.common.transformation.stage.{
 import amf.apicontract.internal.transformation.stages.WebApiReferenceResolutionStage
 import amf.core.client.common.transform._
 import amf.core.client.common.validation.{Oas30Profile, ProfileName}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.remote.Oas30
 
 class Oas30TransformationPipeline private (override val name: String) extends AmfTransformationPipeline(name) {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas30ValidationTransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas30ValidationTransformationPipeline.scala
@@ -2,7 +2,7 @@ package amf.apicontract.internal.transformation
 
 import amf.apicontract.internal.spec.common.transformation.stage.RequestParamsLinkStage
 import amf.core.client.common.validation.Oas30Profile
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class Oas30ValidationTransformationPipeline private (override val name: String)
     extends ValidationTransformationPipeline(Oas30Profile, name) {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas3EditingPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas3EditingPipeline.scala
@@ -4,7 +4,7 @@ import amf.apicontract.internal.spec.common.transformation.stage.{OpenApiParamet
 import amf.apicontract.internal.transformation.stages.WebApiReferenceResolutionStage
 import amf.core.client.common.transform._
 import amf.core.client.common.validation.{Oas30Profile, ProfileName}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.remote.Oas30
 
 class Oas3EditingPipeline private (urlShortening: Boolean, override val name: String)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ValidationTransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ValidationTransformationPipeline.scala
@@ -10,12 +10,8 @@ import amf.apicontract.internal.transformation.stages.ExtensionsResolutionStage
 import amf.core.client.common.validation.{Async20Profile, Oas30Profile, ProfileName}
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.pipelines.{TransformationPipeline, TransformationPipelineRunner}
-import amf.core.client.scala.transform.stages.{
-  ExternalSourceRemovalStage,
-  ReferenceResolutionStage,
-  TransformationStep
-}
+import amf.core.client.scala.transform.{TransformationPipeline, TransformationPipelineRunner, TransformationStep}
+import amf.core.internal.transform.stages.{ExternalSourceRemovalStage, ReferenceResolutionStage}
 import amf.shapes.internal.domain.resolution.ShapeNormalizationStage
 
 // Validation pipeline is not registered in AMF configuration, is it only called internally.

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas20CompatibilityPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas20CompatibilityPipeline.scala
@@ -4,8 +4,7 @@ import amf.apicontract.internal.transformation.Oas20TransformationPipeline
 import amf.apicontract.internal.transformation.compatibility.oas._
 import amf.apicontract.internal.transformation.compatibility.oas3.CleanRepeatedOperationIds
 import amf.core.client.common.transform._
-import amf.core.client.scala.transform.pipelines.TransformationPipeline
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.{TransformationPipeline, TransformationStep}
 import amf.core.internal.remote.Oas20
 
 class Oas20CompatibilityPipeline private (override val name: String) extends TransformationPipeline() {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas3CompatibilityPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas3CompatibilityPipeline.scala
@@ -3,8 +3,7 @@ package amf.apicontract.internal.transformation.compatibility
 import amf.apicontract.internal.transformation.Oas30TransformationPipeline
 import amf.apicontract.internal.transformation.compatibility.oas3._
 import amf.core.client.common.transform._
-import amf.core.client.scala.transform.pipelines.TransformationPipeline
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.{TransformationPipeline, TransformationStep}
 import amf.core.internal.remote.Oas30
 
 class Oas3CompatibilityPipeline private (override val name: String) extends TransformationPipeline() {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/RamlCompatibilityPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/RamlCompatibilityPipeline.scala
@@ -8,8 +8,7 @@ import amf.apicontract.internal.spec.common.transformation.stage.{
 import amf.apicontract.internal.transformation.compatibility.raml._
 import amf.core.client.common.transform._
 import amf.core.client.common.validation.{ProfileName, Raml08Profile, Raml10Profile}
-import amf.core.client.scala.transform.pipelines.TransformationPipeline
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.{TransformationPipeline, TransformationStep}
 import amf.core.internal.remote.{Raml08, Raml10}
 
 class RamlCompatibilityPipeline private[amf] (override val name: String, profile: ProfileName)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/common/AmfElementLinkResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/common/AmfElementLinkResolutionStage.scala
@@ -3,9 +3,9 @@ package amf.apicontract.internal.transformation.compatibility.common
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.{AmfArray, DomainElement, Linkable}
-import amf.core.client.scala.transform.stages.TransformationStep
-import amf.core.client.scala.transform.stages.elements.resolution.ReferenceResolution
-import amf.core.client.scala.transform.stages.elements.resolution.ReferenceResolution.ASSERT_DIFFERENT
+import amf.core.client.scala.transform.TransformationStep
+import amf.core.internal.transform.stages.elements.resolution.ReferenceResolution
+import amf.core.internal.transform.stages.elements.resolution.ReferenceResolution.ASSERT_DIFFERENT
 
 abstract class AmfElementLinkResolutionStage() extends TransformationStep {
   override def transform(model: BaseUnit, errorHandler: AMFErrorHandler): BaseUnit = {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/common/SecuritySettingsMapper.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/common/SecuritySettingsMapper.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.common
 import amf.apicontract.client.scala.model.domain.security._
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, DeclaresModel}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 abstract class SecuritySettingsMapper() extends TransformationStep {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/CleanIdenticalExamples.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/CleanIdenticalExamples.scala
@@ -2,7 +2,7 @@ package amf.apicontract.internal.transformation.compatibility.oas
 
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.Example
 import amf.shapes.client.scala.model.domain.{AnyShape, Example}
 import amf.shapes.internal.domain.metamodel.AnyShapeModel

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/CleanNullSecurity.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/CleanNullSecurity.scala
@@ -6,7 +6,7 @@ import amf.core.client.scala.model.DataType
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.ScalarNode
 import amf.core.client.scala.model.domain.extensions.DomainExtension
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.annotations.NullSecurity
 
 class CleanNullSecurity() extends TransformationStep {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/CleanParameterExamples.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/CleanParameterExamples.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.oas
 import amf.apicontract.client.scala.model.domain.Parameter
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.internal.domain.metamodel.AnyShapeModel
 
 class CleanParameterExamples() extends TransformationStep {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/LowercaseSchemes.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/LowercaseSchemes.scala
@@ -8,7 +8,7 @@ import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.StrField
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.DomainElement
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.metamodel.Field
 
 import scala.language.postfixOps

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/MandatoryDocumentationUrl.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/MandatoryDocumentationUrl.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.oas
 import amf.apicontract.client.scala.model.domain.api.Api
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class MandatoryDocumentationUrl() extends TransformationStep {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/MandatoryPathParameters.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/MandatoryPathParameters.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.oas
 import amf.apicontract.client.scala.model.domain.Parameter
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class MandatoryPathParameters() extends TransformationStep {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/MandatoryResponses.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas/MandatoryResponses.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.oas
 import amf.apicontract.client.scala.model.domain.{Operation, Response}
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class MandatoryResponses() extends TransformationStep {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/AddItemsToArrayType.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/AddItemsToArrayType.scala
@@ -2,7 +2,7 @@ package amf.apicontract.internal.transformation.compatibility.oas3
 
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.ArrayShape
 import amf.shapes.client.scala.model.domain.{AnyShape, ArrayShape}
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/CleanNullSecurity.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/CleanNullSecurity.scala
@@ -6,7 +6,7 @@ import amf.core.client.scala.model.DataType
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.ScalarNode
 import amf.core.client.scala.model.domain.extensions.DomainExtension
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.annotations.NullSecurity
 
 class CleanNullSecurity() extends TransformationStep {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/CleanRepeatedOperationIds.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/CleanRepeatedOperationIds.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.oas3
 import amf.apicontract.client.scala.model.domain.Operation
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class CleanRepeatedOperationIds() extends TransformationStep {
   override def transform(model: BaseUnit, errorHandler: AMFErrorHandler): BaseUnit =

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/CleanSchemes.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/CleanSchemes.scala
@@ -6,7 +6,7 @@ import amf.apicontract.internal.metamodel.domain.OperationModel
 import amf.apicontract.internal.metamodel.domain.api.BaseApiModel
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class CleanSchemes() extends TransformationStep {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/MandatoryDocumentationUrl.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/MandatoryDocumentationUrl.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.oas3
 import amf.apicontract.client.scala.model.domain.api.Api
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class MandatoryDocumentationUrl() extends TransformationStep {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/MandatoryPathParameters.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/MandatoryPathParameters.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.oas3
 import amf.apicontract.client.scala.model.domain.Parameter
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class MandatoryPathParameters() extends TransformationStep {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/MandatoryResponses.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/oas3/MandatoryResponses.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.oas3
 import amf.apicontract.client.scala.model.domain.{Operation, Response}
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class MandatoryResponses() extends TransformationStep {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/CapitalizeSchemes.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/CapitalizeSchemes.scala
@@ -8,7 +8,7 @@ import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.StrField
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.DomainElement
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.metamodel.Field
 
 import scala.language.postfixOps

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/CustomAnnotationDeclaration.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/CustomAnnotationDeclaration.scala
@@ -4,7 +4,7 @@ import amf.apicontract.internal.spec.common.parser.WellKnownAnnotation
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, DeclaresModel}
 import amf.core.client.scala.model.domain.extensions.CustomDomainProperty
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.AnyShape
 
 class CustomAnnotationDeclaration() extends TransformationStep {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/DefaultPayloadMediaType.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/DefaultPayloadMediaType.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.raml
 import amf.apicontract.client.scala.model.domain.Payload
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class DefaultPayloadMediaType() extends TransformationStep {
   override def transform(model: BaseUnit, errorHandler: AMFErrorHandler): BaseUnit = {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/DefaultToNumericDefaultResponse.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/DefaultToNumericDefaultResponse.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.raml
 import amf.apicontract.client.scala.model.domain.{Operation, Response}
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class DefaultToNumericDefaultResponse() extends TransformationStep {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/EscapeTypeNames.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/EscapeTypeNames.scala
@@ -3,7 +3,7 @@ import amf.apicontract.client.scala.model.domain.api.Api
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.{Linkable, Shape}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.utils.IdCounter
 import amf.shapes.internal.spec.common.TypeDef.{JSONSchemaType, TypeExpressionType, UndefinedType, XMLSchemaType}
 import amf.shapes.internal.spec.{RamlTypeDefMatcher, TypeName}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/MakeExamplesOptional.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/MakeExamplesOptional.scala
@@ -2,7 +2,7 @@ package amf.apicontract.internal.transformation.compatibility.raml
 
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.Example
 
 class MakeExamplesOptional() extends TransformationStep {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/MakeRequiredFieldImplicitForOptionalProperties.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/MakeRequiredFieldImplicitForOptionalProperties.scala
@@ -3,9 +3,9 @@ package amf.apicontract.internal.transformation.compatibility.raml
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.DomainElement
-import amf.core.client.scala.transform.stages.TransformationStep
-import amf.core.client.scala.transform.stages.elements.resolution.{ElementResolutionStage, ElementStageTransformer}
-import amf.core.client.scala.transform.stages.selectors.NodeShapeSelector
+import amf.core.client.scala.transform.TransformationStep
+import amf.core.internal.transform.stages.elements.resolution.{ElementResolutionStage, ElementStageTransformer}
+import amf.core.internal.transform.stages.selectors.NodeShapeSelector
 import amf.core.internal.annotations.ExplicitField
 import amf.core.internal.metamodel.MetaModelTypeMapping
 import amf.core.internal.metamodel.domain.extensions.PropertyShapeModel

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/MandatoryAnnotationType.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/MandatoryAnnotationType.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.raml
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.extensions.{CustomDomainProperty, DomainExtension}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.AnyShape
 
 class MandatoryAnnotationType() extends TransformationStep {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/MandatoryCreativeWorkFields.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/MandatoryCreativeWorkFields.scala
@@ -2,7 +2,7 @@ package amf.apicontract.internal.transformation.compatibility.raml
 
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.CreativeWork
 
 class MandatoryCreativeWorkFields() extends TransformationStep {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/MandatoryDocumentationTitle.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/MandatoryDocumentationTitle.scala
@@ -4,7 +4,7 @@ import amf.apicontract.client.scala.model.domain.Tag
 import amf.apicontract.client.scala.model.domain.api.Api
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.DocumentedElement
 import amf.shapes.client.scala.model.domain.{CreativeWork, DocumentedElement}
 import amf.shapes.internal.domain.metamodel.CreativeWorkModel

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/PushSingleOperationPathParams.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/PushSingleOperationPathParams.scala
@@ -4,7 +4,7 @@ import amf.apicontract.client.scala.model.domain.EndPoint
 import amf.apicontract.internal.metamodel.domain.RequestModel
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class PushSingleOperationPathParams() extends TransformationStep {
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/RecursionDetection.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/RecursionDetection.scala
@@ -4,7 +4,7 @@ import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.extensions.PropertyShape
 import amf.core.client.scala.model.domain._
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.DataArrangementShape
 
 import scala.collection.mutable.ListBuffer

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/ResolveRamlCompatibleDeclarations.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/ResolveRamlCompatibleDeclarations.scala
@@ -3,10 +3,10 @@ import amf.apicontract.client.scala.model.domain.Response
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.{DomainElement, Linkable}
-import amf.core.client.scala.transform.stages.TransformationStep
-import amf.core.client.scala.transform.stages.elements.resolution.ReferenceResolution
-import amf.core.client.scala.transform.stages.elements.resolution.ReferenceResolution.ASSERT_DIFFERENT
-import amf.core.client.scala.transform.stages.selectors.{LinkSelector, MetaModelSelector, Selector}
+import amf.core.client.scala.transform.TransformationStep
+import amf.core.internal.transform.stages.elements.resolution.ReferenceResolution
+import amf.core.internal.transform.stages.elements.resolution.ReferenceResolution.ASSERT_DIFFERENT
+import amf.core.internal.transform.stages.selectors.{LinkSelector, MetaModelSelector, Selector}
 import amf.core.client.scala.vocabulary.Namespace.ApiContract
 
 object ResolveRamlCompatibleDeclarationsStage extends TransformationStep {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/SanitizeCustomTypeNames.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/SanitizeCustomTypeNames.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.raml
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.{DomainElement, Linkable, NamedDomainElement}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 
 class SanitizeCustomTypeNames() extends TransformationStep {
   override def transform(model: BaseUnit, errorHandler: AMFErrorHandler): BaseUnit = {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/SecuritySettingsMapper.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/SecuritySettingsMapper.scala
@@ -4,7 +4,7 @@ import amf.apicontract.client.scala.model.domain.security.{ApiKeySettings, OAuth
 import amf.apicontract.internal.metamodel.domain.security.SecuritySchemeModel
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, DeclaresModel}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.client.scala.model.domain.AnyShape
 
 class SecuritySettingsMapper() extends TransformationStep {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/ShapeFormatAdjuster.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/ShapeFormatAdjuster.scala
@@ -2,7 +2,7 @@ package amf.apicontract.internal.transformation.compatibility.raml
 
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.shapes.internal.spec.common.TypeDef.{DateOnlyType, DateTimeOnlyType, DateTimeType, TimeOnlyType}
 import amf.shapes.client.scala.model.domain.ScalarShape
 import amf.shapes.internal.domain.metamodel.ScalarShapeModel

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/UnionsAsTypeExpressions.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/raml/UnionsAsTypeExpressions.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.compatibility.raml
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, DeclaresModel}
 import amf.core.client.scala.model.domain.{DomainElement, NamedDomainElement, Shape}
-import amf.core.client.scala.transform.stages.TransformationStep
+import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.utils.IdCounter
 import amf.shapes.internal.annotations.ParsedFromTypeExpression
 import amf.shapes.client.scala.model.domain.UnionShape

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtendsResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtendsResolutionStage.scala
@@ -18,10 +18,11 @@ import amf.core.client.scala.errorhandling.{AMFErrorHandler, IgnoringErrorHandle
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.{DataNode, DomainElement, ElementTree}
 import amf.core.client.scala.parse.document.ParserContext
-import amf.core.client.scala.transform.stages.{ReferenceResolutionStage, TransformationStep}
+import amf.core.client.scala.transform.TransformationStep
+import amf.core.internal.transform.stages.ReferenceResolutionStage
 import amf.core.internal.annotations.{ErrorDeclaration, SourceAST}
 import amf.core.internal.metamodel.domain.DomainElementModel
-import amf.core.internal.parser.{LimitedParseConfig, CompilerConfiguration, YNodeLikeOps}
+import amf.core.internal.parser.{CompilerConfiguration, LimitedParseConfig, YNodeLikeOps}
 import amf.core.internal.render.SpecOrdering
 import amf.core.internal.unsafe.PlatformSecrets
 import amf.core.internal.utils.AliasCounter

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtensionsResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtensionsResolutionStage.scala
@@ -13,7 +13,8 @@ import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document._
 import amf.core.client.scala.model.domain.{AmfArray, AmfElement, AmfScalar, DomainElement}
 import amf.core.client.scala.parse.document.{EmptyFutureDeclarations, ParserContext}
-import amf.core.client.scala.transform.stages.{ReferenceResolutionStage, TransformationStep}
+import amf.core.client.scala.transform.TransformationStep
+import amf.core.internal.transform.stages.ReferenceResolutionStage
 import amf.core.internal.annotations.Aliases
 import amf.core.internal.metamodel.Type.Scalar
 import amf.core.internal.metamodel.document.BaseUnitModel

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/WebApiReferenceResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/WebApiReferenceResolutionStage.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.transformation.stages
 import amf.apicontract.client.scala.model.domain.{Message, Parameter, Request, Response}
 import amf.apicontract.internal.metamodel.domain.MessageModel
 import amf.core.client.scala.model.domain.{DomainElement, Linkable}
-import amf.core.client.scala.transform.stages.ReferenceResolutionStage
+import amf.core.internal.transform.stages.ReferenceResolutionStage
 import amf.core.internal.parser.domain.{Annotations, Fields}
 
 class WebApiReferenceResolutionStage(keepEditingInfo: Boolean = false)

--- a/amf-cli/shared/src/main/scala/amf/cli/internal/commands/CommandHelper.scala
+++ b/amf-cli/shared/src/main/scala/amf/cli/internal/commands/CommandHelper.scala
@@ -8,7 +8,7 @@ import amf.core.client.scala.AMFGraphConfiguration
 import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.common.transform._
-import amf.core.client.scala.transform.pipelines.TransformationPipeline
+import amf.core.client.scala.transform.TransformationPipeline
 import amf.core.internal.parser.{AMFCompiler, CompilerConfiguration}
 import amf.core.internal.remote.{Cache, Context, Platform, Vendor}
 

--- a/amf-cli/shared/src/test/scala/amf/emit/CompatibilityCycledValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/emit/CompatibilityCycledValidationTest.scala
@@ -5,7 +5,7 @@ import amf.core.client.common.validation._
 import amf.core.client.scala.errorhandling.{DefaultErrorHandler, UnhandledErrorHandler}
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.common.transform._
-import amf.core.client.scala.transform.pipelines.TransformationPipeline
+import amf.core.client.scala.transform.TransformationPipeline
 import amf.core.client.scala.validation.AMFValidationReport
 import amf.core.internal.remote.Syntax.Syntax
 import amf.core.internal.remote._

--- a/amf-cli/shared/src/test/scala/amf/javaparser/org/raml/ModelTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/javaparser/org/raml/ModelTest.scala
@@ -1,13 +1,12 @@
 package amf.javaparser.org.raml
 
 import amf.apicontract.client.scala.{AMFConfiguration, WebAPIConfiguration}
-
 import amf.apicontract.internal.transformation.AmfEditingPipeline
 import amf.core.client.common.validation._
 import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.errorhandling.UnhandledErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document, EncodesModel, Module}
-import amf.core.client.scala.transform.pipelines.TransformationPipelineRunner
+import amf.core.client.scala.transform.TransformationPipelineRunner
 import amf.core.client.scala.validation.AMFValidationReport
 import amf.core.internal.annotations.SourceVendor
 import amf.core.internal.remote.{Raml10YamlHint, _}

--- a/amf-cli/shared/src/test/scala/amf/resolution/ErrorHandlingResolutionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/ErrorHandlingResolutionTest.scala
@@ -5,7 +5,7 @@ import amf.apicontract.internal.validation.definitions.ParserSideValidations.Unk
 import amf.core.client.common.validation.SeverityLevels
 import amf.core.client.scala.errorhandling.DefaultErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.pipelines.TransformationPipelineRunner
+import amf.core.client.scala.transform.TransformationPipelineRunner
 import amf.core.client.scala.validation.AMFValidationResult
 import amf.core.internal.annotations.LexicalInformation
 import amf.core.internal.remote._

--- a/amf-cli/shared/src/test/scala/amf/resolution/ProductionResolutionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/ProductionResolutionTest.scala
@@ -4,7 +4,7 @@ import amf.apicontract.internal.transformation.AmfEditingPipeline
 import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.errorhandling.UnhandledErrorHandler
 import amf.core.client.scala.model.document.Document
-import amf.core.client.scala.transform.pipelines.TransformationPipelineRunner
+import amf.core.client.scala.transform.TransformationPipelineRunner
 import amf.core.internal.plugins.document.graph.EmbeddedForm
 import amf.core.internal.remote._
 

--- a/amf-cli/shared/src/test/scala/amf/resolution/ProductionServiceTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/ProductionServiceTest.scala
@@ -5,7 +5,7 @@ import amf.core.client.scala.AMFGraphConfiguration
 import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.errorhandling.UnhandledErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.stages.ReferenceResolutionStage
+import amf.core.internal.transform.stages.ReferenceResolutionStage
 import amf.core.internal.metamodel.document.DocumentModel
 import amf.core.internal.remote._
 import org.scalatest.Assertion

--- a/amf-cli/shared/src/test/scala/amf/resolution/ResolutionCapabilities.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/ResolutionCapabilities.scala
@@ -5,7 +5,7 @@ import amf.apicontract.internal.transformation.{AmfEditingPipeline, AmfTransform
 import amf.core.client.common.transform._
 import amf.core.client.scala.errorhandling.UnhandledErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.pipelines.TransformationPipelineRunner
+import amf.core.client.scala.transform.TransformationPipelineRunner
 import amf.core.internal.remote._
 
 trait ResolutionCapabilities {

--- a/amf-cli/shared/src/test/scala/amf/resolution/stages/VariableReplacerTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/stages/VariableReplacerTest.scala
@@ -2,7 +2,7 @@ package amf.resolution.stages
 
 import amf.core.client.scala.model.domain.ScalarNode
 import amf.core.client.scala.model.domain.templates.Variable
-import amf.core.client.scala.transform.VariableReplacer
+import amf.core.internal.transform.VariableReplacer
 import org.scalatest.{FunSuite, Inspectors, Matchers}
 
 import scala.collection.mutable.ListBuffer

--- a/amf-cli/shared/src/test/scala/amf/validation/JapaneseResolvedCycleTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/JapaneseResolvedCycleTest.scala
@@ -5,7 +5,7 @@ import amf.apicontract.internal.transformation.AmfEditingPipeline
 import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.errorhandling.UnhandledErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.transform.pipelines.{TransformationPipeline, TransformationPipelineRunner}
+import amf.core.client.scala.transform.TransformationPipelineRunner
 import amf.core.internal.remote.{
   Amf,
   AmfJsonHint,

--- a/amf-cli/shared/src/test/scala/amf/validation/PlatformPayloadValidationPluginsHandlerTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/PlatformPayloadValidationPluginsHandlerTest.scala
@@ -6,7 +6,7 @@ import amf.client.validation.PayloadValidationUtils
 import amf.core.client.common.validation.StrictValidationMode
 import amf.core.client.scala.errorhandling.UnhandledErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Module}
-import amf.core.client.scala.transform.pipelines.TransformationPipelineRunner
+import amf.core.client.scala.transform.TransformationPipelineRunner
 import amf.core.internal.unsafe.PlatformSecrets
 import amf.shapes.client.scala.model.domain.AnyShape
 import org.scalatest.AsyncFunSuite

--- a/amf-cli/shared/src/test/scala/amf/validation/UniquePlatformReportGenTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/UniquePlatformReportGenTest.scala
@@ -2,12 +2,11 @@ package amf.validation
 
 import amf.apicontract.client.scala.{AMFConfiguration, AsyncAPIConfiguration, WebAPIConfiguration}
 import org.scalatest.{Assertion, AsyncFunSuite}
-
 import amf.apicontract.internal.transformation.ValidationTransformationPipeline
 import amf.core.client.common.validation._
 import amf.core.client.scala.AMFResult
 import amf.core.client.scala.errorhandling.DefaultErrorHandler
-import amf.core.client.scala.transform.pipelines.TransformationPipelineRunner
+import amf.core.client.scala.transform.TransformationPipelineRunner
 import amf.core.client.scala.validation.AMFValidationReport
 import amf.core.internal.remote.Syntax.Yaml
 import amf.core.internal.remote._

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/AnyShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/AnyShape.scala
@@ -1,17 +1,14 @@
 package amf.shapes.client.platform.model.domain
 
 import amf.core.client.platform.model.domain.Shape
-import amf.core.client.scala.model.StrField
+import amf.core.client.platform.model.StrField
 import amf.core.internal.unsafe.PlatformSecrets
-import amf.shapes.client.scala.model.domain
-import amf.shapes.internal.convert.ShapeClientConverters._
 
 import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 import amf.shapes.client.scala.model.domain.{AnyShape => InternalAnyShape}
-import amf.shapes.client.scala.model.domain
 import amf.shapes.internal.convert.ShapeClientConverters._
 
-class AnyShape(override private[amf] val _internal: domain.AnyShape) extends Shape with PlatformSecrets {
+class AnyShape(override private[amf] val _internal: InternalAnyShape) extends Shape with PlatformSecrets {
 
   @JSExportTopLevel("AnyShape")
   def this() = this(InternalAnyShape())

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/DataArrangeShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/DataArrangeShape.scala
@@ -1,8 +1,8 @@
 package amf.shapes.client.platform.model.domain
 
-import amf.core.client.scala.model.{BoolField, IntField}
+import amf.core.client.platform.model.{BoolField, IntField}
 import amf.shapes.client.scala.model.domain.DataArrangementShape
-
+import amf.shapes.internal.convert.ShapeClientConverters._
 import scala.scalajs.js.annotation.JSExportAll
 
 @JSExportAll

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/Example.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/Example.scala
@@ -1,5 +1,6 @@
 package amf.shapes.client.platform.model.domain
 
+import amf.core.client.platform.AMFGraphConfiguration
 import amf.core.client.platform.model.domain.{DataNode, DomainElement, Linkable, NamedDomainElement}
 import amf.core.client.platform.model.{BoolField, StrField}
 import amf.shapes.client.scala.model.domain.{Example => InternalExample}
@@ -66,6 +67,8 @@ case class Example(override private[amf] val _internal: InternalExample)
 
   override def linkCopy(): Example = _internal.linkCopy()
 
-  def toJson: String = _internal.toJson
-  def toYaml: String = _internal.toYaml
+  def toJson(): String                              = _internal.toJson
+  def toYaml(): String                              = _internal.toYaml
+  def toJson(config: AMFGraphConfiguration): String = _internal.toJson(config)
+  def toYaml(config: AMFGraphConfiguration): String = _internal.toYaml(config)
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/NodeShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/NodeShape.scala
@@ -1,7 +1,7 @@
 package amf.shapes.client.platform.model.domain
 
+import amf.core.client.platform.model.{BoolField, IntField, StrField}
 import amf.core.client.platform.model.domain.{PropertyShape, Shape}
-import amf.core.client.scala.model.{BoolField, IntField, StrField}
 import amf.shapes.client.scala.model.domain.{NodeShape => InternalNodeShape}
 import amf.shapes.internal.convert.ShapeClientConverters.ClientList
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/ScalarShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/ScalarShape.scala
@@ -1,8 +1,7 @@
 package amf.shapes.client.platform.model.domain
 
-import amf.core.client.scala.model.domain.Shape
-import amf.core.client.scala.model.{BoolField, DoubleField, IntField, StrField}
-import amf.shapes.client.scala.model.domain
+import amf.core.client.platform.model.domain.Shape
+import amf.core.client.platform.model.{BoolField, DoubleField, IntField, StrField}
 
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 import amf.shapes.internal.convert.ShapeClientConverters._

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/SchemaShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/SchemaShape.scala
@@ -1,7 +1,6 @@
 package amf.shapes.client.platform.model.domain
 
-import amf.core.client.scala.model.StrField
-import amf.shapes.client.scala.model.domain
+import amf.core.client.platform.model.StrField
 import amf.shapes.internal.convert.ShapeClientConverters.ClientOption
 import amf.shapes.internal.convert.ShapeClientConverters._
 
@@ -9,7 +8,7 @@ import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 import amf.shapes.client.scala.model.domain.{SchemaShape => InternalSchemaShape}
 
 @JSExportAll
-case class SchemaShape(override private[amf] val _internal: domain.SchemaShape) extends AnyShape(_internal) {
+case class SchemaShape(override private[amf] val _internal: InternalSchemaShape) extends AnyShape(_internal) {
 
   @JSExportTopLevel("SchemaShape")
   def this() = this(InternalSchemaShape())

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/TupleShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/TupleShape.scala
@@ -1,8 +1,7 @@
 package amf.shapes.client.platform.model.domain
 
+import amf.core.client.platform.model.BoolField
 import amf.core.client.platform.model.domain.Shape
-import amf.core.client.scala.model.BoolField
-import amf.shapes.client.scala.model.domain
 import amf.shapes.internal.convert.ShapeClientConverters.ClientList
 
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/UnionShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/UnionShape.scala
@@ -1,7 +1,6 @@
 package amf.shapes.client.platform.model.domain
 
 import amf.core.client.platform.model.domain.Shape
-import amf.shapes.client.scala.model.domain
 import amf.shapes.internal.convert.ShapeClientConverters.ClientList
 
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/AnyShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/AnyShape.scala
@@ -36,7 +36,7 @@ class AnyShape private[amf] (val fields: Fields, val annotations: Annotations = 
   override def meta: AnyShapeModel = AnyShapeModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/any/" + name.option().getOrElse("default-any").urlComponentEncoded
+  private[amf] override def componentId: String = "/any/" + name.option().getOrElse("default-any").urlComponentEncoded
 
   protected[amf] def copyAnyShape(fields: Fields = fields, annotations: Annotations = annotations): AnyShape =
     AnyShape(fields, annotations).withId(id)
@@ -50,7 +50,7 @@ class AnyShape private[amf] (val fields: Fields, val annotations: Annotations = 
 
   protected[amf] def inlined: Boolean = annotations.find(classOf[InlineDefinition]).isDefined
 
-  override def ramlSyntaxKey: String = "anyShape"
+  private[amf] override def ramlSyntaxKey: String = "anyShape"
 
   protected[amf] def trackedExample(trackId: String): Option[Example] = examples.find(_.isTrackedBy(trackId))
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/CreativeWork.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/CreativeWork.scala
@@ -34,7 +34,7 @@ class CreativeWork private[amf] (override val fields: Fields, override val annot
   }
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/creative-work/" + searchIdPart.orNull
+  private[amf] override def componentId: String = "/creative-work/" + searchIdPart.orNull
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement = CreativeWork.apply

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/DataArrangementShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/DataArrangementShape.scala
@@ -45,7 +45,8 @@ abstract class DataArrangementShape private[amf] (fields: Fields, annotations: A
     array
   }
 
-  override def componentId: String = "/array/" + name.option().getOrElse("default-array").urlComponentEncoded
+  private[amf] override def componentId: String =
+    "/array/" + name.option().getOrElse("default-array").urlComponentEncoded
 
   override def adopted(parent: String, cycle: Seq[String] = Seq()): this.type = {
     val isCycle = cycle.contains(id)
@@ -67,5 +68,5 @@ abstract class DataArrangementShape private[amf] (fields: Fields, annotations: A
     this
   }
 
-  override def ramlSyntaxKey: String = "arrayShape"
+  private[amf] override def ramlSyntaxKey: String = "arrayShape"
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/DiscriminatorValueMapping.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/DiscriminatorValueMapping.scala
@@ -21,7 +21,7 @@ case class DiscriminatorValueMapping private[amf] (fields: Fields, annotations: 
   override def meta: DiscriminatorValueMappingModel.type = DiscriminatorValueMappingModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String =
+  private[amf] override def componentId: String =
     s"/discriminator-value-mapping/${value.value().urlComponentEncoded}"
 }
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/Example.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/Example.scala
@@ -43,7 +43,8 @@ class Example private[amf] (override val fields: Fields, override val annotation
   override def key: StrField = fields.field(ExampleModel.key)
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/example/" + name.option().getOrElse("default-example").urlComponentEncoded
+  private[amf] override def componentId: String =
+    "/example/" + name.option().getOrElse("default-example").urlComponentEncoded
 
   def toJson: String = toJson(this, AMFGraphConfiguration.predefined())
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/FileShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/FileShape.scala
@@ -21,9 +21,9 @@ case class FileShape private[amf] (override val fields: Fields, override val ann
   override val meta: AnyShapeModel = FileShapeModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + name.option().getOrElse("default-file").urlComponentEncoded
+  private[amf] override def componentId: String = "/" + name.option().getOrElse("default-file").urlComponentEncoded
 
-  override val ramlSyntaxKey: String = "fileShape"
+  private[amf] override val ramlSyntaxKey: String = "fileShape"
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement = FileShape.apply

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/InheritanceChain.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/InheritanceChain.scala
@@ -10,42 +10,28 @@ import scala.collection.mutable
 // defined in RAML
 trait InheritanceChain { this: AnyShape =>
   // Array of subtypes to compute
-  var subTypes: mutable.Seq[Shape]   = mutable.Seq()
-  var superTypes: mutable.Seq[Shape] = mutable.Seq()
+  private var subTypes: mutable.Seq[Shape]   = mutable.Seq()
+  private var superTypes: mutable.Seq[Shape] = mutable.Seq()
   // Any ID, not only the ones with discriminator, just keep the ID ref
-  var inheritedIds: mutable.Seq[String] = mutable.Seq()
+  private[amf] var inheritedIds: mutable.Seq[String] = mutable.Seq()
 
-  def addSubType(shape: Shape): Unit = {
+  protected[amf] def addSubType(shape: Shape): Unit = {
     subTypes.find(_.id == shape.id) match {
       case Some(_) => // duplicated
       case _       => subTypes ++= Seq(shape)
     }
   }
 
-  def addSuperType(shape: Shape): Unit = {
+  protected[amf] def addSuperType(shape: Shape): Unit = {
     superTypes.find(_.id == shape.id) match {
       case Some(_) => // duplicated
       case _       => superTypes ++= Seq(shape)
     }
   }
 
-  def linkSubType(shape: AnyShape): Unit = {
+  protected[amf] def linkSubType(shape: AnyShape): Unit = {
     addSubType(shape)
     shape.addSuperType(this)
-  }
-
-  def effectiveStructuralShapes: Seq[Shape] = {
-    val acc =
-      if (annotations
-            .contains(classOf[DeclaredElement])) { // problem with inlined types extending types with discriminator
-        computeSubtypesClosure()
-      } else {
-        superTypes.find(_.isInstanceOf[AnyShape]) match { // which one if multiple inheritance?
-          case Some(superType: AnyShape) => superType.effectiveStructuralShapes
-          case _                         => Nil
-        }
-      }
-    (Seq(this) ++ acc).distinct
   }
 
   protected def computeSubtypesClosure(): Seq[Shape] = {

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/IriTemplateMapping.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/IriTemplateMapping.scala
@@ -18,7 +18,7 @@ case class IriTemplateMapping private[amf] (fields: Fields, annotations: Annotat
   override def meta: IriTemplateMappingModel.type = IriTemplateMappingModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String =
+  private[amf] override def componentId: String =
     s"/mapping/${templateVariable.option().getOrElse("unknownVar").urlComponentEncoded}"
 }
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/NilShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/NilShape.scala
@@ -14,9 +14,9 @@ case class NilShape private[amf] (override val fields: Fields, override val anno
   override val meta: AnyShapeModel = NilShapeModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/nil/" + name.option().getOrElse("default-nil").urlComponentEncoded
+  private[amf] override def componentId: String = "/nil/" + name.option().getOrElse("default-nil").urlComponentEncoded
 
-  override def ramlSyntaxKey: String = "shape"
+  private[amf] override def ramlSyntaxKey: String = "shape"
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement = NilShape.apply

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/NodeShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/NodeShape.scala
@@ -101,9 +101,9 @@ case class NodeShape private[amf] (override val fields: Fields, override val ann
   override val meta: AnyShapeModel = NodeShapeModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/" + name.option().getOrElse("default-node").urlComponentEncoded
+  private[amf] override def componentId: String = "/" + name.option().getOrElse("default-node").urlComponentEncoded
 
-  override val ramlSyntaxKey: String = "nodeShape"
+  private[amf] override val ramlSyntaxKey: String = "nodeShape"
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement = NodeShape.apply

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/PropertyDependencies.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/PropertyDependencies.scala
@@ -14,7 +14,7 @@ trait Dependencies extends DomainElement {
   def propertySource: StrField                              = fields.field(PropertySource)
   def withPropertySource(propertySource: String): this.type = set(PropertySource, propertySource)
 
-  override def componentId: String = {
+  private[amf] override def componentId: String = {
     val propertySourceName = propertySource.option().map(x => x).getOrElse("unknown").split("/").last
     s"/dependency/$propertySourceName"
   }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/ScalarShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/ScalarShape.scala
@@ -31,9 +31,10 @@ case class ScalarShape private[amf] (override val fields: Fields, override val a
   override val meta: ScalarShapeModel.type = ScalarShapeModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/scalar/" + name.option().getOrElse("default-scalar").urlComponentEncoded
+  private[amf] override def componentId: String =
+    "/scalar/" + name.option().getOrElse("default-scalar").urlComponentEncoded
 
-  override def ramlSyntaxKey: String = dataType.option().getOrElse("#shape").split("#").last match {
+  private[amf] override def ramlSyntaxKey: String = dataType.option().getOrElse("#shape").split("#").last match {
     case "integer" | "float" | "double" | "long" | "number" => "numberScalarShape"
     case "string"                                           => "stringScalarShape"
     case "dateTime"                                         => "dateScalarShape"

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/SchemaDependencies.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/SchemaDependencies.scala
@@ -23,7 +23,7 @@ case class SchemaDependencies private[amf] (fields: Fields, annotations: Annotat
     this
   }
 
-  override def componentId: String = {
+  private[amf] override def componentId: String = {
     val propertySourceName = propertySource.option().map(x => x).getOrElse("unknown").split("/").last
     s"/dependencySchema/$propertySourceName"
   }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/SchemaShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/SchemaShape.scala
@@ -20,9 +20,10 @@ case class SchemaShape private[amf] (override val fields: Fields, override val a
   override def linkCopy(): SchemaShape = SchemaShape().withId(id)
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/schema/" + name.option().getOrElse("default-schema").urlComponentEncoded
+  private[amf] override def componentId: String =
+    "/schema/" + name.option().getOrElse("default-schema").urlComponentEncoded
 
-  override def ramlSyntaxKey: String = "schemaShape" // same that any shape
+  private[amf] override def ramlSyntaxKey: String = "schemaShape" // same that any shape
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement = SchemaShape.apply
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/ShapeHelpers.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/ShapeHelpers.scala
@@ -9,19 +9,20 @@ import amf.shapes.internal.annotations.ParsedFromTypeExpression
 
 trait ShapeHelpers { this: Shape =>
 
-  def fromExternalSource: Boolean = this match {
+  private[amf] def fromExternalSource: Boolean = this match {
     case any: AnyShape => any.referenceId.option().isDefined
     case _             => false
   }
 
-  def typeExpression: Option[String] = this.annotations.find(classOf[ParsedFromTypeExpression]).map(_.value)
+  private[amf] def typeExpression: Option[String] =
+    this.annotations.find(classOf[ParsedFromTypeExpression]).map(_.value)
 
-  def externalSourceID: Option[String] = this match {
+  private[amf] def externalSourceID: Option[String] = this match {
     case any: AnyShape => any.referenceId.option()
     case _             => None
   }
 
-  def cloneAllExamples(cloned: Shape, s: Shape): Unit = (cloned, s) match {
+  private def cloneAllExamples(cloned: Shape, s: Shape): Unit = (cloned, s) match {
     case (cloned: AnyShape, s: AnyShape) =>
       cloned.withExamples(s.examples.map { e =>
         e.copyElement().asInstanceOf[Example]

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/UnionShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/UnionShape.scala
@@ -20,9 +20,10 @@ case class UnionShape private[amf] (override val fields: Fields, override val an
   override val meta: AnyShapeModel = UnionShapeModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/union/" + name.option().getOrElse("default-union").urlComponentEncoded
+  private[amf] override def componentId: String =
+    "/union/" + name.option().getOrElse("default-union").urlComponentEncoded
 
-  override def ramlSyntaxKey: String = "unionShape"
+  private[amf] override def ramlSyntaxKey: String = "unionShape"
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement = UnionShape.apply

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/UnresolvedShape.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/UnresolvedShape.scala
@@ -40,10 +40,10 @@ case class UnresolvedShape private[amf] (override val fields: Fields,
     override def modelInstance: UnresolvedShape = UnresolvedShape(Fields(), Annotations(), reference = reference)
   }
 
-  override def ramlSyntaxKey: String = "unresolvedShape"
+  private[amf] override def ramlSyntaxKey: String = "unresolvedShape"
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/unresolved"
+  private[amf] override def componentId: String = "/unresolved"
 
   override def afterResolve(fatherSyntaxKey: Option[String], resolvedKey: String): Unit = {
     fatherExtensionParser.foreach { parser =>

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/XMLSerializer.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/XMLSerializer.scala
@@ -24,7 +24,7 @@ case class XMLSerializer private[amf] (fields: Fields, annotations: Annotations)
   override def meta = XMLSerializerModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override def componentId: String = "/xml"
+  private[amf] override def componentId: String = "/xml"
 }
 
 object XMLSerializer {

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ExampleTracking.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ExampleTracking.scala
@@ -1,7 +1,8 @@
-package amf.shapes.client.scala.model.domain
+package amf.shapes.internal.domain.resolution
 
 import amf.core.client.scala.model.domain.Shape
 import amf.core.internal.annotations.TrackedElement
+import amf.shapes.client.scala.model.domain.{AnyShape, Example}
 
 // TODO tidy up code
 object ExampleTracking {

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ShapeLinksTransformer.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ShapeLinksTransformer.scala
@@ -1,7 +1,7 @@
 package amf.shapes.internal.domain.resolution
 
 import amf.core.client.scala.model.domain.{AmfArray, Shape}
-import amf.core.client.scala.transform.stages.elements.resolution.ElementStageTransformer
+import amf.core.internal.transform.stages.elements.resolution.ElementStageTransformer
 import amf.core.internal.metamodel.domain.ShapeModel
 import amf.core.internal.metamodel.domain.extensions.PropertyShapeModel
 import amf.core.internal.parser.domain.Value

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ShapeNormalizationStage.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ShapeNormalizationStage.scala
@@ -4,9 +4,9 @@ import amf.core.client.common.validation.ProfileName
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.{DomainElement, Shape}
-import amf.core.client.scala.transform.stages.TransformationStep
-import amf.core.client.scala.transform.stages.elements.resolution.ElementStageTransformer
-import amf.core.client.scala.transform.stages.selectors.ShapeSelector
+import amf.core.client.scala.transform.TransformationStep
+import amf.core.internal.transform.stages.elements.resolution.ElementStageTransformer
+import amf.core.internal.transform.stages.selectors.ShapeSelector
 import amf.shapes.internal.domain.resolution.shape_normalization._
 
 /**

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ShapeTransformer.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ShapeTransformer.scala
@@ -3,13 +3,9 @@ package amf.shapes.internal.domain.resolution
 import amf.core.client.common.validation.ProfileName
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.domain.Shape
-import amf.core.client.scala.transform.stages.elements.resolution.ElementStageTransformer
+import amf.core.internal.transform.stages.elements.resolution.ElementStageTransformer
 import amf.shapes.internal.domain.resolution.recursion.RecursionErrorRegister
-import amf.shapes.internal.domain.resolution.shape_normalization.{
-  NormalizationContext,
-  ShapeCanonizer,
-  ShapeExpander
-}
+import amf.shapes.internal.domain.resolution.shape_normalization.{NormalizationContext, ShapeCanonizer, ShapeExpander}
 
 class ShapeTransformer(context: NormalizationContext) extends ElementStageTransformer[Shape] {
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/elements/CompleteShapeTransformationPipeline.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/elements/CompleteShapeTransformationPipeline.scala
@@ -3,8 +3,8 @@ package amf.shapes.internal.domain.resolution.elements
 import amf.core.client.common.validation.ProfileName
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.domain.Shape
-import amf.core.client.scala.transform.pipelines.elements.ElementTransformationPipeline
-import amf.core.client.scala.transform.stages.elements.resolution.ElementStageTransformer
+import amf.core.internal.transform.pipelines.elements.ElementTransformationPipeline
+import amf.core.internal.transform.stages.elements.resolution.ElementStageTransformer
 import amf.shapes.internal.domain.resolution.{ShapeChainLinksTransformer, ShapeTransformer}
 
 class CompleteShapeTransformationPipeline(shape: Shape, errorHandler: AMFErrorHandler, profileName: ProfileName)

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/datanode/AbstractVariables.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/datanode/AbstractVariables.scala
@@ -1,7 +1,7 @@
 package amf.shapes.internal.spec.datanode
 
 import amf.core.client.scala.model.domain.AmfScalar
-import amf.core.client.scala.transform.VariableReplacer.VariableRegex
+import amf.core.internal.transform.VariableReplacer.VariableRegex
 import amf.core.internal.parser.domain.{Annotations, ScalarNode}
 import org.yaml.model.YNode
 


### PR DESCRIPTION
- add toRamlDataType in element client
- add forInstance methods in platform client
- remove client.scala imports from client.platform (primarily incorrect StrField imports)
- make internal methods defined in client.scala private or moved to internal.

changes also apply for https://github.com/aml-org/amf-aml/pull/330 and https://github.com/aml-org/amf-core/pull/295