### PR TITLE
APIMF-3114: added tests for semantic extensions validations. Modified test helpers to provide a configuration

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ValidationTransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ValidationTransformationPipeline.scala
@@ -1,11 +1,7 @@
 package amf.apicontract.internal.transformation
 
-import amf.apicontract.internal.spec.common.transformation.stage.{
-  AnnotationRemovalStage,
-  MediaTypeResolutionStage,
-  PayloadAndParameterResolutionStage,
-  ResponseExamplesResolutionStage
-}
+import amf.aml.internal.transform.steps.SemanticExtensionFlatteningStage
+import amf.apicontract.internal.spec.common.transformation.stage.{AnnotationRemovalStage, MediaTypeResolutionStage, PayloadAndParameterResolutionStage, ResponseExamplesResolutionStage}
 import amf.apicontract.internal.transformation.stages.ExtensionsResolutionStage
 import amf.core.client.common.validation.{Async20Profile, GrpcProfile, Oas30Profile, ProfileName}
 import amf.core.client.scala.AMFGraphConfiguration
@@ -30,7 +26,8 @@ class ValidationTransformationPipeline private[amf] (profile: ProfileName,
       new MediaTypeResolutionStage(profile, isValidation = true),
       new ResponseExamplesResolutionStage(),
       new PayloadAndParameterResolutionStage(profile),
-      new AnnotationRemovalStage()
+      SemanticExtensionFlatteningStage,
+      new AnnotationRemovalStage(),
     )
 }
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/plugin/BaseApiValidationPlugin.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/plugin/BaseApiValidationPlugin.scala
@@ -1,11 +1,12 @@
 package amf.apicontract.internal.validation.plugin
 
+import amf.aml.internal.utils.DialectRegister
 import amf.core.client.common.validation._
-import amf.core.client.common.{HighPriority, NormalPriority, PluginPriority}
+import amf.core.client.common.{NormalPriority, PluginPriority}
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.validation.AMFValidationReport
 import amf.core.internal.plugins.validation.{AMFValidatePlugin, ValidationInfo, ValidationOptions, ValidationResult}
-import amf.core.internal.validation.{EffectiveValidations, ValidationConfiguration}
+import amf.core.internal.validation.{EffectiveValidations, ValidationConfiguration, core}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/shacl/ShaclModelValidationPlugin.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/shacl/ShaclModelValidationPlugin.scala
@@ -1,12 +1,13 @@
 package amf.apicontract.internal.validation.shacl
 
+import amf.aml.internal.validate.SemanticExtensionConstraints
 import amf.apicontract.internal.validation.plugin.BaseApiValidationPlugin
-import amf.core.client.common.{HighPriority, PluginPriority}
 import amf.core.client.common.validation.ProfileName
+import amf.core.client.common.{HighPriority, PluginPriority}
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.validation.AMFValidationReport
-import amf.core.internal.plugins.validation.{ValidationInfo, ValidationOptions}
-import amf.core.internal.validation.{EffectiveValidations, ShaclReportAdaptation}
+import amf.core.internal.plugins.validation.ValidationOptions
+import amf.core.internal.validation.ShaclReportAdaptation
 import amf.validation.internal.shacl.custom.CustomShaclValidator
 import amf.validation.internal.shacl.custom.CustomShaclValidator.CustomShaclFunctions
 
@@ -14,7 +15,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class ShaclModelValidationPlugin(profile: ProfileName)
     extends BaseApiValidationPlugin
