### PR TITLE
APIMF-2973/5: make nillable notation behave like union

### DIFF
--- a/amf-cli/shared/src/test/resources/union/optional-object.out.editing.raml
+++ b/amf-cli/shared/src/test/resources/union/optional-object.out.editing.raml
@@ -1,16 +1,6 @@
 #%RAML 1.0
 title: New API
 types:
-  SomeType:
-    type: object
-    additionalProperties: true
-    properties:
-      a:
-        type: string
-        required: true
-      b:
-        type: integer
-        required: true
   OtherType:
     anyOf:
       -
@@ -25,6 +15,16 @@ types:
             required: true
       -
         type: nil
+  SomeType:
+    type: object
+    additionalProperties: true
+    properties:
+      a:
+        type: string
+        required: true
+      b:
+        type: integer
+        required: true
 /someEndpoint:
   post:
     body:

--- a/amf-cli/shared/src/test/resources/union/optional-object.out.raml
+++ b/amf-cli/shared/src/test/resources/union/optional-object.out.raml
@@ -1,6 +1,8 @@
 #%RAML 1.0
 title: New API
 types:
+  OtherType:
+    type: SomeType | nil
   SomeType:
     type: object
     properties:
@@ -8,12 +10,6 @@ types:
         type: string
       b:
         type: integer
-  OtherType:
-    anyOf:
-      -
-        type: SomeType
-      -
-        type: nil
 /someEndpoint:
   post:
     body:

--- a/amf-cli/shared/src/test/resources/union/optional-scalar.out.editing.raml
+++ b/amf-cli/shared/src/test/resources/union/optional-scalar.out.editing.raml
@@ -1,20 +1,12 @@
 #%RAML 1.0
 title: New API
+types:
+  SomeType:
+    description: some description
+    type: string | nil
 /someEndpoint:
   post:
     body:
       application/json:
-        anyOf:
-          -
-            type: string
-            description: some description
-          -
-            type: nil
-types:
-  SomeType:
-    anyOf:
-      -
-        type: string
         description: some description
-      -
-        type: nil
+        type: string | nil

--- a/amf-cli/shared/src/test/resources/union/optional-scalar.out.raml
+++ b/amf-cli/shared/src/test/resources/union/optional-scalar.out.raml
@@ -1,15 +1,11 @@
 #%RAML 1.0
 title: New API
+types:
+  SomeType:
+    type: string | nil
+    description: some description
 /someEndpoint:
   post:
     body:
       application/json:
         type: SomeType
-types:
-  SomeType:
-    anyOf:
-      -
-        type: string
-        description: some description
-      -
-        type: nil

--- a/amf-cli/shared/src/test/resources/union/union-default.out.default.raml
+++ b/amf-cli/shared/src/test/resources/union/union-default.out.default.raml
@@ -4,5 +4,5 @@ title: New API
   post:
     body:
       application/json:
-        description: some description
-        type: string | nil
+        default: 20
+        type: integer | nil

--- a/amf-cli/shared/src/test/resources/union/union-default.out.editing.raml
+++ b/amf-cli/shared/src/test/resources/union/union-default.out.editing.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: New API
+types:
+  UnionType:
+    default: 20
+    type: integer | nil
+/someEndpoint:
+  post:
+    body:
+      application/json:
+        default: 20
+        type: integer | nil

--- a/amf-cli/shared/src/test/resources/union/union-default.out.raml
+++ b/amf-cli/shared/src/test/resources/union/union-default.out.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+title: New API
+types:
+  UnionType:
+    type: integer | nil
+    default: 20
+/someEndpoint:
+  post:
+    body:
+      application/json:
+        type: UnionType

--- a/amf-cli/shared/src/test/resources/union/union-default.raml
+++ b/amf-cli/shared/src/test/resources/union/union-default.raml
@@ -1,8 +1,13 @@
 #%RAML 1.0
 title: New API
+
+types:
+  UnionType:
+    type: integer?
+    default: 20
+
 /someEndpoint:
   post:
     body:
       application/json:
