### PR TITLE
APIMF-3356: add resolution step for headers in components

### DIFF
--- a/amf-client/shared/src/test/resources/compatibility/cycled-apis/raml/parameter-names.raml
+++ b/amf-client/shared/src/test/resources/compatibility/cycled-apis/raml/parameter-names.raml
@@ -1,0 +1,95 @@
+#%RAML 1.0
+annotationTypes:
+  amf-serverDescription:
+    type: any
+  amf-exclusiveMinimum:
+    type: any
+  amf-binding:
+    type: any
+  amf-pattern:
+    type: any
+  amf-payloads:
+    type: any
+  amf-exclusiveMaximum:
+    type: any
+  amf-consumes:
+    type: any
+  amf-additionalProperties:
+    type: any
+  amf-or:
+    type: any
+  amf-url:
+    type: any
+  amf-externalDocs:
+    type: any
+  amf-flow:
+    type: any
+  amf-oasDeprecated:
+    type: any
+  amf-contact:
+    type: any
+  amf-multipleOf:
+    type: any
+  amf-xor:
+    type: any
+  amf-not:
+    type: any
+  amf-callbacks:
+    type: any
+  amf-produces:
+    type: any
+  amf-format:
+    type: any
+  amf-license:
+    type: any
+  amf-summary:
+    type: any
+  amf-responses:
+    type: any
+  amf-maximum:
+    type: any
+  amf-tags:
+    type: any
+  amf-dependencies:
+    type: any
+  amf-readOnly:
+    type: any
+  amf-tuple:
+    type: any
+  amf-examples:
+    type: any
+  amf-collectionFormat:
+    type: any
+  amf-termsOfService:
+    type: any
+  amf-servers:
+    type: any
+  amf-xone:
+    type: any
+  amf-defaultResponse:
+    type: any
+  amf-baseUriParameters:
+    type: any
+  amf-parameters:
+    type: any
+  amf-minimum:
+    type: any
+  amf-recursive:
+    type: any
+  amf-and:
+    type: any
+title: test API
+version: 1.0.0
+/users:
+  get:
+    headers:
+      X-Client-Id?:
+        type: string
+      X-Client-Secret?:
+        type: string
+    responses:
+      "200":
+        description: ""
+        body:
+          application/json:
+            type: string

--- a/amf-client/shared/src/test/resources/compatibility/oas30/parameter-names.json
+++ b/amf-client/shared/src/test/resources/compatibility/oas30/parameter-names.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "test API"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ClientId"
+          },
+          {
+            "$ref": "#/components/parameters/ClientSecret"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "ClientId": {
+        "name": "X-Client-Id",
+        "in": "header",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ClientSecret": {
+        "name": "X-Client-Secret",
+        "in": "header",
+        "schema": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/amf-client/shared/src/test/scala/amf/resolution/CompatibilityCycleGoldenTest.scala
+++ b/amf-client/shared/src/test/scala/amf/resolution/CompatibilityCycleGoldenTest.scala
@@ -182,4 +182,14 @@ class CompatibilityCycleGoldenTest extends ResolutionTest {
     )
   }
 
+  test("RAML headers") {
+    cycle(
+      "oas30/parameter-names.json",
+      "cycled-apis/raml/parameter-names.raml",
+      OasJsonHint,
+      Raml,
+      transformWith = Some(Raml10)
+    )
+  }
+
 }

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/pipelines/compatibility/RamlCompatibilityPipeline.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/pipelines/compatibility/RamlCompatibilityPipeline.scala
@@ -34,7 +34,8 @@ class RamlCompatibilityPipeline(override val eh: ErrorHandler) extends Resolutio
     new RamlCompatiblePayloadAndParameterResolutionStage(profileName),
     new SanitizeCustomTypeNames(),
     new RecursionDetection(),
-    new AnnotationRemovalStage()
+    new AnnotationRemovalStage(),
+    new ParameterNameNormalization()
   )
 
   override def profileName: ProfileName = RamlProfile

--- a/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/pipelines/compatibility/raml/ParameterNameNormalization.scala
+++ b/amf-webapi/shared/src/main/scala/amf/plugins/document/webapi/resolution/pipelines/compatibility/raml/ParameterNameNormalization.scala
@@ -1,0 +1,23 @@
+package amf.plugins.document.webapi.resolution.pipelines.compatibility.raml
+
+import amf.core.errorhandling.ErrorHandler
+import amf.core.model.document.BaseUnit
+import amf.core.resolution.stages.ResolutionStage
+import amf.plugins.domain.webapi.metamodel.ParameterModel
+import amf.plugins.domain.webapi.models.Parameter
+
+class ParameterNameNormalization()(override implicit val errorHandler: ErrorHandler) extends ResolutionStage {
+
+  override def resolve[T <: BaseUnit](model: T): T = {
+    try {
+      model.iterator().foreach {
+        case param: Parameter if param.parameterName.value().nonEmpty =>
+          param.set(ParameterModel.Name, param.parameterName.value())
+        case _ =>
+      }
+      model
+    } catch {
+      case _: Exception => model
+    }
+  }
+}


### PR DESCRIPTION
- headers declared in components in OAS were being named by the key of the reference rather than the 'parameterName' field
