### PR TITLE
APIMF-3209: catch duplicated nullable property names

### DIFF
--- a/amf-client/shared/src/test/resources/validations/duplicate-property/api.raml
+++ b/amf-client/shared/src/test/resources/validations/duplicate-property/api.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0
+title: test-duplicated-properties-raml10
+
+types:
+  test-duplicated-properties:
+    type: object
+    properties:
+      a: string
+      a?: string
+      b: string
+      b?: string
+      c: string
+      d: string

--- a/amf-client/shared/src/test/resources/validations/reports/model/raml/duplicated-property.report
+++ b/amf-client/shared/src/test/resources/validations/reports/model/raml/duplicated-property.report
@@ -1,0 +1,14 @@
+Model: file://amf-client/shared/src/test/resources/validations/duplicate-property/api.raml
+Profile: RAML 1.0
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/parser#NodeShape-properties-duplicatePropertyNames
+  Message: Duplicated property names: b, a
+  Level: Violation
+  Target: file://amf-client/shared/src/test/resources/validations/duplicate-property/api.raml#/declarations/types/test-duplicated-properties
+  Property: http://www.w3.org/ns/shacl#property
+  Position: Some(LexicalInformation([(8,6)-(9,0)]))
+  Location: file://amf-client/shared/src/test/resources/validations/duplicate-property/api.raml

--- a/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-client/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -598,4 +598,8 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
   test("multiple uses objects pointing to the same library file") {
     validate("multiple-uses/multiple-uses.raml")
   }
+
+  test("invalid duplicated nullable property") {
+    validate("duplicate-property/api.raml", Some("raml/duplicated-property.report"))
+  }
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/validation/AMFRawValidations.scala
@@ -4,7 +4,6 @@ import amf._
 import amf.core.validation.{SeverityLevels => Severity}
 import amf.core.vocabulary.Namespace.XsdTypes
 import amf.core.vocabulary.{Namespace, ValueType}