-        description: some description
-        type: string | nil
+        type: UnionType

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml.expanded.jsonld
@@ -335,7 +335,7 @@
         ],
         "http://a.ml/vocabularies/shapes#schema": [
           {
-            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema",
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored",
             "@type": [
               "http://a.ml/vocabularies/shapes#UnionShape",
               "http://a.ml/vocabularies/shapes#AnyShape",
@@ -343,58 +343,125 @@
               "http://a.ml/vocabularies/shapes#Shape",
               "http://a.ml/vocabularies/document#DomainElement"
             ],
-            "http://a.ml/vocabularies/shapes#anyOf": [
+            "http://www.w3.org/ns/shacl#name": [
               {
-                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/",
+                "@value": "ignored"
+              }
+            ],
+            "http://a.ml/vocabularies/core#description": [
+              {
+                "@value": "This annotation allows to specify a method which will not be transformed into an operation.\nOptionally, a reason can be defined.\n"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#inherits": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union",
                 "@type": [
-                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#UnionShape",
                   "http://a.ml/vocabularies/shapes#AnyShape",
                   "http://www.w3.org/ns/shacl#Shape",
                   "http://a.ml/vocabularies/shapes#Shape",
                   "http://a.ml/vocabularies/document#DomainElement"
                 ],
-                "http://www.w3.org/ns/shacl#datatype": [
+                "http://a.ml/vocabularies/shapes#anyOf": [
                   {
-                    "@id": "http://www.w3.org/2001/XMLSchema#string"
-                  }
-                ],
-                "http://www.w3.org/ns/shacl#name": [
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#ScalarShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://www.w3.org/ns/shacl#datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar/source-map",
+                        "@type": [
+                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar/source-map/lexical/element_0",
+                            "http://a.ml/vocabularies/document-source-maps#element": [
+                              {
+                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#value": [
+                              {
+                                "@value": "[(0,0)-(0,6)]"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
                   {
-                    "@value": ""
-                  }
-                ],
-                "http://a.ml/vocabularies/core#description": [
-                  {
-                    "@value": "This annotation allows to specify a method which will not be transformed into an operation.\nOptionally, a reason can be defined.\n"
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#NilShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#sources": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil/source-map",
+                        "@type": [
+                          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#lexical": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil/source-map/lexical/element_0",
+                            "http://a.ml/vocabularies/document-source-maps#element": [
+                              {
+                                "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#value": [
+                              {
+                                "@value": "[(0,9)-(0,12)]"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ],
                 "http://a.ml/vocabularies/document-source-maps#sources": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map",
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/source-map",
                     "@type": [
                       "http://a.ml/vocabularies/document-source-maps#SourceMap"
                     ],
-                    "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+                    "http://a.ml/vocabularies/document-source-maps#type-expression": [
                       {
-                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/type-property-lexical-info/element_0",
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/source-map/type-expression/element_0",
                         "http://a.ml/vocabularies/document-source-maps#element": [
                           {
-                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/"
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union"
                           }
                         ],
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
-                            "@value": "[(1,0)-(1,0)]"
+                            "@value": "string | nil"
                           }
                         ]
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#lexical": [
                       {
-                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/lexical/element_2",
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/source-map/lexical/element_0",
                         "http://a.ml/vocabularies/document-source-maps#element": [
                           {
-                            "@value": "http://www.w3.org/ns/shacl#datatype"
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union"
                           }
                         ],
                         "http://a.ml/vocabularies/document-source-maps#value": [
@@ -402,69 +469,70 @@
                             "@value": "[(1,0)-(1,0)]"
                           }
                         ]
-                      },
-                      {
-                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/lexical/element_0",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "http://a.ml/vocabularies/core#description"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(10,8)-(13,0)]"
-                          }
-                        ]
-                      },
-                      {
-                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/lexical/element_1",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(13,8)-(15,0)]"
-                          }
-                        ]
                       }
                     ]
                   }
                 ]
-              },
-              {
-                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/nil/default-nil",
-                "@type": [
-                  "http://a.ml/vocabularies/shapes#NilShape",
-                  "http://www.w3.org/ns/shacl#Shape",
-                  "http://a.ml/vocabularies/shapes#Shape",
-                  "http://a.ml/vocabularies/document#DomainElement"
-                ]
-              }
-            ],
-            "http://www.w3.org/ns/shacl#name": [
-              {
-                "@value": "schema"
               }
             ],
             "http://a.ml/vocabularies/document-source-maps#sources": [
               {
-                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/source-map",
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map",
                 "@type": [
                   "http://a.ml/vocabularies/document-source-maps#SourceMap"
                 ],
-                "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/source-map/synthesized-field/element_0",
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/type-property-lexical-info/element_0",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "http://a.ml/vocabularies/shapes#anyOf"
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "true"
+                        "@value": "[(1,0)-(1,0)]"
+                      }
+                    ]
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/lexical/element_2",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/core#description"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(10,8)-(13,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/shapes#inherits"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(1,0)-(1,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/lexical/element_1",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(13,8)-(15,0)]"
                       }
                     ]
                   }

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml.flattened.jsonld
@@ -159,7 +159,7 @@
         }
       ],
       "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored"
       },
       "http://a.ml/vocabularies/core#name": "ignored",
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -256,7 +256,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored",
       "@type": [
         "http://a.ml/vocabularies/shapes#UnionShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -264,18 +264,16 @@
         "http://a.ml/vocabularies/shapes#Shape",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
-      "http://a.ml/vocabularies/shapes#anyOf": [
+      "http://www.w3.org/ns/shacl#name": "ignored",
+      "http://a.ml/vocabularies/core#description": "This annotation allows to specify a method which will not be transformed into an operation.\nOptionally, a reason can be defined.\n",
+      "http://a.ml/vocabularies/shapes#inherits": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/nil/default-nil"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union"
         }
       ],
