### PR TITLE
APIMF-3429: rollback not using/setting deprecated fields definedBy & graphDependencies

### DIFF
--- a/amf-cli/shared/src/main/scala/amf/cli/internal/commands/ValidateCommand.scala
+++ b/amf-cli/shared/src/main/scala/amf/cli/internal/commands/ValidateCommand.scala
@@ -9,6 +9,7 @@ import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.validation.AMFValidationReport
 import amf.core.internal.remote.Platform
 import amf.validation.internal.emitters.ValidationReportJSONLDEmitter
+import com.github.ghik.silencer.silent
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -48,7 +49,10 @@ class ValidateCommand(override val platform: Platform) extends CommandHelper {
     val customProfileLoaded: Future[(ProfileName, AMFConfiguration)] = Future {
       model match {
         case dialectInstance: DialectInstance =>
-          findDialect(configuration, dialectInstance.processingData.definedBy().value()) match {
+          @silent("deprecated") // Silent can only be used in assignment expressions
+          val definedBy =
+            dialectInstance.processingData.definedBy().option().orElse(dialectInstance.definedBy().option()).orNull
+          findDialect(configuration, definedBy) match {
             case Some(dialect) =>
               (ProfileName(dialect.nameAndVersion()), configuration)
             case _ =>


### PR DESCRIPTION
Depends on [https://github.com/aml-org/amf-aml/pull/387](https://github.com/aml-org/amf-aml/pull/387)
