### PR TITLE
APIMF-3499: fix merging type error by avoiding uriParameter merging with default types

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/DomainElementMerging.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/DomainElementMerging.scala
@@ -219,7 +219,7 @@ case class DomainElementMerging()(implicit ctx: RamlWebApiContext) {
   def fixPayloadTrackedElements[T <: DomainElement](main: T, other: T): Unit = {
     (main, other) match {
       case (main: Payload, other: Payload) => ExampleTracking.replaceTracking(main.schema, main, other.id)
-      case _ =>
+      case _                               =>
     }
   }
 
@@ -366,7 +366,9 @@ case class DomainElementMerging()(implicit ctx: RamlWebApiContext) {
             if (field == EndPointModel.Operations) {
               ctx.mergeOperationContext(otherObj)
             }
-            if (!areSameJsonSchema(mainObjOption.get, otherObj)) {
+            if (mainObjOption.get.annotations.find(classOf[DefaultNode]).isDefined) {
+              target.add(field, adoptInner(target.id, o))
+            } else if (!areSameJsonSchema(mainObjOption.get, otherObj)) {
               val adopted = adoptInner(target.id, otherObj).asInstanceOf[DomainElement]
               merge(existing(value.scalar.value), adopted)
             }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlEndpointParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/raml/parser/domain/RamlEndpointParser.scala
@@ -24,7 +24,7 @@ import amf.core.client.common.position.Range
 import amf.core.client.scala.model.DataType
 import amf.core.client.scala.model.domain.{AmfArray, AmfScalar, DataNode, Shape, ScalarNode => ScalarDataNode}
 import amf.core.client.scala.parse.document.ParserContext
-import amf.core.internal.annotations.{LexicalInformation, VirtualElement}
+import amf.core.internal.annotations.{DefaultNode, LexicalInformation, VirtualElement}
 import amf.core.internal.parser.domain.Annotations
 import amf.core.internal.parser.{CompilerConfiguration, YMapOps}
 import amf.core.internal.utils.{AmfStrings, IdCounter, TemplateUri}
@@ -308,7 +308,7 @@ abstract class RamlEndpointParser(entry: YMapEntry,
 
     if (operationsDefineParam) None
     else {
-      val pathParam = Parameter(Annotations.virtual())
+      val pathParam = Parameter(Annotations.virtual() += DefaultNode())
         .withSynthesizeName(variable)
         .set(ParameterModel.ParameterName, variable, Annotations.synthesized())
         .syntheticBinding("path")

--- a/amf-cli/shared/src/test/resources/production/event-api/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/event-api/api.expanded.jsonld
@@ -126,6 +126,9 @@
                             "apiContract:paramName": "true",
                             "core:name": "true",
                             "apiContract:required": "true"
+                          },
+                          "default-node": {
+                            "#46": ""
                           }
                         }
                       }

--- a/amf-cli/shared/src/test/resources/production/event-api/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/event-api/api.flattened.jsonld
@@ -245,6 +245,9 @@
           "apiContract:paramName": "true",
           "core:name": "true",
           "apiContract:required": "true"
+        },
+        "default-node": {
+          "#46": ""
         }
       }
     },

--- a/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.expanded.jsonld
@@ -18136,6 +18136,21 @@
                                   }
                                 ]
                               }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#default-node": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/parameter/parameter/path/hostedModelName/source-map/default-node/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/parameter/parameter/path/hostedModelName"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": ""
+                                  }
+                                ]
+                              }
                             ]
                           }
                         ]

--- a/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.flattened.jsonld
@@ -6944,6 +6944,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/parameter/parameter/path/hostedModelName/source-map/synthesized-field/element_2"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/parameter/parameter/path/hostedModelName/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -10348,6 +10353,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/parameter/parameter/path/hostedModelName/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/parameter/parameter/path/hostedModelName/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/parameter/parameter/path/hostedModelName",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "oas-body-name",