-import amf.plugins.document.webapi.validation.AMFRawValidations.AMFValidation
 import amf.plugins.domain.webapi.metamodel._
 
 object AMFRawValidations {
@@ -936,7 +935,12 @@ object AMFRawValidations {
 
   object Raml10Validations extends RamlValidations {
     private lazy val result = super.validations() ++ Seq(
+      AMFValidation(
+        owlClass = sh("NodeShape"),
+        owlProperty = sh("properties"),
+        constraint = shape("duplicatePropertyNames")
       )
+    )
 
     override def validations(): Seq[AMFValidation] = result
   }

--- a/amf-webapi/shared/src/main/scala/amf/validations/CustomShaclFunctions.scala
+++ b/amf-webapi/shared/src/main/scala/amf/validations/CustomShaclFunctions.scala
@@ -1,51 +1,60 @@
 package amf.validations
 
-import java.util.regex.Pattern
-
 import amf.core.annotations.SynthesizedField
-import amf.core.metamodel.Field
 import amf.core.metamodel.domain.extensions.PropertyShapeModel
+import amf.core.model.domain._
 import amf.core.model.domain.extensions.PropertyShape
-import amf.core.model.domain.{AmfArray, AmfElement, AmfScalar, DomainElement, Shape}
-import amf.core.parser.Annotations
-import amf.core.services.RuntimeValidator.{CustomShaclFunctions, PropertyInfo}
+import amf.core.services.RuntimeValidator.{CustomShaclFunction, CustomShaclFunctions, ValidationInfo}
 import amf.core.utils.RegexConverter
 import amf.plugins.document.webapi.validation.runtimeexpression.{AsyncExpressionValidator, Oas3ExpressionValidator}
 import amf.plugins.domain.shapes.metamodel._
 import amf.plugins.domain.shapes.models.{FileShape, NodeShape, ScalarShape}
-import amf.plugins.domain.webapi.metamodel.bindings.{BindingHeaders, BindingQuery, HttpMessageBindingModel}
-import amf.plugins.domain.webapi.metamodel.security.{OAuth2SettingsModel, OpenIdConnectSettingsModel, SecuritySchemeModel}
 import amf.plugins.domain.webapi.metamodel._
 import amf.plugins.domain.webapi.metamodel.api.BaseApiModel
-import amf.plugins.domain.webapi.models.{IriTemplateMapping, Parameter}
+import amf.plugins.domain.webapi.metamodel.bindings.{BindingHeaders, BindingQuery, HttpMessageBindingModel}
+import amf.plugins.domain.webapi.metamodel.security.{
+  OAuth2SettingsModel,
+  OpenIdConnectSettingsModel,
+  SecuritySchemeModel
+}
+import amf.plugins.domain.webapi.models.IriTemplateMapping
 import amf.plugins.domain.webapi.models.security.{OAuth2Settings, OpenIdConnectSettings}
+
+import java.util.regex.Pattern
 
 object CustomShaclFunctions {
 
-  val functions: CustomShaclFunctions = Map(
-    "pathParameterRequiredProperty" -> ((element, violation) => {
-      val optBindingValue  = element.fields.?[AmfScalar](ParameterModel.Binding).map(_.value)
-      val optRequiredValue = element.fields.?[AmfScalar](ParameterModel.Required).map(_.value)
-      (optBindingValue, optRequiredValue) match {
-        case (Some("path"), Some(false)) | (Some("path"), None) =>
-          violation(None)
-        case _ =>
+  val listOfFunctions: List[CustomShaclFunction] = List(
+    new CustomShaclFunction {
+      override val name: String = "pathParameterRequiredProperty"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        val optBindingValue  = element.fields.?[AmfScalar](ParameterModel.Binding).map(_.value)
+        val optRequiredValue = element.fields.?[AmfScalar](ParameterModel.Required).map(_.value)
+        (optBindingValue, optRequiredValue) match {
+          case (Some("path"), Some(false)) | (Some("path"), None) =>
+            validate(None)
+          case _ =>
+        }
       }
-    }),
-    "fileParameterMustBeInFormData" -> ((element, violation) => {
-      element.fields
-        .getValueAsOption(ParameterModel.Schema)
-        .foreach(field =>
-          field.value match {
-            case _: FileShape =>
-              val optBindingValue = element.fields.?[AmfScalar](ParameterModel.Binding).map(_.value)
-              if (optBindingValue.isEmpty || optBindingValue.get != "formData")
-                violation(None)
-            case _ => None
-        })
-    }),
-    "minimumMaximumValidation" ->
-      ((element, violation) => {
+    },
+    new CustomShaclFunction {
+      override val name: String = "fileParameterMustBeInFormData"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        element.fields
+          .getValueAsOption(ParameterModel.Schema)
+          .foreach(field =>
+            field.value match {
+              case _: FileShape =>
+                val optBindingValue = element.fields.?[AmfScalar](ParameterModel.Binding).map(_.value)
+                if (optBindingValue.isEmpty || optBindingValue.get != "formData")
+                  validate(None)
+              case _ => None
+          })
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "minimumMaximumValidation"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
         for {
           minInclusive <- element.fields.?[AmfScalar](ScalarShapeModel.Minimum)
           maxInclusive <- element.fields.?[AmfScalar](ScalarShapeModel.Maximum)
@@ -53,214 +62,279 @@ object CustomShaclFunctions {
           val minValue = minInclusive.toString.toDouble
           val maxValue = maxInclusive.toString.toDouble
           if (minValue > maxValue) {
-            violation(None)
+            validate(None)
           }
         }
-      }),
-    "minMaxItemsValidation" -> ((element, violation) => {
-      for {
-        minInclusive <- element.fields.?[AmfScalar](ArrayShapeModel.MinItems)
-        maxInclusive <- element.fields.?[AmfScalar](ArrayShapeModel.MaxItems)
-      } yield {
-        val minValue = minInclusive.toString.toDouble
-        val maxValue = maxInclusive.toString.toDouble
-        if (minValue > maxValue) {
-          violation(None)
-        }
       }
-    }),
-    "minMaxPropertiesValidation" -> ((element, violation) => {
-      for {
-        minInclusive <- element.fields.?[AmfScalar](NodeShapeModel.MinProperties)
-        maxInclusive <- element.fields.?[AmfScalar](NodeShapeModel.MaxProperties)
-      } yield {
-        val minValue = minInclusive.toString.toDouble
-        val maxValue = maxInclusive.toString.toDouble
-        if (minValue > maxValue) {
-          violation(None)
-        }
-      }
-    }),
-    "minMaxLengthValidation" -> ((element, violation) => {
-      for {
-        minInclusive <- element.fields.?[AmfScalar](ScalarShapeModel.MinLength)
-        maxInclusive <- element.fields.?[AmfScalar](ScalarShapeModel.MaxLength)
-      } yield {
-        val minValue = minInclusive.value.toString.toDouble
-        val maxValue = maxInclusive.value.toString.toDouble
-        if (minValue > maxValue) {
-          violation(None)
-        }
-      }
-    }),
-    "xmlWrappedScalar" -> ((element, violation) => {
-      element match {
-        case scalar: ScalarShape =>
-          scalar.fields.?[DomainElement](AnyShapeModel.XMLSerialization) match {
-            case Some(xmlSerialization) =>
-              xmlSerialization.fields
-                .fields()
-                .find(f => f.field.value.iri().endsWith("xmlWrapped"))
-                .foreach { isWrappedEntry =>
-                  val isWrapped = isWrappedEntry.scalar.toBool
-                  if (isWrapped) {
-                    violation(None)
-                  }
-                }
-            case _ =>
+    },
+    new CustomShaclFunction {
+      override val name: String = "minMaxItemsValidation"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        for {
+          minInclusive <- element.fields.?[AmfScalar](ArrayShapeModel.MinItems)
+          maxInclusive <- element.fields.?[AmfScalar](ArrayShapeModel.MaxItems)
+        } yield {
+          val minValue = minInclusive.toString.toDouble
+          val maxValue = maxInclusive.toString.toDouble
+          if (minValue > maxValue) {
+            validate(None)
           }
-        case _ =>
+        }
       }
-    }),
-    "xmlNonScalarAttribute" -> ((element, violation) => {
-      element.fields.getValueAsOption(AnyShapeModel.XMLSerialization) match {
-        case Some(xmlSerialization) =>
-          xmlSerialization.value match {
-            case xmlElement: DomainElement =>
-              val xmlAttribute = xmlElement.fields.?[AmfScalar](XMLSerializerModel.Attribute)
-              xmlAttribute
-                .foreach { attributeScalar =>
-                  val isAttribute = attributeScalar.toBool
-                  val isNonScalar = !element.meta.`type`.exists(_.name == "ScalarShape")
-                  if (isAttribute && isNonScalar)
-                    violation(None)
-                }
-            case _ =>
+    },
+    new CustomShaclFunction {
+      override val name: String = "minMaxPropertiesValidation"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        for {
+          minInclusive <- element.fields.?[AmfScalar](NodeShapeModel.MinProperties)
+          maxInclusive <- element.fields.?[AmfScalar](NodeShapeModel.MaxProperties)
+        } yield {
+          val minValue = minInclusive.toString.toDouble
+          val maxValue = maxInclusive.toString.toDouble
+          if (minValue > maxValue) {
+            validate(None)
           }
-        case None => // Nothing
-      }
-    }),
-    "patternValidation" -> ((element, violation) => {
-      element.fields.?[AmfScalar](ScalarShapeModel.Pattern).foreach { pattern =>
-        try Pattern.compile(pattern.toString.convertRegex)
-        catch {
-          case _: Throwable =>
-            violation(None)
         }
       }
-    }),
-    "nonEmptyListOfProtocols" -> ((element, violation) => {
-      val maybeValue = element.fields.getValueAsOption(BaseApiModel.Schemes)
-      maybeValue
-        .map(_.value)
-        .foreach {
-          case AmfArray(elements, _) if elements.isEmpty =>
-            violation(Some(Annotations(), BaseApiModel.Schemes))
-          case _ =>
-        }
-    }),
-    "exampleMutuallyExclusiveFields" -> ((element, violation) => {
-      for {
-        _ <- element.fields.getValueAsOption(ExampleModel.StructuredValue)
-        _ <- element.fields.getValueAsOption(ExampleModel.ExternalValue)
-      } yield {
-        violation(None)
-      }
-    }),
-    "requiredOpenIdConnectUrl" -> ((element, violation) => {
-      element.fields.getValueAsOption(SecuritySchemeModel.Settings).map(_.value) foreach {
-        case OpenIdConnectSettings(fields, _) =>
-          if (!fields.exists(OpenIdConnectSettingsModel.Url)) violation(None)
-        case _ =>
-      }
-    }),
-    "requiredFlowsInOAuth2" -> ((element, violation) => {
-      element.fields.getValueAsOption(SecuritySchemeModel.Settings).map(_.value) foreach {
-        case OAuth2Settings(fields, _) =>
-          if (!fields.exists(OAuth2SettingsModel.Flows)) violation(None)
-        case _ =>
-      }
-    }),
-    "validCallbackExpression" -> ((callback, violation) => {
-      val optExpression = callback.fields.getValueAsOption(CallbackModel.Expression).map(_.value)
-      validateOas3Expression(optExpression, () => violation(Some(Annotations(), CallbackModel.Expression)))
-    }),
-    "validLinkRequestBody" -> ((link, violation) => {
-      val optExpression = link.fields.getValueAsOption(TemplatedLinkModel.RequestBody).map(_.value)
-      validateOas3Expression(optExpression, () => violation(Some(Annotations(), TemplatedLinkModel.RequestBody)))
-    }),
-    "validLinkParameterExpressions" -> ((link, violation) => {
-      val maybeArray = link.fields.?[AmfArray](TemplatedLinkModel.Mapping)
-      maybeArray foreach { array =>
-        array.values.foreach {
-          case link: IriTemplateMapping =>
-            val optExpression: Option[AmfElement] =
-              link.fields.getValueAsOption(IriTemplateMappingModel.LinkExpression).map(_.value)
-            validateOas3Expression(optExpression, () => violation(Some(Annotations(), TemplatedLinkModel.Mapping)))
-          case _ =>
+    },
+    new CustomShaclFunction {
+      override val name: String = "minMaxLengthValidation"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        for {
+          minInclusive <- element.fields.?[AmfScalar](ScalarShapeModel.MinLength)
+          maxInclusive <- element.fields.?[AmfScalar](ScalarShapeModel.MaxLength)
+        } yield {
+          val minValue = minInclusive.value.toString.toDouble
+          val maxValue = maxInclusive.value.toString.toDouble
+          if (minValue > maxValue) {
+            validate(None)
+          }
         }
       }
-    }),
-    "validCorrelationIdLocation" -> ((link, violation) => {
-      val optExpression = link.fields.getValueAsOption(CorrelationIdModel.Location).map(_.value)
-      validateAsyncExpression(optExpression, () => violation(Some(Annotations(), CorrelationIdModel.Location)))
-    }),
-    "validParameterLocation" -> ((link, violation) => {
-      val location = link.fields.getValueAsOption(ParameterModel.Binding)
-      if (location.exists(!_.annotations.contains(classOf[SynthesizedField]))) {
-        validateAsyncExpression(location.map(_.value), () => violation(Some(Annotations(), ParameterModel.Binding)))
-      }
-    }),
-    "mandatoryHeadersObjectNodeWithPropertiesFacet" -> ((element, violation) => {
-      for {
-        headerElement <- element.fields.?[AmfElement](BindingHeaders.Headers)
-      } yield {
-        val isObjectAndHasProperties = validateObjectAndHasProperties(headerElement)
-        if (!isObjectAndHasProperties) violation(None)
-      }
-    }),
-    "mandatoryQueryObjectNodeWithPropertiesFacet" -> ((element, violation) => {
-      for {
-        queryElement <- element.fields.?[AmfElement](BindingQuery.Query)
-      } yield {
-        val isObjectAndHasProperties = validateObjectAndHasProperties(queryElement)
-        if (!isObjectAndHasProperties) violation(None)
-      }
-    }),
-    "mandatoryHeaderNamePattern" -> ((element, violation) => {
-      for {
-        headerName <- element.fields ? [AmfScalar] ParameterModel.ParameterName
-        binding    <- element.fields ? [AmfScalar] ParameterModel.Binding
-      } yield {
-        binding.toString match {
-          case "header" if isInvalidHttpHeaderName(headerName.toString) => violation(None)
-          case _                                                    => // ignore
-        }
-      }
-    }),
-    "discriminatorInRequiredProperties" -> ((element, violation) => {
-      for {
-        discriminator <- element.fields.?[AmfScalar](NodeShapeModel.Discriminator)
-      } yield {
+    },
+    new CustomShaclFunction {
+      override val name: String = "xmlWrappedScalar"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
         element match {
-          case shape: NodeShape if !isRequiredPropertyInShape(shape, discriminator.value.toString) =>
-            violation(Some(shape.discriminator.annotations(), NodeShapeModel.Discriminator))
-          case  _ => // ignore
-        }
-      }
-    }),
-    "mandatoryHeaderBindingNamePattern" -> ((element, violation) => {
-      for {
-        header <- element.fields.?[Shape](HttpMessageBindingModel.Headers)
-      } yield {
-        header match {
-          case n: NodeShape =>
-            n.properties.foreach { p =>
-              p.name.option() match {
-                case Some(name) if isInvalidHttpHeaderName(name) => violation(Some(p.name.annotations(), PropertyShapeModel.Name))
-                case _                                       => // ignore
-              }
+          case scalar: ScalarShape =>
+            scalar.fields.?[DomainElement](AnyShapeModel.XMLSerialization) match {
+              case Some(xmlSerialization) =>
+                xmlSerialization.fields
+                  .fields()
+                  .find(f => f.field.value.iri().endsWith("xmlWrapped"))
+                  .foreach { isWrappedEntry =>
+                    val isWrapped = isWrappedEntry.scalar.toBool
+                    if (isWrapped) {
+                      validate(None)
+                    }
+                  }
+              case _ =>
             }
-          case _ => // ignore
+          case _ =>
         }
       }
-    }),
+    },
+    new CustomShaclFunction {
+      override val name: String = "xmlNonScalarAttribute"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        element.fields.getValueAsOption(AnyShapeModel.XMLSerialization) match {
+          case Some(xmlSerialization) =>
+            xmlSerialization.value match {
+              case xmlElement: DomainElement =>
+                val xmlAttribute = xmlElement.fields.?[AmfScalar](XMLSerializerModel.Attribute)
+                xmlAttribute
+                  .foreach { attributeScalar =>
+                    val isAttribute = attributeScalar.toBool
+                    val isNonScalar = !element.meta.`type`.exists(_.name == "ScalarShape")
+                    if (isAttribute && isNonScalar)
+                      validate(None)
+                  }
+              case _ =>
+            }
+          case None => // Nothing
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "patternValidation"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        element.fields.?[AmfScalar](ScalarShapeModel.Pattern).foreach { pattern =>
+          try Pattern.compile(pattern.toString.convertRegex)
+          catch {
+            case _: Throwable =>
+              validate(None)
+          }
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "nonEmptyListOfProtocols"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        val maybeValue = element.fields.getValueAsOption(BaseApiModel.Schemes)
+        maybeValue
+          .map(_.value)
+          .foreach {
+            case AmfArray(elements, _) if elements.isEmpty =>
+              validate(Some(ValidationInfo(BaseApiModel.Schemes)))
+            case _ =>
+          }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "exampleMutuallyExclusiveFields"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        for {
+          _ <- element.fields.getValueAsOption(ExampleModel.StructuredValue)
+          _ <- element.fields.getValueAsOption(ExampleModel.ExternalValue)
+        } yield {
+          validate(None)
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "requiredOpenIdConnectUrl"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        element.fields.getValueAsOption(SecuritySchemeModel.Settings).map(_.value) foreach {
+          case OpenIdConnectSettings(fields, _) =>
+            if (!fields.exists(OpenIdConnectSettingsModel.Url)) validate(None)
+          case _ =>
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "requiredFlowsInOAuth2"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        element.fields.getValueAsOption(SecuritySchemeModel.Settings).map(_.value) foreach {
+          case OAuth2Settings(fields, _) =>
+            if (!fields.exists(OAuth2SettingsModel.Flows)) validate(None)
+          case _ =>
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "validCallbackExpression"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        val optExpression = element.fields.getValueAsOption(CallbackModel.Expression).map(_.value)
+        validateOas3Expression(optExpression, () => validate(Some(ValidationInfo(CallbackModel.Expression))))
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "validLinkRequestBody"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        val optExpression = element.fields.getValueAsOption(TemplatedLinkModel.RequestBody).map(_.value)
+        validateOas3Expression(optExpression, () => validate(Some(ValidationInfo(TemplatedLinkModel.RequestBody))))
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "validLinkParameterExpressions"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        val maybeArray = element.fields.?[AmfArray](TemplatedLinkModel.Mapping)
+        maybeArray foreach { array =>
+          array.values.foreach {
+            case link: IriTemplateMapping =>
+              val optExpression: Option[AmfElement] =
+                link.fields.getValueAsOption(IriTemplateMappingModel.LinkExpression).map(_.value)
+              validateOas3Expression(optExpression, () => validate(Some(ValidationInfo(TemplatedLinkModel.Mapping))))
+            case _ =>
+          }
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "validCorrelationIdLocation"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        val optExpression = element.fields.getValueAsOption(CorrelationIdModel.Location).map(_.value)
+        validateAsyncExpression(optExpression, () => validate(Some(ValidationInfo(CorrelationIdModel.Location))))
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "validParameterLocation"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        val location = element.fields.getValueAsOption(ParameterModel.Binding)
+        if (location.exists(!_.annotations.contains(classOf[SynthesizedField]))) {
+          validateAsyncExpression(location.map(_.value), () => validate(Some(ValidationInfo(ParameterModel.Binding))))
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "mandatoryHeadersObjectNodeWithPropertiesFacet"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        for {
+          headerElement <- element.fields.?[AmfElement](BindingHeaders.Headers)
+        } yield {
+          val isObjectAndHasProperties = validateObjectAndHasProperties(headerElement)
+          if (!isObjectAndHasProperties) validate(None)
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "mandatoryQueryObjectNodeWithPropertiesFacet"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        for {
+          queryElement <- element.fields.?[AmfElement](BindingQuery.Query)
+        } yield {
+          val isObjectAndHasProperties = validateObjectAndHasProperties(queryElement)
+          if (!isObjectAndHasProperties) validate(None)
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "mandatoryHeaderNamePattern"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        for {
+          headerName <- element.fields ? [AmfScalar] ParameterModel.ParameterName
+          binding    <- element.fields ? [AmfScalar] ParameterModel.Binding
+        } yield {
+          binding.toString match {
+            case "header" if isInvalidHttpHeaderName(headerName.toString) => validate(None)
+            case _                                                        => // ignore
+          }
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "discriminatorInRequiredProperties"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        for {
+          discriminator <- element.fields.?[AmfScalar](NodeShapeModel.Discriminator)
+        } yield {
+          element match {
+            case shape: NodeShape if !isRequiredPropertyInShape(shape, discriminator.value.toString) =>
+              validate(Some(ValidationInfo(NodeShapeModel.Discriminator)))
+            case _ => // ignore
+          }
+        }
+      }
+    },
+    new CustomShaclFunction {
+      override val name: String = "mandatoryHeaderBindingNamePattern"
+      override def run(element: AmfObject, validate: Option[ValidationInfo] => Unit): Unit = {
+        for {
+          header <- element.fields.?[Shape](HttpMessageBindingModel.Headers)
+        } yield {
+          header match {
+            case n: NodeShape =>
+              n.properties.foreach { p =>
+                p.name.option() match {
+                  case Some(name) if isInvalidHttpHeaderName(name) =>
+                    validate(Some(ValidationInfo(PropertyShapeModel.Name)))
+                  case _ => // ignore
+                }
+              }
+            case _ => // ignore
+          }
+        }
+      }
+    },
   )
 
-  private def isRequiredPropertyInShape(shape: NodeShape, name: String) = shape.properties.filter(isRequiredProperty).exists {
-    p => p.name.option() match {
+  val functions: CustomShaclFunctions = listOfFunctions.map(f => f.name -> f).toMap
+
+  private def isRequiredPropertyInShape(shape: NodeShape, name: String) =
+    shape.properties.filter(isRequiredProperty).exists { p =>
+      p.name.option() match {
         case Some(propertyName) => propertyName == name
-        case _ => false
+        case _                  => false
       }
     }
 
@@ -288,7 +362,8 @@ object CustomShaclFunctions {
   }
 
   // Obtained from the BNF in: https://tools.ietf.org/html/rfc7230#section-3.2
-  private def isInvalidHttpHeaderName(name: String): Boolean = !name.matches("^[!#$%&'*\\+\\-\\.^\\_\\`\\|\\~0-9a-zA-Z]+$")
+  private def isInvalidHttpHeaderName(name: String): Boolean =
+    !name.matches("^[!#$%&'*\\+\\-\\.^\\_\\`\\|\\~0-9a-zA-Z]+$")
 
   private def isRequiredProperty(shape: PropertyShape) = shape.minCount.option().contains(1)
 }


### PR DESCRIPTION
- refactor: improve CustomShaclValidator
- APIMF-3209: catch duplicated nullable property names
