### PR TITLE
APIMF-3393: added warning to fallback for composite configurations in case of external fragment

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/document/OasFragmentParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/document/OasFragmentParser.scala
@@ -57,8 +57,9 @@ case class OasFragmentParser(root: Root, fragment: Option[OasHeader] = None)(imp
       case Oas20AnnotationTypeDeclaration => Some(AnnotationFragmentParser(map).parse())
       case Oas20SecurityScheme            => Some(SecuritySchemeFragmentParser(map).parse())
       case Oas20NamedExample              => Some(NamedExampleFragmentParser(map).parse())
-      case Oas20Header | Oas30Header      => Some(ApiContractFallbackPlugin(false).plugin(parsed).parse(root, ctx))
-      case _                              => None
+      case Oas20Header | Oas30Header =>
+        Some(ApiContractFallbackPlugin(false, skipWarnings = true).plugin(parsed).parse(root, ctx))
+      case _ => None
     }).getOrElse {
       val fragment = ExternalFragment()
         .withLocation(root.location)

--- a/amf-cli/shared/src/test/resources/configuration/validation/unrecognized-guess-root-fallback/api.raml
+++ b/amf-cli/shared/src/test/resources/configuration/validation/unrecognized-guess-root-fallback/api.raml
@@ -1,0 +1,2 @@
+#%%RAML 1.0
+title: Something

--- a/amf-cli/shared/src/test/resources/configuration/validation/unrecognized-guess-root-fallback/report.report
+++ b/amf-cli/shared/src/test/resources/configuration/validation/unrecognized-guess-root-fallback/report.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/configuration/validation/unrecognized-guess-root-fallback/api.raml
+Profile: AMF Graph
+Conforms: true
+Number of results: 1
+
+Level: Warning
+
+- Constraint: http://a.ml/vocabularies/amf/parser#couldnt-guess-root
+  Message: Couldn't guess spec for root file
+  Severity: Warning
+  Target: 
+  Property: 
+  Range: 
+  Location: file://amf-cli/shared/src/test/resources/configuration/validation/unrecognized-guess-root-fallback/api.raml

--- a/amf-cli/shared/src/test/resources/configuration/validation/warning-fallback/api.raml
+++ b/amf-cli/shared/src/test/resources/configuration/validation/warning-fallback/api.raml
@@ -1,0 +1,4 @@
+#%RAML 0.8
+title: Something
+traits:
+  someTrait: !include raml10-trait.raml

--- a/amf-cli/shared/src/test/resources/configuration/validation/warning-fallback/raml10-trait.raml
+++ b/amf-cli/shared/src/test/resources/configuration/validation/warning-fallback/raml10-trait.raml
@@ -1,0 +1,9 @@
+#%RAML 1.0 Trait
+usage: Some Trait
+headers:
+  authorization:
+    description: Bearer <JWT>
+    type: string
+  responses:
+    default:
+      description: Token was not provided.

--- a/amf-cli/shared/src/test/resources/configuration/validation/warning-fallback/warning-fallback.report
+++ b/amf-cli/shared/src/test/resources/configuration/validation/warning-fallback/warning-fallback.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/configuration/validation/warning-fallback/api.raml
+Profile: RAML 0.8
+Conforms: true
+Number of results: 1
+
+Level: Warning
+
+- Constraint: http://a.ml/vocabularies/amf/parser#cant-reference-spec-in-file-tree
+  Message: Document identified as RAML 1.0 is of different spec from root
+  Severity: Warning
+  Target: 
+  Property: 
+  Range: 
+  Location: file://amf-cli/shared/src/test/resources/configuration/validation/warning-fallback/raml10-trait.raml

--- a/amf-cli/shared/src/test/resources/production/inter-spec-refs/reports/oas-raml-datatype.report
+++ b/amf-cli/shared/src/test/resources/production/inter-spec-refs/reports/oas-raml-datatype.report
@@ -1,7 +1,7 @@
 ModelId: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/oas-raml-datatype/api.json
 Profile: 
 Conforms: false
-Number of results: 2
+Number of results: 3
 
 Level: Violation
 
@@ -19,4 +19,14 @@ Level: Violation
   Target: 
   Property: 
   Range: [(5,12)-(5,18)]
+  Location: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/oas-raml-datatype/datatype.raml
+
+Level: Warning
+
+- Constraint: http://a.ml/vocabularies/amf/parser#cant-reference-spec-in-file-tree
+  Message: Document identified as RAML 1.0 is of different spec from root
+  Severity: Warning
+  Target: 
+  Property: 
+  Range: 
   Location: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/oas-raml-datatype/datatype.raml

--- a/amf-cli/shared/src/test/resources/production/inter-spec-refs/reports/oas-raml-securityScheme.report
+++ b/amf-cli/shared/src/test/resources/production/inter-spec-refs/reports/oas-raml-securityScheme.report
@@ -1,7 +1,7 @@
 ModelId: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/oas-raml-securityScheme/api.json
 Profile: 
 Conforms: false
-Number of results: 3
+Number of results: 4
 
 Level: Violation
 
@@ -22,6 +22,14 @@ Level: Violation
   Location: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/oas-raml-securityScheme/securityScheme.raml
 
 Level: Warning
+
+- Constraint: http://a.ml/vocabularies/amf/parser#cant-reference-spec-in-file-tree
+  Message: Document identified as RAML 1.0 is of different spec from root
+  Severity: Warning
+  Target: 
+  Property: 
+  Range: 
+  Location: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/oas-raml-securityScheme/securityScheme.raml
 
 - Constraint: http://a.ml/vocabularies/amf/parser#cross-security-warning
   Message: RAML 1.0 security scheme type detected in OAS 2.0 spec

--- a/amf-cli/shared/src/test/resources/production/inter-spec-refs/reports/raml-oas-jsonpointer.report
+++ b/amf-cli/shared/src/test/resources/production/inter-spec-refs/reports/raml-oas-jsonpointer.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/raml-oas-jsonpointer/api.raml
+Profile: RAML 1.0
+Conforms: true
+Number of results: 1
+
+Level: Warning
+
+- Constraint: http://a.ml/vocabularies/amf/parser#cant-reference-spec-in-file-tree
+  Message: Document identified as OAS 2.0 is of different spec from root
+  Severity: Warning
+  Target: 
+  Property: 
+  Range: 
+  Location: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/raml-oas-jsonpointer/api.json

--- a/amf-cli/shared/src/test/resources/production/inter-spec-refs/reports/raml08-raml1-datatype.report
+++ b/amf-cli/shared/src/test/resources/production/inter-spec-refs/reports/raml08-raml1-datatype.report
@@ -1,7 +1,7 @@
 ModelId: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/raml08-raml1-datatype/api.raml
 Profile: 
 Conforms: false
-Number of results: 2
+Number of results: 3
 
 Level: Violation
 
@@ -19,4 +19,14 @@ Level: Violation
   Target: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/raml08-raml1-datatype/api.raml#/declarations/schemas/scalar/a
   Property: 
   Range: [(3,0)-(5,18)]
+  Location: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/raml08-raml1-datatype/datatype.raml
+
+Level: Warning
+
+- Constraint: http://a.ml/vocabularies/amf/parser#cant-reference-spec-in-file-tree
+  Message: Document identified as RAML 1.0 is of different spec from root
+  Severity: Warning
+  Target: 
+  Property: 
+  Range: 
   Location: file://amf-cli/shared/src/test/resources/production/inter-spec-refs/raml08-raml1-datatype/datatype.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/model/invalid-cross-overlay.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/model/invalid-cross-overlay.report
@@ -1,7 +1,7 @@
 ModelId: file://amf-cli/shared/src/test/resources/validations/invalid-cross-overlay/invalid-cross-overlay.raml
 Profile: RAML 1.0
 Conforms: false
-Number of results: 1
+Number of results: 2
 
 Level: Violation
 
@@ -12,3 +12,13 @@ Level: Violation
   Property: http://a.ml/vocabularies/core#name
   Range: [(2,0)-(2,17)]
   Location: file://amf-cli/shared/src/test/resources/validations/invalid-cross-overlay/invalid-cross-overlay.raml
+
+Level: Warning
+
+- Constraint: http://a.ml/vocabularies/amf/parser#cant-reference-spec-in-file-tree
+  Message: Document identified as OAS 2.0 is of different spec from root
+  Severity: Warning
+  Target: 
+  Property: 
+  Range: 
+  Location: file://amf-cli/shared/src/test/resources/validations/invalid-cross-overlay/oas.json

--- a/amf-cli/shared/src/test/scala/amf/configuration/E2EParserConfigurationSetupTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/configuration/E2EParserConfigurationSetupTest.scala
@@ -56,7 +56,7 @@ class E2EParserConfigurationSetupTest extends ConfigurationSetupTest {
           result   <- client.parse(f.apiPath)
           document <- Future.successful { result.baseUnit }
         } yield {
-          result.results should have length 0
+          result.conforms shouldBe true
           f.expectation(document, result.sourceSpec)
         }
       }