--- a/amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml.expanded.jsonld
@@ -2127,6 +2127,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml#/web-api/endpoint/%2Fstores%2F%7BstoreNumber%7D/parameter/parameter/path/storeNumber/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml#/web-api/endpoint/%2Fstores%2F%7BstoreNumber%7D/parameter/parameter/path/storeNumber"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml.flattened.jsonld
@@ -439,6 +439,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml#/web-api/endpoint/%2Fstores%2F%7BstoreNumber%7D/parameter/parameter/path/storeNumber/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml#/web-api/endpoint/%2Fstores%2F%7BstoreNumber%7D/parameter/parameter/path/storeNumber/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -637,6 +642,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml#/web-api/endpoint/%2Fstores%2F%7BstoreNumber%7D/parameter/parameter/path/storeNumber/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml#/web-api/endpoint/%2Fstores%2F%7BstoreNumber%7D/parameter/parameter/path/storeNumber/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml#/web-api/endpoint/%2Fstores%2F%7BstoreNumber%7D/parameter/parameter/path/storeNumber",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml#/web-api/endpoint/%2Fstores%2Fcount/supportedOperation/get/expects/request/parameter/parameter/query/from",

--- a/amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml.expanded.jsonld
@@ -8179,6 +8179,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml.flattened.jsonld
@@ -679,6 +679,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -1044,6 +1049,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml#/web-api/endpoint/%2Fflights/supportedOperation/get/expects/request/parameter/parameter/query/code/scalar/schema",

--- a/amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml.expanded.jsonld
@@ -1062,6 +1062,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -1319,6 +1334,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcopy/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcopy/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -1560,6 +1590,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftouch/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftouch/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }
@@ -1807,6 +1852,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftrash/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftrash/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -2048,6 +2108,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Funtrash/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Funtrash/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }
@@ -2348,6 +2423,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -2642,6 +2732,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents%2F%7BparentId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents%2F%7BparentId%7D/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }
@@ -3142,6 +3247,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -3601,6 +3721,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions%2F%7BpermissionId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions%2F%7BpermissionId%7D/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -4027,6 +4162,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -4355,6 +4505,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions%2F%7BrevisionId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions%2F%7BrevisionId%7D/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }
@@ -4837,6 +5002,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -5204,6 +5384,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -5325,6 +5520,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/commentId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/commentId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }
@@ -5589,6 +5799,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -5710,6 +5935,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/commentId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/commentId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }
@@ -6116,6 +6356,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -6237,6 +6492,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/commentId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/commentId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }
@@ -6755,6 +7025,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frealtime/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frealtime/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -7049,6 +7334,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }
@@ -7380,6 +7680,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties%2F%7BpropertyKey%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties%2F%7BpropertyKey%7D/parameter/parameter/path/fileId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }
@@ -7998,6 +8313,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren/parameter/parameter/path/folderId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren/parameter/parameter/path/folderId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -8295,6 +8625,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/folderId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/folderId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -8416,6 +8761,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/childId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/childId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }

--- a/amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml.flattened.jsonld
@@ -3535,6 +3535,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -3608,6 +3613,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcopy/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcopy/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -3675,6 +3685,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftouch/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftouch/parameter/parameter/path/fileId/source-map/default-node/element_0"
         }
       ]
     },
@@ -3744,6 +3759,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftrash/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftrash/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -3811,6 +3831,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Funtrash/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Funtrash/parameter/parameter/path/fileId/source-map/default-node/element_0"
         }
       ]
     },
@@ -3894,6 +3919,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -3975,6 +4005,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents%2F%7BparentId%7D/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents%2F%7BparentId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0"
         }
       ]
     },
@@ -4107,6 +4142,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -4235,6 +4275,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions%2F%7BpermissionId%7D/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions%2F%7BpermissionId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -4349,6 +4394,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -4446,6 +4496,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions%2F%7BrevisionId%7D/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions%2F%7BrevisionId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0"
         }
       ]
     },
@@ -4575,6 +4630,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -4679,6 +4739,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -4717,6 +4782,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/commentId/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/commentId/source-map/default-node/element_0"
         }
       ]
     },
