### PR TITLE
Inject EffectiveValidations and ProfileName in model validation and payload validation plugin

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/model/ApiValidationProfiles.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/model/ApiValidationProfiles.scala
@@ -1,8 +1,17 @@
 package amf.apicontract.internal.validation.model
 
 import amf.apicontract.internal.validation.model.AMFRawValidations._
+import amf.apicontract.internal.validation.model.ApiValidationProfiles.{
+  AmfValidationProfile,
+  Async20ValidationProfile,
+  Oas20ValidationProfile,
+  Oas30ValidationProfile,
+  Raml08ValidationProfile,
+  Raml10ValidationProfile
+}
 import amf.apicontract.internal.validation.model.DefaultAMFValidations.buildProfileFrom
 import amf.core.client.common.validation._
+import amf.core.internal.validation.EffectiveValidations
 import amf.core.internal.validation.core.ValidationProfile
 
 object ApiValidationProfiles {
@@ -26,4 +35,16 @@ object ApiValidationProfiles {
   )
 
   def profile(name: ProfileName): Option[ValidationProfile] = apiProfiles.get(name)
+}
+
+object ApiEffectiveValidations {
+  val Raml08EffectiveValidations: EffectiveValidations = EffectiveValidations().someEffective(Raml08ValidationProfile)
+  val Raml10EffectiveValidations: EffectiveValidations = EffectiveValidations().someEffective(Raml10ValidationProfile)
+
+  val Oas20EffectiveValidations: EffectiveValidations = EffectiveValidations().someEffective(Oas20ValidationProfile)
+  val Oas30EffectiveValidations: EffectiveValidations = EffectiveValidations().someEffective(Oas30ValidationProfile)
+
+  val Async20EffectiveValidations: EffectiveValidations =
+    EffectiveValidations().someEffective(Async20ValidationProfile)
+  val AmfEffectiveValidations: EffectiveValidations = EffectiveValidations().someEffective(AmfValidationProfile)
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/shacl/ViolationModelValidationPlugin.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/shacl/ViolationModelValidationPlugin.scala
@@ -1,7 +1,7 @@
 package amf.apicontract.internal.validation.shacl
 
 import amf.apicontract.internal.validation.plugin.BaseApiValidationPlugin
-import amf.core.client.common.validation.{ProfileName, SeverityLevels}
+import amf.core.client.common.validation.{ProfileName, ProfileNames, SeverityLevels, UnknownProfile}
 import amf.core.client.common.{NormalPriority, PluginPriority}
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.validation.{AMFValidationReport, AMFValidationResult}
@@ -14,16 +14,18 @@ case class ViolationModelValidationPlugin(configName: String) extends BaseApiVal
 
   override def priority: PluginPriority = NormalPriority
 
+  override protected def profile: ProfileName = ProfileNames.AMF
+
   override def validate(unit: BaseUnit, options: ValidationOptions)(
       implicit executionContext: ExecutionContext): Future[ValidationResult] = {
-    specificValidate(unit, options.profile, options).map { report =>
+    specificValidate(unit, options).map { report =>
       ValidationResult(unit, report)
     }
   }
 
-  override protected def specificValidate(unit: BaseUnit, profile: ProfileName, options: ValidationOptions)(
+  override protected def specificValidate(unit: BaseUnit, options: ValidationOptions)(
       implicit executionContext: ExecutionContext): Future[AMFValidationReport] = {
-    Future.successful { AMFValidationReport(unit.id, options.profile, Seq(validationResult)) }
+    Future.successful { AMFValidationReport(unit.id, UnknownProfile, Seq(validationResult)) }
   }
 
   private def validationResult: AMFValidationResult = AMFValidationResult(

--- a/amf-cli/shared/src/test/resources/configuration/validation/unrecognized-guess-root-fallback/report.report
+++ b/amf-cli/shared/src/test/resources/configuration/validation/unrecognized-guess-root-fallback/report.report
@@ -1,5 +1,5 @@
 ModelId: file://amf-cli/shared/src/test/resources/configuration/validation/unrecognized-guess-root-fallback/api.raml
-Profile: AMF Graph
+Profile: 
 Conforms: true
 Number of results: 1
 

--- a/amf-cli/shared/src/test/scala/amf/compiler/AMFCompilerTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/compiler/AMFCompilerTest.scala
@@ -1,6 +1,12 @@
 package amf.compiler
 
-import amf.apicontract.client.scala.{AMFConfiguration, APIConfiguration, AsyncAPIConfiguration, WebAPIConfiguration}
+import amf.apicontract.client.scala.{
+  AMFConfiguration,
+  APIConfiguration,
+  AsyncAPIConfiguration,
+  RAMLConfiguration,
+  WebAPIConfiguration
+}
 import amf.apicontract.client.scala.model.domain.api.WebApi
 import amf.core.client.common.validation.Raml10Profile
 import amf.core.client.scala.errorhandling.{DefaultErrorHandler, IgnoringErrorHandler, UnhandledErrorHandler}
@@ -102,9 +108,8 @@ class AMFCompilerTest extends AsyncFunSuite with CompilerTestBuilder {
   }
 
   test("Non existing included file") {
-    val eh = DefaultErrorHandler()
-    val amfConfig =
-      APIConfiguration.API().withErrorHandlerProvider(() => eh)
+    val eh        = DefaultErrorHandler()
+    val amfConfig = RAMLConfiguration.RAML10().withErrorHandlerProvider(() => eh)
     build("file://amf-cli/shared/src/test/resources/non-exists-include.raml", Raml10YamlHint, amfConfig, None)
       .flatMap(bu => {
         AMFValidator.validate(bu, amfConfig)

--- a/amf-cli/shared/src/test/scala/amf/configuration/ConfiguredValidationSetupTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/configuration/ConfiguredValidationSetupTest.scala
@@ -1,0 +1,49 @@
+package amf.configuration
+
+import amf.apicontract.client.scala.model.domain.api.WebApi
+import amf.core.client.common.validation.{Async20Profile, Oas20Profile, Oas30Profile, Raml08Profile, Raml10Profile}
+import amf.core.client.scala.model.document.Document
+
+import scala.concurrent.ExecutionContext
+
+class ConfiguredValidationSetupTest extends ConfigurationSetupTest {
+
+  implicit override val executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  private val model = Document()
+    .withId("someId")
+    .withEncodes(
+      WebApi()
+        .withName("something")
+    )
+
+  test("Model without source spec can be validated with RAML 1.0 config") {
+    raml10Config.baseUnitClient().validate(model).map { report =>
+      report.profile shouldEqual Raml10Profile
+    }
+  }
+
+  test("Model without source spec can be validated with RAML 0.8 config") {
+    raml08Config.baseUnitClient().validate(model).map { report =>
+      report.profile shouldEqual Raml08Profile
+    }
+  }
+
+  test("Model without source spec can be validated with OAS 2.0 config") {
+    oas20Config.baseUnitClient().validate(model).map { report =>
+      report.profile shouldEqual Oas20Profile
+    }
+  }
+
+  test("Model without source spec can be validated with OAS 3.0 config") {
+    oas30Config.baseUnitClient().validate(model).map { report =>
+      report.profile shouldEqual Oas30Profile
+    }
+  }
+
+  test("Model without source spec can be validated with ASYNC 2.0 config") {
+    async20Config.baseUnitClient().validate(model).map { report =>
+      report.profile shouldEqual Async20Profile
+    }
+  }
+}

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/ShapesConfiguration.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/ShapesConfiguration.scala
@@ -18,6 +18,7 @@ import amf.core.internal.plugins.AMFPlugin
 import amf.core.internal.plugins.parse.DomainParsingFallback
 import amf.core.internal.registries.AMFRegistry
 import amf.core.internal.resource.AMFResolvers
+import amf.core.internal.validation.EffectiveValidations
 import amf.core.internal.validation.core.ValidationProfile
 import amf.shapes.client.scala.plugin.JsonSchemaShapePayloadValidationPlugin
 import amf.shapes.internal.annotations.ShapeSerializableAnnotations
@@ -101,6 +102,11 @@ class ShapesConfiguration private[amf] (override private[amf] val resolvers: AMF
 
   private[amf] override def withValidationProfile(profile: ValidationProfile): ShapesConfiguration =
     super._withValidationProfile(profile)
+
+  // Keep AMF internal, done to avoid recomputing validations every time a config is requested
+  private[amf] override def withValidationProfile(profile: ValidationProfile,
+                                                  effective: EffectiveValidations): ShapesConfiguration =
+    super._withValidationProfile(profile, effective)
 
   /**
     * Add a [[TransformationPipeline]]


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-aml/pull/403

This enables us to validate a BaseUnit without taking into account it's SourceSpec.

Alternative:
- leave the ValidationProfile in the AMFConfiguration and only inject the ProfileName (we should remove ProfileName from AMFConfiguration). We then query the effective validations as we used to.
     Pros: leaves the AMFConfiguration as the place-to-find constraints. We don't have constraints disperse in several places.
     Cons: we would have to handle the possibility of the constraints not being present. AMFValidator will have to know how to build EffectiveValidations for a Profile (it already does but it would be nice to not have it constrained to amf-core).
     
Thoughts:
- What happens if two plugins provide different ProfileNames for the same BaseUnit (shouldn't but its a possibility with this approach) -> We need this approach to validate any base unit with any configuration AND avoid depending on the base unit's "SourceSpec" field to validate.
- Why store the constraints in the configuration when we could create several instances of the ModelValidationPlugin with different "EffectiveValidations" provided in the constructor? Pros,Cons??
- We should add a story to remove the ProfileName (know it is hard because of the MessageStyle field) as it doesn't make sense to have it when we have the Spec object.