### PR TITLE
APIMF-3212: cherry-pick to remod-breaking

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtendsResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtendsResolutionStage.scala
@@ -35,11 +35,11 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 /**
-  * 1) Get a queue of resource types for this Endpoint.
-  * 2) Resolve each resource type and merge each one to the endpoint. Start with the closest to the endpoint.
-  * 3) Get the traits as branches, as described in the spec, to get the order of the traits to apply.
-  * 4) Resolve each trait and merge each one to the operation in the provided order..
-  * 5) Remove 'extends' property from the endpoint and from the operations.
+  *  1. Get a queue of resource types for this Endpoint.
+  *  1. Resolve each resource type and merge each one to the endpoint. Start with the closest to the endpoint.
+  *  1. Get the traits as branches, as described in the spec, to get the order of the traits to apply.
+  *  1. Resolve each trait and merge each one to the operation in the provided order..
+  *  1. Remove 'extends' property from the endpoint and from the operations.
   */
 class ExtendsResolutionStage(profile: ProfileName, val keepEditingInfo: Boolean, val fromOverlay: Boolean = false)
     extends TransformationStep()

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtensionsResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/ExtensionsResolutionStage.scala
@@ -315,9 +315,9 @@ class ExtensionResolutionStage(override val profile: ProfileName, override val k
                                           other: AmfArray,
                                           extensionId: String,
                                           extensionLocation: Option[String]): Unit = {
-    other.values.foreach { value =>
-      target.add(field, value)
-    }
+    val targetValues = target.fields.get(field).asInstanceOf[AmfArray].values
+    val mergedValues = (targetValues ++ other.values).distinct
+    target.set(field, AmfArray(mergedValues))
   }
 
   override val restrictions: MergingRestrictions = MergingRestrictions.unrestricted

--- a/amf-cli/shared/src/test/resources/production/override-enum/api.raml
+++ b/amf-cli/shared/src/test/resources/production/override-enum/api.raml
@@ -1,0 +1,14 @@
+#%RAML 1.0
+title: test API to be extended
+
+types:
+  TestObject:
+    type: object
+
+/test:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: TestObject

--- a/amf-cli/shared/src/test/resources/production/override-enum/extension.raml
+++ b/amf-cli/shared/src/test/resources/production/override-enum/extension.raml
@@ -1,0 +1,19 @@
+#%RAML 1.0 Extension
+extends: /api.raml
+types:
+  TestObject:
+    properties:
+      testObjectProperty:
+        enum:
+          - A
+          - B
+    example:
+        testObjectProperty: A
+
+/test:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: TestObject

--- a/amf-cli/shared/src/test/resources/production/override-enum/result.raml
+++ b/amf-cli/shared/src/test/resources/production/override-enum/result.raml
@@ -1,0 +1,19 @@
+#%RAML 1.0
+title: test API to be extended
+/test:
+  get:
+    responses:
+      "200":
+        body:
+          application/json:
+            type: object
+            example:
+              testObjectProperty: A
+            additionalProperties: true
+            properties:
+              testObjectProperty:
+                enum:
+                  - A
+                  - B
+                type: string
+                required: true

--- a/amf-cli/shared/src/test/scala/amf/resolution/ProductionValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/ProductionValidationTest.scala
@@ -34,4 +34,7 @@ class ProductionValidationTest extends RamlResolutionTest {
     cycle("api.raml", "api.raml.raml", Raml10YamlHint, Raml10, directory = basePath + "patch-method/")
   }
 
+  test("Override enum in extension raml to raml") {
+    cycle("extension.raml", "result.raml", Raml10YamlHint, Raml10, directory = basePath + "override-enum/")
+  }
 }


### PR DESCRIPTION
fix duplication of enum values when applying raml extension