@@ -4794,6 +4864,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -4832,6 +4907,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/commentId/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/commentId/source-map/default-node/element_0"
         }
       ]
     },
@@ -4943,6 +5023,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -4981,6 +5066,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/commentId/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/commentId/source-map/default-node/element_0"
         }
       ]
     },
@@ -5116,6 +5206,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frealtime/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frealtime/parameter/parameter/path/fileId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -5197,6 +5292,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties/parameter/parameter/path/fileId/source-map/default-node/element_0"
         }
       ]
     },
@@ -5295,6 +5395,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties%2F%7BpropertyKey%7D/parameter/parameter/path/fileId/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties%2F%7BpropertyKey%7D/parameter/parameter/path/fileId/source-map/default-node/element_0"
         }
       ]
     },
@@ -5456,6 +5561,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren/parameter/parameter/path/folderId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren/parameter/parameter/path/folderId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -5538,6 +5648,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/folderId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/folderId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -5576,6 +5691,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/childId/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/childId/source-map/default-node/element_0"
         }
       ]
     },
@@ -6276,6 +6396,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcopy/supportedOperation/post/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcopy/supportedOperation/post",
       "http://a.ml/vocabularies/document-source-maps#value": "[(121,6)-(123,0)]"
@@ -6309,6 +6434,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcopy/parameter/parameter/path/fileId/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcopy/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcopy/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftouch/supportedOperation/post/source-map/lexical/element_1",
@@ -6346,6 +6476,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftouch/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftouch/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftrash/supportedOperation/post/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftrash/supportedOperation/post",
       "http://a.ml/vocabularies/document-source-maps#value": "[(127,6)-(129,0)]"
@@ -6381,6 +6516,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftrash/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Ftrash/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Funtrash/supportedOperation/post/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Funtrash/supportedOperation/post",
       "http://a.ml/vocabularies/document-source-maps#value": "[(130,6)-(132,0)]"
@@ -6414,6 +6554,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Funtrash/parameter/parameter/path/fileId/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Funtrash/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Funtrash/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents/supportedOperation/get/source-map/lexical/element_1",
@@ -6461,6 +6606,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents%2F%7BparentId%7D/supportedOperation/get/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents%2F%7BparentId%7D/supportedOperation/get",
       "http://a.ml/vocabularies/document-source-maps#value": "[(142,8)-(144,0)]"
@@ -6504,6 +6654,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents%2F%7BparentId%7D/parameter/parameter/path/fileId/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents%2F%7BparentId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents%2F%7BparentId%7D/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fparents%2F%7BparentId%7D/parameter/parameter/path/parentId/scalar/schema/source-map",
@@ -6593,6 +6748,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions%2F%7BpermissionId%7D/supportedOperation/get/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions%2F%7BpermissionId%7D/supportedOperation/get",
       "http://a.ml/vocabularies/document-source-maps#value": "[(159,8)-(161,0)]"
@@ -6674,6 +6834,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions%2F%7BpermissionId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions%2F%7BpermissionId%7D/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fpermissions%2F%7BpermissionId%7D/parameter/parameter/path/permissionId/scalar/schema/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
@@ -6746,6 +6911,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions%2F%7BrevisionId%7D/supportedOperation/get/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions%2F%7BrevisionId%7D/supportedOperation/get",
       "http://a.ml/vocabularies/document-source-maps#value": "[(185,8)-(187,0)]"
@@ -6789,6 +6959,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions%2F%7BrevisionId%7D/parameter/parameter/path/fileId/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions%2F%7BrevisionId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions%2F%7BrevisionId%7D/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frevisions%2F%7BrevisionId%7D/parameter/parameter/path/revisionId/scalar/schema/source-map",
@@ -6873,6 +7048,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/supportedOperation/get/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/supportedOperation/get",
       "http://a.ml/vocabularies/document-source-maps#value": "[(199,8)-(202,0)]"
