### PR TITLE
APIMF-3414: added InferredProperty annotation to signal properties that were created from the required array

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/annotations/APISerializableAnnotations.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/annotations/APISerializableAnnotations.scala
@@ -12,7 +12,7 @@ private[amf] object APISerializableAnnotations extends SerializableAnnotations {
     "type-property-lexical-info"             -> TypePropertyLexicalInfo,
     "parameter-binding-in-body-lexical-info" -> ParameterBindingInBodyLexicalInfo,
     "invalid-binding"                        -> InvalidBinding,
-    "extends-reference"                     -> ExtendsReference
+    "extends-reference"                      -> ExtendsReference
   )
 
 }

--- a/amf-cli/shared/src/test/resources/model/raml-with-inferred-json-schema-property.raml
+++ b/amf-cli/shared/src/test/resources/model/raml-with-inferred-json-schema-property.raml
@@ -1,0 +1,20 @@
+#%RAML 1.0
+title: test
+mediaType: application/json
+
+/someEndpoint:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: |
+              {
+                "type": "object",
+                "properties": {
+                  "A": {
+                   "type": "boolean"
+                  }
+                },
+                "required": ["A", "B"]
+              }

--- a/amf-cli/shared/src/test/resources/production/oas-complex-example/api.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas-complex-example/api.resolved.expanded.jsonld
@@ -4952,6 +4952,21 @@
                           }
                         ]
                       }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#inferred-property": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/oas-complex-example/spec/swagger.json#/references/3/shape/schema/and/shape/item1/property/property/name/source-map/inferred-property/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/oas-complex-example/spec/swagger.json#/references/3/shape/schema/and/shape/item1/property/property/name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": ""
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/amf-cli/shared/src/test/resources/production/oas-complex-example/api.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas-complex-example/api.resolved.flattened.jsonld
@@ -2919,6 +2919,11 @@
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/oas-complex-example/spec/swagger.json#/references/3/shape/schema/and/shape/item1/property/property/name/source-map/synthesized-field/element_0"
         }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#inferred-property": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/oas-complex-example/spec/swagger.json#/references/3/shape/schema/and/shape/item1/property/property/name/source-map/inferred-property/element_0"
+        }
       ]
     },
     {
@@ -3097,6 +3102,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/oas-complex-example/spec/swagger.json#/references/3/shape/schema/and/shape/item1/property/property/name/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#minCount",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/oas-complex-example/spec/swagger.json#/references/3/shape/schema/and/shape/item1/property/property/name/source-map/inferred-property/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/oas-complex-example/spec/swagger.json#/references/3/shape/schema/and/shape/item1/property/property/name",
+      "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/oas-complex-example/spec/swagger.json#/references/1/shape/schema/property/property/id/scalar/id/source-map/type-property-lexical-info/element_0",

--- a/amf-cli/shared/src/test/scala/amf/model/ModelAssertionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/model/ModelAssertionTest.scala
@@ -1,0 +1,84 @@
+package amf.model
+
+import amf.apicontract.client.scala.APIConfiguration
+import amf.apicontract.client.scala.model.domain.api.WebApi
+import amf.core.client.common.transform.PipelineId
+import amf.core.client.scala.errorhandling.UnhandledErrorHandler
+import amf.core.client.scala.model.document.{BaseUnit, Document}
+import amf.core.internal.annotations.InferredProperty
+import amf.core.internal.remote.{Mimes, Spec}
+import amf.shapes.client.scala.model.domain.NodeShape
+import org.scalatest.{Assertion, AsyncFunSuite, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ModelAssertionTest extends AsyncFunSuite with Matchers {
+
+  val base = "file://amf-cli/shared/src/test/resources/model/"
+
+  override implicit val executionContext = ExecutionContext.Implicits.global
+
+  test("Inferred property annotation survived transformation") {
+    parse(Spec.RAML10, base + "raml-with-inferred-json-schema-property.raml", PipelineId.Editing).map { unit =>
+      assertInferredProperty(unit)
+    }
+  }
+
+  test("Inferred property annotation is serialized to jsonld and then parsed") {
+    cycle(Spec.RAML10, base + "raml-with-inferred-json-schema-property.raml", PipelineId.Editing).map { unit =>
+      assertInferredProperty(unit)
+    }
+  }
+
+  private def assertInferredProperty(unit: BaseUnit): Assertion = {
+    val properties = unit
+      .asInstanceOf[Document]
+      .encodes
+      .asInstanceOf[WebApi]
+      .endPoints
+      .head
+      .operations
+      .head
+      .responses
+      .head
+      .payloads
+      .head
+      .schema
+      .asInstanceOf[NodeShape]
+      .properties
+
+    val propertyB = properties.find(p => p.name.value() == "B").get
+    val propertyA = properties.find(p => p.name.value() == "A").get
+
+    propertyB.annotations.contains(classOf[InferredProperty]) shouldBe true
+    propertyB.annotations.isInferredProperty shouldBe true
+
+    propertyA.annotations.contains(classOf[InferredProperty]) shouldBe false
+    propertyA.annotations.isInferredProperty shouldBe false
+  }
+
+  private def parse(spec: Spec, url: String): Future[BaseUnit] = {
+    config(spec).baseUnitClient().parse(url).map(_.baseUnit)
+  }
+
+  private def parse(spec: Spec, url: String, pipeline: String): Future[BaseUnit] = {
+    parse(spec, url).map { unit =>
+      config(spec).baseUnitClient().transform(unit, pipeline).baseUnit
+    }
+  }
+
+  private def cycle(spec: Spec, url: String, pipeline: String): Future[BaseUnit] = {
+    parse(spec, url).flatMap { unit =>
+      val client          = config(spec).baseUnitClient()
+      val transformedUnit = client.transform(unit, pipeline).baseUnit
+      val jsonld          = client.render(transformedUnit, Mimes.`application/ld+json`)
+      client.parseContent(jsonld).map(_.baseUnit)
+    }
+  }
+
+  private def config(spec: Spec) = {
+    APIConfiguration
+      .fromSpec(spec)
+      .withErrorHandlerProvider(() => UnhandledErrorHandler)
+  }
+}

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/annotations/ShapeSerializableAnnotations.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/annotations/ShapeSerializableAnnotations.scala
@@ -1,8 +1,8 @@
 package amf.shapes.internal.annotations
 
 import amf.core.client.scala.model.domain.AnnotationGraphLoader
-import amf.core.internal.annotations.{InheritanceProvenance, InheritedShapes, NilUnion}
 import amf.core.internal.annotations.serializable.SerializableAnnotations
+import amf.core.internal.annotations.{InferredProperty, InheritanceProvenance, InheritedShapes, NilUnion}
 
 private[amf] object ShapeSerializableAnnotations extends SerializableAnnotations {
 
@@ -10,7 +10,7 @@ private[amf] object ShapeSerializableAnnotations extends SerializableAnnotations
     "type-expression"        -> ParsedFromTypeExpression,
     "inheritance-provenance" -> InheritanceProvenance,
     "inherited-shapes"       -> InheritedShapes,
-    "nil-union"              -> NilUnion
+    "nil-union"              -> NilUnion,
+    "inferred-property"      -> InferredProperty
   )
-
 }


### PR DESCRIPTION
*Note*: to have a better UX we should create a method `isExplicit` or something like that so that users don't have to by hand, find the annotation InferredProperty.
I couldn't do this because PropertyShape is in amf-core and the annotation should be part of amf-shapes. I could add it in amf-core if you validate it﻿

Related to: https://github.com/aml-org/amf-core/pull/367