-      "http://www.w3.org/ns/shacl#name": "schema",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map"
         }
       ]
     },
@@ -455,44 +453,47 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(7,8)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union",
       "@type": [
-        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#UnionShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
         "http://www.w3.org/ns/shacl#Shape",
         "http://a.ml/vocabularies/shapes#Shape",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
-      "http://www.w3.org/ns/shacl#datatype": [
+      "http://a.ml/vocabularies/shapes#anyOf": [
         {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil"
         }
       ],
-      "http://www.w3.org/ns/shacl#name": "",
-      "http://a.ml/vocabularies/core#description": "This annotation allows to specify a method which will not be transformed into an operation.\nOptionally, a reason can be defined.\n",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/nil/default-nil",
-      "@type": [
-        "http://a.ml/vocabularies/shapes#NilShape",
-        "http://www.w3.org/ns/shacl#Shape",
-        "http://a.ml/vocabularies/shapes#Shape",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
-      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/type-property-lexical-info/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/lexical/element_1"
         }
       ]
     },
@@ -635,31 +636,74 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar",
       "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
       ],
-      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+      "http://www.w3.org/ns/shacl#datatype": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/type-property-lexical-info/element_0"
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
+      "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/lexical/element_2"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/lexical/element_0"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/source-map/synthesized-field/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#anyOf",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#NilShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-expression": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/source-map/type-expression/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(1,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(10,8)-(13,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#inherits",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(1,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/ignored",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(13,8)-(15,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/operationName/scalar/schema/source-map/type-property-lexical-info/element_0",
@@ -712,24 +756,46 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(1,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/source-map/type-expression/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union",
+      "http://a.ml/vocabularies/document-source-maps#value": "string | nil"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union",
       "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(1,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(1,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/0/scalar/default-scalar",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(0,0)-(0,6)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(10,8)-(13,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/scalar/",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(13,8)-(15,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml#/declarations/annotations/ignored/union/schema/union/default-union/1/nil/default-nil",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(0,9)-(0,12)]"
     }
   ]
 }

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml.jsonld.raml.ignore
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml.jsonld.raml.ignore
@@ -5,16 +5,12 @@ annotationTypes:
   base:
     type: string | nil
   ignored:
+    type: string | nil
+    description: |
+      This annotation allows to specify a method which will not be transformed into an operation.
+      Optionally, a reason can be defined.
     allowedTargets:
       - Method
-    anyOf:
-      -
-        type: string
-        description: |
-          This annotation allows to specify a method which will not be transformed into an operation.
-          Optionally, a reason can be defined.
-      -
-        type: nil
   operationName:
     type: string
     description: |

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/dumped.raml.ignore
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/dumped.raml.ignore
@@ -5,19 +5,15 @@ annotationTypes:
   base:
     type: string | nil
   ignored:
+    type: string | nil
+    description: |
+      This annotation allows to specify a method which will not be transformed into an operation.
+      Optionally, a reason can be defined.
     description: |
       This annotation allows to specify a method which will not be transformed into an operation.
       Optionally, a reason can be defined.
     allowedTargets:
       - Method
-    anyOf:
-      -
-        type: string
-        description: |
-          This annotation allows to specify a method which will not be transformed into an operation.
-          Optionally, a reason can be defined.
-      -
-        type: nil
   operationName:
     type: string
     description: |

--- a/amf-cli/shared/src/test/resources/validations/nillable-with-nillable.raml
+++ b/amf-cli/shared/src/test/resources/validations/nillable-with-nillable.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0
+title: Sample API
+types:
+  TestObject:
+    properties:
+      testProperty?:
+        type: string?

--- a/amf-cli/shared/src/test/resources/validations/nillable-with-required.raml
+++ b/amf-cli/shared/src/test/resources/validations/nillable-with-required.raml
@@ -1,0 +1,8 @@
+#%RAML 1.0
+title: Sample API
+types:
+  TestObject:
+    properties:
+      testProperty:
+        required: false
+        type: string?