@@ -6928,6 +7108,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/commentId/source-map/synthesized-field/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
@@ -6951,6 +7136,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/commentId/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/commentId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D/parameter/parameter/path/commentId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/supportedOperation/get/source-map/lexical/element_0",
@@ -6988,6 +7178,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/commentId/source-map/synthesized-field/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
@@ -7011,6 +7206,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/commentId/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/commentId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies/parameter/parameter/path/commentId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/supportedOperation/get/source-map/lexical/element_1",
@@ -7078,6 +7278,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/commentId/source-map/synthesized-field/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
@@ -7101,6 +7306,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/commentId/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/commentId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/commentId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D%2Freplies%2F%7BreplyId%7D/parameter/parameter/path/replyId/scalar/schema/source-map",
@@ -7195,6 +7405,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frealtime/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Frealtime/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties/supportedOperation/get/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties/supportedOperation/get",
       "http://a.ml/vocabularies/document-source-maps#value": "[(247,6)-(250,0)]"
@@ -7240,6 +7455,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties%2F%7BpropertyKey%7D/supportedOperation/get/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties%2F%7BpropertyKey%7D/supportedOperation/get",
       "http://a.ml/vocabularies/document-source-maps#value": "[(258,8)-(260,0)]"
@@ -7283,6 +7503,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties%2F%7BpropertyKey%7D/parameter/parameter/path/fileId/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties%2F%7BpropertyKey%7D/parameter/parameter/path/fileId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties%2F%7BpropertyKey%7D/parameter/parameter/path/fileId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfileId%7D%2Fproperties%2F%7BpropertyKey%7D/parameter/parameter/path/propertyKey/scalar/schema/source-map",
@@ -7382,6 +7607,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren/parameter/parameter/path/folderId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren/parameter/parameter/path/folderId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/supportedOperation/delete/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/supportedOperation/delete",
       "http://a.ml/vocabularies/document-source-maps#value": "[(277,6)-(279,0)]"
@@ -7427,6 +7657,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/folderId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/folderId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/childId/source-map/synthesized-field/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#binding",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
@@ -7450,6 +7685,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/childId/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/childId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Ffiles%2F%7BfolderId%7D%2Fchildren%2F%7BchildId%7D/parameter/parameter/path/childId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml#/web-api/endpoint/%2Fabout/supportedOperation/get/source-map/lexical/element_1",

--- a/amf-cli/shared/src/test/resources/resolution/binary-fragment/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/binary-fragment/api.expanded.jsonld
@@ -176,6 +176,9 @@
                             "apiContract:paramName": "true",
                             "core:name": "true",
                             "apiContract:required": "true"
+                          },
+                          "default-node": {
+                            "#17": ""
                           }
                         }
                       }

--- a/amf-cli/shared/src/test/resources/resolution/binary-fragment/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/binary-fragment/api.flattened.jsonld
@@ -188,6 +188,9 @@
           "apiContract:paramName": "true",
           "core:name": "true",
           "apiContract:required": "true"
+        },
+        "default-node": {
+          "#17": ""
         }
       }
     },

--- a/amf-cli/shared/src/test/resources/resolution/nested-parameters.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/nested-parameters.raml.expanded.jsonld
@@ -1241,6 +1241,21 @@
                                   }
                                 ]
                               }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#default-node": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/resolution/nested-parameters.raml#/web-api/endpoint/%2Fusers%2F%7BuserId%7D%2F%7BuserLastName%7D%2FlastName/parameter/parameter/path/userLastName/source-map/default-node/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/resolution/nested-parameters.raml#/web-api/endpoint/%2Fusers%2F%7BuserId%7D%2F%7BuserLastName%7D%2FlastName/parameter/parameter/path/userLastName"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": ""
+                                  }
+                                ]
+                              }
                             ]
                           }
                         ]