-    with ShaclReportAdaptation {
+    with ShaclReportAdaptation
+    with SemanticExtensionConstraints {
 
   override val id: String = this.getClass.getSimpleName
 
@@ -28,8 +30,9 @@ case class ShaclModelValidationPlugin(profile: ProfileName)
   private def validateWithShacl(unit: BaseUnit, options: ValidationOptions)(
       implicit executionContext: ExecutionContext): Future[AMFValidationReport] = {
 
-    val validator   = new CustomShaclValidator(functions, profile.messageStyle)
-    val validations = effectiveOrException(options.config, profile)
+    val validator = new CustomShaclValidator(functions, profile.messageStyle)
+    val validations =
+      withSemanticExtensionsConstraints(effectiveOrException(options.config, profile), options.config.constraints)
 
     validator
       .validate(unit, validations.effective.values.toSeq)

--- a/amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml
@@ -1,0 +1,24 @@
+asyncapi: "2.0.0"
+info:
+  title: Something
+  version: 1.0.1
+
+channels:
+  /endpoint:
+    subscribe:
+      operationId: validVal
+      message:
+        name: lightMeasured
+        x-pagination: 2
+  /endpoint1:
+    subscribe:
+      operationId: invalidLowerVal
+      message:
+        name: lightMeasured
+        x-pagination: -30
+  /endpoint2:
+    subscribe:
+      operationId: invalidUpperVal
+      message:
+        name: lightMeasured
+        x-pagination: 50

--- a/amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml
@@ -1,0 +1,17 @@
+swagger: "2.0"
+info:
+  title: Something
+  version: '1.0'
+paths:
+  /endpoint:
+    get:
+      responses:
+        200:
+          description: Something
+          x-pagination: 5
+        201:
+          description: Something
+          x-pagination: -4
+        203:
+          description: Something
+          x-pagination: 20

--- a/amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Something
+  version: '1.0'
+paths:
+  /endpoint:
+    get:
+      responses:
+        "200":
+          description: Something
+          x-pagination: 5
+        "201":
+          description: Something
+          x-pagination: -4
+        "203":
+          description: Something
+          x-pagination: 20

--- a/amf-cli/shared/src/test/resources/semantic/validation/api.raml
+++ b/amf-cli/shared/src/test/resources/semantic/validation/api.raml
@@ -1,0 +1,14 @@
+#%RAML 1.0
+title: Something
+/sample:
+  get:
+    responses:
+      200:
+        (pagination): 5
+        description: A Response
+      201:
+        (pagination): -50
+        description: A Response
+      203:
+        (pagination): 24
+        description: A Response

--- a/amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml
@@ -1,0 +1,20 @@
+#%Dialect 1.0
+dialect: Pagination Test
+version: 1.0
+
+external:
+  apiContract: http://a.ml/vocabularies/apiContract#
+  aml: http://a.ml/vocab#
+
+documents: {}
+
+annotationMappings:
+  PaginationAnnotation:
+    domain: apiContract.Response
+    propertyTerm: aml.pagination
+    range: integer
+    minimum: 1
+    maximum: 10
+
+extensions:
+  pagination: PaginationAnnotation

--- a/amf-cli/shared/src/test/resources/semantic/validation/reports/api.async.report.js
+++ b/amf-cli/shared/src/test/resources/semantic/validation/reports/api.async.report.js
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml
+Profile: ASYNC 2.0
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_minimum_validation
+  Message: Property 'pagination' minimum inclusive value is 1
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml#/async-api/endpoint/%2Fendpoint1/supportedOperation/subscribe/invalidLowerVal/returns/resp/default-response
+  Property: http://a.ml/vocab#pagination
+  Range: [(18,22)-(18,25)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_maximum_validation
+  Message: Property 'pagination' maximum inclusive value is 10
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml#/async-api/endpoint/%2Fendpoint2/supportedOperation/subscribe/invalidUpperVal/returns/resp/default-response
+  Property: http://a.ml/vocab#pagination
+  Range: [(24,22)-(24,24)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml

--- a/amf-cli/shared/src/test/resources/semantic/validation/reports/api.async.report.jvm
+++ b/amf-cli/shared/src/test/resources/semantic/validation/reports/api.async.report.jvm
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml
+Profile: ASYNC 2.0
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_minimum_validation
+  Message: Property 'pagination' minimum inclusive value is 1.0
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml#/async-api/endpoint/%2Fendpoint1/supportedOperation/subscribe/invalidLowerVal/returns/resp/default-response
+  Property: http://a.ml/vocab#pagination
+  Range: [(18,22)-(18,25)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_maximum_validation
+  Message: Property 'pagination' maximum inclusive value is 10.0
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml#/async-api/endpoint/%2Fendpoint2/supportedOperation/subscribe/invalidUpperVal/returns/resp/default-response
+  Property: http://a.ml/vocab#pagination
+  Range: [(24,22)-(24,24)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.async.yaml

--- a/amf-cli/shared/src/test/resources/semantic/validation/reports/api.oas20.report.js
+++ b/amf-cli/shared/src/test/resources/semantic/validation/reports/api.oas20.report.js
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml
+Profile: OAS 2.0
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_minimum_validation
+  Message: Property 'pagination' minimum inclusive value is 1
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/201
+  Property: http://a.ml/vocab#pagination
+  Range: [(14,24)-(14,26)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_maximum_validation
+  Message: Property 'pagination' maximum inclusive value is 10
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/203
+  Property: http://a.ml/vocab#pagination
+  Range: [(17,24)-(17,26)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml

--- a/amf-cli/shared/src/test/resources/semantic/validation/reports/api.oas20.report.jvm
+++ b/amf-cli/shared/src/test/resources/semantic/validation/reports/api.oas20.report.jvm
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml
+Profile: OAS 2.0
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_minimum_validation
+  Message: Property 'pagination' minimum inclusive value is 1.0
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/201
+  Property: http://a.ml/vocab#pagination
+  Range: [(14,24)-(14,26)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_maximum_validation
+  Message: Property 'pagination' maximum inclusive value is 10.0
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/203
+  Property: http://a.ml/vocab#pagination
+  Range: [(17,24)-(17,26)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas20.yaml

--- a/amf-cli/shared/src/test/resources/semantic/validation/reports/api.oas30.report.js
+++ b/amf-cli/shared/src/test/resources/semantic/validation/reports/api.oas30.report.js
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml
+Profile: OAS 3.0
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_minimum_validation
+  Message: Property 'pagination' minimum inclusive value is 1
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/201
+  Property: http://a.ml/vocab#pagination
+  Range: [(14,24)-(14,26)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_maximum_validation
+  Message: Property 'pagination' maximum inclusive value is 10
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/203
+  Property: http://a.ml/vocab#pagination
+  Range: [(17,24)-(17,26)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml

--- a/amf-cli/shared/src/test/resources/semantic/validation/reports/api.oas30.report.jvm
+++ b/amf-cli/shared/src/test/resources/semantic/validation/reports/api.oas30.report.jvm
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml
+Profile: OAS 3.0
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_minimum_validation
+  Message: Property 'pagination' minimum inclusive value is 1.0
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/201
+  Property: http://a.ml/vocab#pagination
+  Range: [(14,24)-(14,26)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_maximum_validation
+  Message: Property 'pagination' maximum inclusive value is 10.0
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/203
+  Property: http://a.ml/vocab#pagination
+  Range: [(17,24)-(17,26)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.oas30.yaml

--- a/amf-cli/shared/src/test/resources/semantic/validation/reports/api.raml.report.js
+++ b/amf-cli/shared/src/test/resources/semantic/validation/reports/api.raml.report.js
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/semantic/validation/api.raml
+Profile: RAML 1.0
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_minimum_validation
+  Message: Property 'pagination' minimum inclusive value is 1
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.raml#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/201
+  Property: http://a.ml/vocab#pagination
+  Range: [(10,22)-(10,25)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.raml
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_maximum_validation
+  Message: Property 'pagination' maximum inclusive value is 10
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.raml#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/203
+  Property: http://a.ml/vocab#pagination
+  Range: [(13,22)-(13,24)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.raml

--- a/amf-cli/shared/src/test/resources/semantic/validation/reports/api.raml.report.jvm
+++ b/amf-cli/shared/src/test/resources/semantic/validation/reports/api.raml.report.jvm
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/semantic/validation/api.raml
+Profile: RAML 1.0
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_minimum_validation
+  Message: Property 'pagination' minimum inclusive value is 1.0
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.raml#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/201
+  Property: http://a.ml/vocab#pagination
+  Range: [(10,22)-(10,25)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.raml
+
+- Constraint: http://a.ml/vocabularies/data#file://amf-cli/shared/src/test/resources/semantic/validation/dialect.yaml#/declarations/PaginationAnnotation_pagination_maximum_validation
+  Message: Property 'pagination' maximum inclusive value is 10.0
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/semantic/validation/api.raml#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/203
+  Property: http://a.ml/vocab#pagination
+  Range: [(13,22)-(13,24)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/api.raml

--- a/amf-cli/shared/src/test/scala/amf/semantic/SemanticExtensionValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/semantic/SemanticExtensionValidationTest.scala
@@ -1,0 +1,66 @@
+package amf.semantic
+
+import amf.apicontract.client.scala.{
+  AMFConfiguration,
+  APIConfiguration,
+  AsyncAPIConfiguration,
+  OASConfiguration,
+  RAMLConfiguration
+}
+import amf.core.client.scala.config.RenderOptions
+import amf.core.client.scala.errorhandling.UnhandledErrorHandler
+import amf.core.internal.remote.{AmfJsonHint, Async20YamlHint, Hint, Oas20YamlHint, Oas30YamlHint, Raml10YamlHint}
+import amf.validation.{MultiPlatformReportGenTest, UniquePlatformReportGenTest}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SemanticExtensionValidationTest extends MultiPlatformReportGenTest {
+
+  override val basePath: String    = "file://amf-cli/shared/src/test/resources/semantic/validation/"
+  override val reportsPath: String = "amf-cli/shared/src/test/resources/semantic/validation/reports/"
+  override val hint: Hint          = Raml10YamlHint
+
+  test("Validate scalar semantic extensions in RAML 1.0 api") {
+    getConfig("dialect.yaml", RAMLConfiguration.RAML10()).flatMap { config =>
+      validate("api.raml",
+               Some("api.raml.report"),
+               overridedHint = Some(Raml10YamlHint),
+               configOverride = Some(config))
+    }
+  }
+
+  test("Validate scalar semantic extensions in OAS 2.0 api") {
+    getConfig("dialect.yaml", OASConfiguration.OAS20()).flatMap { config =>
+      validate("api.oas20.yaml",
+               Some("api.oas20.report"),
+               overridedHint = Some(Oas20YamlHint),
+               configOverride = Some(config))
+    }
+  }
+
+  test("Validate scalar semantic extensions in OAS 3.0 api") {
+    getConfig("dialect.yaml", OASConfiguration.OAS30()).flatMap { config =>
+      validate("api.oas30.yaml",
+               Some("api.oas30.report"),
+               overridedHint = Some(Oas30YamlHint),
+               configOverride = Some(config))
+    }
+  }
+
+  test("Validate scalar semantic extensions in ASYNC 2.0 api") {
+    getConfig("dialect.yaml", AsyncAPIConfiguration.Async20()).flatMap { config =>
+      validate("api.async.yaml",
+               Some("api.async.report"),
+               overridedHint = Some(Async20YamlHint),
+               configOverride = Some(config))
+    }
+  }
+
+  private def getConfig(dialect: String,
+                        baseConfig: AMFConfiguration = APIConfiguration.API()): Future[AMFConfiguration] = {
+    baseConfig
+      .withRenderOptions(RenderOptions().withPrettyPrint.withCompactUris)
+      .withErrorHandlerProvider(() => UnhandledErrorHandler)
+      .withDialect(s"$basePath" + dialect)
+  }
+}

--- a/amf-cli/shared/src/test/scala/amf/validation/UniquePlatformReportGenTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/UniquePlatformReportGenTest.scala
@@ -52,12 +52,16 @@ sealed trait AMFValidationReportGenTest extends AsyncFunSuite with FileAssertion
                          profile: ProfileName = defaultProfile,
                          profileFile: Option[String] = None,
                          overridedHint: Option[Hint] = None,
-                         directory: String = basePath): Future[Assertion] = {
-    val initialConfig = APIConfiguration.API()
+                         directory: String = basePath,
+                         configOverride: Option[AMFConfiguration] = None): Future[Assertion] = {
+    val initialConfig = configOverride.getOrElse(APIConfiguration.API())
     val finalHint     = overridedHint.getOrElse(hint)
     for {
       parseResult <- parse(directory + api, initialConfig, finalHint)
-      report      <- configFor(parseResult.sourceSpec).baseUnitClient().validate(parseResult.baseUnit)
+      report <- configOverride
+        .getOrElse(configFor(parseResult.sourceSpec))
+        .baseUnitClient()
+        .validate(parseResult.baseUnit)
       r <- {
         val parseReport = AMFValidationReport.unknownProfile(parseResult)
         val finalReport =


### PR DESCRIPTION
Depends on: https://github.com/aml-org/amf-aml/pull/416