--- a/amf-cli/shared/src/test/scala/amf/emit/UnionRamlEmissionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/emit/UnionRamlEmissionTest.scala
@@ -290,4 +290,23 @@ class UnionRamlEmissionTest extends FunSuiteCycleTests {
           pipeline = Some(PipelineId.Default))
   }
 
+  test("Union with default - No Resolution") {
+    cycle("union-default.raml", "union-default.out.raml", Raml10YamlHint, Raml10YamlHint, pipeline = None)
+  }
+
+  test("Union with default - Editing Resolution") {
+    cycle("union-default.raml",
+          "union-default.out.editing.raml",
+          Raml10YamlHint,
+          Raml10YamlHint,
+          pipeline = Some(PipelineId.Editing))
+  }
+
+  test("Union with default - Default Resolution") {
+    cycle("union-default.raml",
+          "union-default.out.default.raml",
+          Raml10YamlHint,
+          Raml10YamlHint,
+          pipeline = Some(PipelineId.Default))
+  }
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -630,4 +630,12 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
   test("invalid duplicated nullable property") {
     validate("duplicate-property/api.raml", Some("raml/duplicated-property.report"))
   }
+
+  test("nillable type notation should accept required facet") {
+    validate("nillable-with-required.raml")
+  }
+
+  test("nillable property of nillable type") {
+    validate("nillable-with-nillable.raml")
+  }
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/Raml10TypeParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/Raml10TypeParser.scala
@@ -576,29 +576,40 @@ sealed abstract class RamlTypeParser(entryOrNode: YMapEntryLike,
     val union = UnionShape(Annotations.virtual()).withName(name, nameAnnotations)
     adopt(union)
 
-    val parsed = node.value match {
+    node.value match {
       case s: YScalar =>
         val toParse = YMapEntry(YNode(""), YNode(s.text.stripSuffix("?")))
-        ctx.typeParser(toParse, s => s.withId(union.id), typeInfo.isAnnotation, defaultType).parse().get
+        val parsed =
+          ctx.typeParser(toParse, s => s.withId(union.id), typeInfo.isAnnotation, defaultType).parse().get
+        union.set(UnionShapeModel.AnyOf,
+                  AmfArray(
+                    Seq(
+                      parsed,
+                      NilShape(Annotations.virtual()).withId(union.id)
+                    )),
+                  Annotations.synthesized())
       case m: YMap =>
         val newEntries = m.entries.map { entry =>
           if (entry.key.as[YScalar].text == "type") {
-            YMapEntry("type", entry.value.as[YScalar].text.stripSuffix("?"))
+            val typeToUnion = s"${entry.value.as[YScalar].text.stripSuffix("?")} | nil"
+            YMapEntry("type", typeToUnion)
           } else {
             entry
           }
         }
-
-        val toParse = YMapEntry(YNode(""), YMap(newEntries, newEntries.headOption.map(_.sourceName).getOrElse("")))
-        ctx.typeParser(toParse, s => s.withId(union.id), typeInfo.isAnnotation, defaultType).parse().get
+        val toParse = YMapEntry(YNode(name), YMap(newEntries, newEntries.headOption.map(_.sourceName).getOrElse("")))
+        val parsed =
+          ctx.typeParser(toParse, s => s.withId(union.id), typeInfo.isAnnotation, defaultType).parse().get
+        parsed.inherits.head match {
+          case union: UnionShape =>
+            union.anyOf.tail.head match {
+              case nil: NilShape => nil.add(Annotations.virtual())
+              case _             => // ignore
+            }
+          case _ => // ignore
+        }
+        parsed
     }
-    union.set(UnionShapeModel.AnyOf,
-              AmfArray(
-                Seq(
-                  parsed,
-                  NilShape(Annotations.virtual()).withId(union.id)
-                )),
-              Annotations.synthesized())
   }
 
   // These are the actual custom facets, just regular properties in the AST map that have been

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/Raml10TypeParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/Raml10TypeParser.scala
@@ -598,8 +598,7 @@ sealed abstract class RamlTypeParser(entryOrNode: YMapEntryLike,
           }
         }
         val toParse = YMapEntry(YNode(name), YMap(newEntries, newEntries.headOption.map(_.sourceName).getOrElse("")))
-        val parsed =
-          ctx.typeParser(toParse, s => s.withId(union.id), typeInfo.isAnnotation, defaultType).parse().get
+        val parsed  = Raml10TypeParser(toParse, s => s.withId(union.id), typeInfo).parse().get
         parsed.inherits.head match {
           case union: UnionShape =>
             union.anyOf.tail.head match {


### PR DESCRIPTION
- APIMF-2973: make nillable type behave like nil union
- APIMF-2975: nillable properties now accept required facet

Fixes for #869 and #874 