--- a/amf-cli/shared/src/test/resources/resolution/nested-parameters.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/nested-parameters.raml.flattened.jsonld
@@ -909,6 +909,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/resolution/nested-parameters.raml#/web-api/endpoint/%2Fusers%2F%7BuserId%7D%2F%7BuserLastName%7D%2FlastName/parameter/parameter/path/userLastName/source-map/synthesized-field/element_2"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/resolution/nested-parameters.raml#/web-api/endpoint/%2Fusers%2F%7BuserId%7D%2F%7BuserLastName%7D%2FlastName/parameter/parameter/path/userLastName/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -1169,6 +1174,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/resolution/nested-parameters.raml#/web-api/endpoint/%2Fusers%2F%7BuserId%7D%2F%7BuserLastName%7D%2FlastName/parameter/parameter/path/userLastName/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/resolution/nested-parameters.raml#/web-api/endpoint/%2Fusers%2F%7BuserId%7D%2F%7BuserLastName%7D%2FlastName/parameter/parameter/path/userLastName/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/resolution/nested-parameters.raml#/web-api/endpoint/%2Fusers%2F%7BuserId%7D%2F%7BuserLastName%7D%2FlastName/parameter/parameter/path/userLastName",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/resolution/nested-parameters.raml#/web-api/endpoint/%2Fusers%2F%7BuserId%7D%2Fpepito%2Fage/parameter/parameter/path/userId/scalar/schema/source-map",

--- a/amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.expanded.jsonld
@@ -736,6 +736,21 @@
                                   }
                                 ]
                               }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#default-node": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.raml#/web-api/endpoint/%2Fhistory%2F%7Bversion%7D/parameter/parameter/path/version/source-map/default-node/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.raml#/web-api/endpoint/%2Fhistory%2F%7Bversion%7D/parameter/parameter/path/version"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": ""
+                                  }
+                                ]
+                              }
                             ]
                           }
                         ]

--- a/amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.flattened.jsonld
@@ -563,6 +563,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.raml#/web-api/endpoint/%2Fhistory%2F%7Bversion%7D/parameter/parameter/path/version/source-map/synthesized-field/element_2"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.raml#/web-api/endpoint/%2Fhistory%2F%7Bversion%7D/parameter/parameter/path/version/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -675,6 +680,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.raml#/web-api/endpoint/%2Fhistory%2F%7Bversion%7D/parameter/parameter/path/version/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.raml#/web-api/endpoint/%2Fhistory%2F%7Bversion%7D/parameter/parameter/path/version/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.raml#/web-api/endpoint/%2Fhistory%2F%7Bversion%7D/parameter/parameter/path/version",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.raml#/web-api/endpoint/%2Fhistory%2F%7Bversion%7D/supportedOperation/get/returns/resp/200/payload/application%2Fjson/source-map/lexical/element_0",

--- a/amf-cli/shared/src/test/resources/resolution/security/security.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/security/security.raml.expanded.jsonld
@@ -1641,6 +1641,21 @@
                                   }
                                 ]
                               }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#default-node": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/resolution/security/security.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid/source-map/default-node/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/resolution/security/security.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": ""
+                                  }
+                                ]
+                              }
                             ]
                           }
                         ]