--- a/amf-cli/shared/src/test/scala/amf/configuration/FallbackConfigurationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/configuration/FallbackConfigurationTest.scala
@@ -1,0 +1,18 @@
+package amf.configuration
+
+import amf.core.internal.remote.{Hint, Raml08YamlHint}
+import amf.validation.UniquePlatformReportGenTest
+
+class FallbackConfigurationTest extends UniquePlatformReportGenTest {
+  override val basePath: String    = "file://amf-cli/shared/src/test/resources/configuration/validation/"
+  override val reportsPath: String = "file://amf-cli/shared/src/test/resources/configuration/validation/"
+  override val hint: Hint          = Raml08YamlHint
+
+  test("RAML 0.8 api that references RAML 1.0 fragment should have a warning") {
+    validate("warning-fallback/api.raml", Some("warning-fallback/warning-fallback.report"))
+  }
+
+  test("External Fragment as root with composite configuration throws warning") {
+    validate("unrecognized-guess-root-fallback/api.raml", Some("unrecognized-guess-root-fallback/report.report"))
+  }
+}

--- a/amf-cli/shared/src/test/scala/amf/validation/RamlInterSpecRefsReportTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/RamlInterSpecRefsReportTest.scala
@@ -12,7 +12,7 @@ class RamlInterSpecRefsReportTest extends UniquePlatformReportGenTest {
   }
 
   test("Raml refs json schema Oas API") {
-    validate("raml-oas-jsonpointer/api.raml", None)
+    validate("raml-oas-jsonpointer/api.raml", Some("raml-oas-jsonpointer.report"))
   }
 
   test("Raml 0.8 refs Raml 1.0 datatype fragment") {

--- a/amf-cli/shared/src/test/scala/amf/validation/UniquePlatformReportGenTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/UniquePlatformReportGenTest.scala
@@ -118,7 +118,7 @@ trait ResolutionForUniquePlatformReportTest extends UniquePlatformReportGenTest 
 
 trait ValidModelTest extends MultiPlatformReportGenTest {
   override val basePath: String    = "file://amf-cli/shared/src/test/resources/validations/"
-  override val reportsPath: String = ""
+  override val reportsPath: String = "file://amf-cli/shared/src/test/resources/validations/reports/"
 
   protected def checkValid(api: String, profile: ProfileName = Raml10Profile): Future[Assertion] =
     super.validate(api, None, profile, None)


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-core/pull/339