### PR TITLE
APIMF-3326: do not propagate examples into disjoint UnionShapes

### DIFF
--- a/amf-cli/shared/src/test/resources/validations/jsonschema/type/invalid-type-array.raml
+++ b/amf-cli/shared/src/test/resources/validations/jsonschema/type/invalid-type-array.raml
@@ -1,0 +1,32 @@
+#%RAML 1.0
+title: test
+
+types:
+  testType: |
+    {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "testProp": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "a string",
+            123
+          ]
+        }
+      }
+    }
+
+/ep1:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: testType
+            example:
+              validTestProp: "a string"
+              invalidTestProp: 123

--- a/amf-cli/shared/src/test/resources/validations/jsonschema/type/type-array.raml
+++ b/amf-cli/shared/src/test/resources/validations/jsonschema/type/type-array.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0
+title: test
+
+types:
+  testType: |
+    {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "testProp": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "a string",
+            null
+          ]
+        }
+      }
+    }

--- a/amf-cli/shared/src/test/resources/validations/reports/jsonschema-examples/type/invalid-type-array.report.js
+++ b/amf-cli/shared/src/test/resources/validations/reports/jsonschema-examples/type/invalid-type-array.report.js
@@ -1,0 +1,17 @@
+Model: file://amf-cli/shared/src/test/resources/validations/jsonschema/type/invalid-type-array.raml
+Profile: RAML 1.0
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: should be null
+should be string
+should match some schema in anyOf
+
+  Level: Violation
+  Target: file://amf-cli/shared/src/test/resources/validations/jsonschema/type/invalid-type-array.raml#/declarations/types/testType/property/testProp/union/testProp/example/default-example_2
+  Property: file://amf-cli/shared/src/test/resources/validations/jsonschema/type/invalid-type-array.raml#/declarations/types/testType/property/testProp/union/testProp/example/default-example_2
+  Position: Some(LexicalInformation([(17,19)-(17,22)]))
+  Location: file://amf-cli/shared/src/test/resources/validations/jsonschema/type/invalid-type-array.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/jsonschema-examples/type/invalid-type-array.report.jvm
+++ b/amf-cli/shared/src/test/resources/validations/reports/jsonschema-examples/type/invalid-type-array.report.jvm
@@ -1,0 +1,16 @@
+Model: file://amf-cli/shared/src/test/resources/validations/jsonschema/type/invalid-type-array.raml
+Profile: RAML 1.0
+Conforms? false
+Number of results: 1
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/validation#example-validation-error
+  Message: expected type: String, found: Integer
+expected: null, found: Integer
+
+  Level: Violation
+  Target: file://amf-cli/shared/src/test/resources/validations/jsonschema/type/invalid-type-array.raml#/declarations/types/testType/property/testProp/union/testProp/example/default-example_2
+  Property: file://amf-cli/shared/src/test/resources/validations/jsonschema/type/invalid-type-array.raml#/declarations/types/testType/property/testProp/union/testProp/example/default-example_2
+  Position: Some(LexicalInformation([(17,19)-(17,22)]))
+  Location: file://amf-cli/shared/src/test/resources/validations/jsonschema/type/invalid-type-array.raml

--- a/amf-cli/shared/src/test/scala/amf/validation/JsonSchemaExampleValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/JsonSchemaExampleValidationTest.scala
@@ -188,5 +188,13 @@ class JsonSchemaExampleValidationTest extends MultiPlatformReportGenTest {
     validate("/dependencies/schema-dependencies.raml", Some("/dependencies/schema-dependencies.report"))
   }
 
+  test("JSON Schema 7 type array with examples") {
+    validate("/type/type-array.raml")
+  }
+
+  test("JSON Schema 7 invalid example in type array") {
+    validate("/type/invalid-type-array.raml", Some("/type/invalid-type-array.report"))
+  }
+
   override val hint: Hint = Raml10YamlHint
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/oas/parser/InlineOasTypeParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/oas/parser/InlineOasTypeParser.scala
@@ -148,6 +148,7 @@ case class InlineOasTypeParser(entryOrNode: YMapEntryLike,
 
     val filterKeys = Seq(
       "example",
+      "examples",
       "examples".asOasExtension,
       "title",
       "description",


### PR DESCRIPTION
- refactor disjoint union parser to improve legibility
- APIMF-3326: do not propagate examples into disjoint UnionShapes