--- a/amf-cli/shared/src/test/resources/resolution/security/security.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/security/security.raml.flattened.jsonld
@@ -543,6 +543,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/resolution/security/security.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid/source-map/synthesized-field/element_2"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/resolution/security/security.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -802,6 +807,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/resolution/security/security.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid/source-map/synthesized-field/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/resolution/security/security.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/resolution/security/security.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/resolution/security/security.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/supportedOperation/get/security/default-requirement_1/schemes/null/source-map/synthesized-field/element_0",

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml.expanded.jsonld
@@ -7683,6 +7683,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml.flattened.jsonld
@@ -594,6 +594,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -919,6 +924,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml#/web-api/endpoint/%2Fflights%2F%7BID%7D/parameter/parameter/path/ID",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml#/web-api/endpoint/%2Fflights/supportedOperation/get/expects/request/parameter/parameter/query/code/scalar/code",

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml.expanded.jsonld
@@ -1394,6 +1394,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml#/web-api/endpoint/%2Ftest%2F%7BpathParam%7D/parameter/parameter/path/pathParam/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml#/web-api/endpoint/%2Ftest%2F%7BpathParam%7D/parameter/parameter/path/pathParam"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml.flattened.jsonld
@@ -327,6 +327,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml#/web-api/endpoint/%2Ftest%2F%7BpathParam%7D/parameter/parameter/path/pathParam/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml#/web-api/endpoint/%2Ftest%2F%7BpathParam%7D/parameter/parameter/path/pathParam/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -514,6 +519,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml#/web-api/endpoint/%2Ftest%2F%7BpathParam%7D/parameter/parameter/path/pathParam/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml#/web-api/endpoint/%2Ftest%2F%7BpathParam%7D/parameter/parameter/path/pathParam/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml#/web-api/endpoint/%2Ftest%2F%7BpathParam%7D/parameter/parameter/path/pathParam",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/returns/resp/200/payload/application%2Fjson/shape/schema",

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml.expanded.jsonld
@@ -1021,6 +1021,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml#/web-api/endpoint/%2Fauthors%2F%7BauthorId%7D%2Fbooks%2F%7BbookId%7D/parameter/parameter/path/bookId/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml#/web-api/endpoint/%2Fauthors%2F%7BauthorId%7D%2Fbooks%2F%7BbookId%7D/parameter/parameter/path/bookId"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml.flattened.jsonld
@@ -585,6 +585,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml#/web-api/endpoint/%2Fauthors%2F%7BauthorId%7D%2Fbooks%2F%7BbookId%7D/parameter/parameter/path/bookId/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml#/web-api/endpoint/%2Fauthors%2F%7BauthorId%7D%2Fbooks%2F%7BbookId%7D/parameter/parameter/path/bookId/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -767,6 +772,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml#/web-api/endpoint/%2Fauthors%2F%7BauthorId%7D%2Fbooks%2F%7BbookId%7D/parameter/parameter/path/bookId/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml#/web-api/endpoint/%2Fauthors%2F%7BauthorId%7D%2Fbooks%2F%7BbookId%7D/parameter/parameter/path/bookId/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml#/web-api/endpoint/%2Fauthors%2F%7BauthorId%7D%2Fbooks%2F%7BbookId%7D/parameter/parameter/path/bookId",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml#/web-api/endpoint/%2Fauthors%2F%7BauthorId%7D/parameter/parameter/path/authorId/scalar/schema/source-map/type-property-lexical-info/element_0",

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml.expanded.jsonld
@@ -1963,6 +1963,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml.flattened.jsonld
@@ -385,6 +385,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -584,6 +589,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml#/web-api/endpoint/%2Fusers%2F%7Buserid%7D%2Fgists/parameter/parameter/path/userid",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml#/declares/scheme/oauth_2_0/source-map",

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml.expanded.jsonld
@@ -802,6 +802,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml#/web-api/endpoint/%2Ftrial%2F%7BuriParam%7D/parameter/parameter/path/uriParam/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml#/web-api/endpoint/%2Ftrial%2F%7BuriParam%7D/parameter/parameter/path/uriParam"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml.flattened.jsonld
@@ -339,6 +339,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml#/web-api/endpoint/%2Ftrial%2F%7BuriParam%7D/parameter/parameter/path/uriParam/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml#/web-api/endpoint/%2Ftrial%2F%7BuriParam%7D/parameter/parameter/path/uriParam/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -444,6 +449,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml#/web-api/endpoint/%2Ftrial%2F%7BuriParam%7D/parameter/parameter/path/uriParam/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml#/web-api/endpoint/%2Ftrial%2F%7BuriParam%7D/parameter/parameter/path/uriParam/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml#/web-api/endpoint/%2Ftrial%2F%7BuriParam%7D/parameter/parameter/path/uriParam",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml#/web-api/endpoint/%2Ftrial%2F%7BuriParam%7D/supportedOperation/post/expects/request/payload/application%2Fjson/array/schema",

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml.expanded.jsonld
@@ -781,6 +781,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D/parameter/parameter/path/id/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D/parameter/parameter/path/id"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -1203,6 +1218,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "true"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#default-node": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D%2Faccount/parameter/parameter/path/id/source-map/default-node/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D%2Faccount/parameter/parameter/path/id"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
                           }
                         ]
                       }

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml.flattened.jsonld
@@ -444,6 +444,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D/parameter/parameter/path/id/source-map/synthesized-field/element_3"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D/parameter/parameter/path/id/source-map/default-node/element_0"
+        }
       ]
     },
     {
@@ -531,6 +536,11 @@
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D%2Faccount/parameter/parameter/path/id/source-map/synthesized-field/element_3"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#default-node": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D%2Faccount/parameter/parameter/path/id/source-map/default-node/element_0"
         }
       ]
     },
@@ -655,6 +665,11 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D/parameter/parameter/path/id/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D/parameter/parameter/path/id",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
+    },
+    {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D%2Faccount/supportedOperation/get/returns/resp/200/payload/application%2Fjson",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Payload",
@@ -718,6 +733,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D%2Faccount/parameter/parameter/path/id/source-map/synthesized-field/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#paramName",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D%2Faccount/parameter/parameter/path/id/source-map/default-node/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers%2F%7Bid%7D%2Faccount/parameter/parameter/path/id",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml#/web-api/endpoint/%2Fusers/supportedOperation/get/returns/resp/200/payload/application%2Fjson/array/schema",

--- a/amf-cli/shared/src/test/resources/validations/raml/valid-default-uri-parameter-merge-error.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/valid-default-uri-parameter-merge-error.raml
@@ -1,0 +1,15 @@
+#%RAML 1.0
+title: api
+
+resourceTypes:
+  myResourceType:
+    uriParameters:
+      myUriParameter:
+        type: myInteger
+
+types:
+  myInteger:
+    type: integer
+
+/myEndpoint/{myUriParameter}:
+  type: myResourceType

--- a/amf-cli/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
@@ -4,6 +4,7 @@ import amf.core.client.common.validation.Raml08Profile
 import amf.core.internal.remote.{Hint, Raml08YamlHint, Raml10YamlHint}
 
 class ValidRamlModelParserTest extends ValidModelTest {
+
   test("Valid baseUri validations test") {
     checkValid("webapi/valid_baseuri.raml")
   }
@@ -285,6 +286,10 @@ class ValidRamlModelParserTest extends ValidModelTest {
 
   test("Custom facet defined in shapes with inheritance") {
     checkValid("/raml/custom-facet-in-inherited-shape.raml")
+  }
+
+  test("Uri parameter merge with default parameters doesn't reduce merge error") {
+    checkValid("/raml/valid-default-uri-parameter-merge-error.raml")
   }
 
   override val hint: Hint = Raml10YamlHint


### PR DESCRIPTION
This PR fixes a merging error in:
https://github.com/aml-org/amf/pull/1187/files#diff-06f97a03634e4877d5a3e42a9590918ea7b302853db18558cf3d0b66cd559b47

This is because a default uriParameter is created for myUriParameter of type string. When the resource type is applied the schema with inheritance chain `(myInteger <- integer)` gets merged with the `(string)` resulting in: `(string <- integer)`. This creates an error later on in ShapeCanonization.

When replacing the uriParameter schema type `myInteger` for `integer` there isn't any error because scalars aren't merged.

**Solution**: avoid merging default uriParameter when applying traits/resource types. This enables the user to override undeclared parameters with resource types/traits.

**Note 1**: this might be a breaking change as users that were attempting to override their default uriParameters with resource type and traits didn't have the correct result or they had errors.. APIKit validates with the relaxed validation mode so for scalars the validation result should be the same. Now, uriParameter validation of object uriParameters and arrays will start to kick in.

**Note 2**: several JSON-LD changed because I added the DefaultNode annotations to default uriParameters