### PR TITLE
APIMF 3519

### DIFF
--- a/amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/output.txt.js
+++ b/amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/output.txt.js
@@ -8,31 +8,31 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be >= 5
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk1/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk1/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk1/customDomainProperties/age/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk1/customDomainProperties/age/scalar_1
   Range: [(23,9)-(23,10)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be <= 10
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk2/customDomainProperties/extension_3/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk2/customDomainProperties/extension_3/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk2/customDomainProperties/fingers/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk2/customDomainProperties/fingers/scalar_1
   Range: [(27,13)-(27,15)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be <= 10
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2Frange/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2Frange/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2Frange/customDomainProperties/range/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2Frange/customDomainProperties/range/scalar_1
   Range: [(29,11)-(29,13)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be multiple of 4
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FyearsBad/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FyearsBad/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FyearsBad/customDomainProperties/leapYear/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FyearsBad/customDomainProperties/leapYear/scalar_1
   Range: [(33,14)-(33,18)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml

--- a/amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/output.txt.jvm
+++ b/amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/output.txt.jvm
@@ -8,31 +8,31 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: 4 is not greater or equal to 5
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk1/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk1/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk1/customDomainProperties/age/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk1/customDomainProperties/age/scalar_1
   Range: [(23,9)-(23,10)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: 11 is not less or equal to 10
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk2/customDomainProperties/extension_3/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk2/customDomainProperties/extension_3/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk2/customDomainProperties/fingers/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FpersonNotOk2/customDomainProperties/fingers/scalar_1
   Range: [(27,13)-(27,15)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: 15 is not less or equal to 10
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2Frange/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2Frange/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2Frange/customDomainProperties/range/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2Frange/customDomainProperties/range/scalar_1
   Range: [(29,11)-(29,13)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: 2003 is not a multiple of 4
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FyearsBad/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FyearsBad/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FyearsBad/customDomainProperties/leapYear/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml#/web-api/endpoint/%2FyearsBad/customDomainProperties/leapYear/scalar_1
   Range: [(33,14)-(33,18)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/numeric/input.raml

--- a/amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/output.txt.js
+++ b/amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/output.txt.js
@@ -8,15 +8,15 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should have required property 'alive'
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad0/customDomainProperties/extension/object_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad0/customDomainProperties/extension/object_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad0/customDomainProperties/user/object_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad0/customDomainProperties/user/object_1
   Range: [(22,0)-(23,0)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: alive should be boolean
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad1/customDomainProperties/extension/object_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad1/customDomainProperties/extension/object_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad1/customDomainProperties/user/object_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad1/customDomainProperties/user/object_1
   Range: [(25,0)-(26,15)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml

--- a/amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/output.txt.jvm
+++ b/amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/output.txt.jvm
@@ -8,15 +8,15 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: required key [alive] not found
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad0/customDomainProperties/extension/object_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad0/customDomainProperties/extension/object_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad0/customDomainProperties/user/object_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad0/customDomainProperties/user/object_1
   Range: [(22,0)-(23,0)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: /alive expected type: Boolean, found: Integer
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad1/customDomainProperties/extension/object_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad1/customDomainProperties/extension/object_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad1/customDomainProperties/user/object_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml#/web-api/endpoint/%2Fbad1/customDomainProperties/user/object_1
   Range: [(25,0)-(26,15)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/object/input.raml

--- a/amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/output.txt.js
+++ b/amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/output.txt.js
@@ -8,23 +8,23 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be string
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/image/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/image/scalar_1
   Range: [(18,11)-(18,12)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should NOT be longer than 2 characters
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension_2/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension_2/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/foo/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/foo/scalar_1
   Range: [(19,9)-(19,12)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should NOT be shorter than 10 characters
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension_3/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension_3/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/tato/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/tato/scalar_1
   Range: [(20,10)-(20,15)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml

--- a/amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/output.txt.jvm
+++ b/amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/output.txt.jvm
@@ -8,23 +8,23 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected type: String, found: Integer
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/image/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/image/scalar_1
   Range: [(18,11)-(18,12)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected maxLength: 2, actual: 3
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension_2/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension_2/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/foo/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/foo/scalar_1
   Range: [(19,9)-(19,12)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected minLength: 10, actual: 5
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension_3/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/extension_3/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/tato/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml#/web-api/endpoint/%2Ftext/customDomainProperties/tato/scalar_1
   Range: [(20,10)-(20,15)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/annotation/string/input.raml

--- a/amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/output.txt.js
+++ b/amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/output.txt.js
@@ -8,7 +8,7 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be number
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/input.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension_4/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/input.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension_4/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/input.raml#/web-api/endpoint/%2Fusers/customDomainProperties/intAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/input.raml#/web-api/endpoint/%2Fusers/customDomainProperties/intAnnotation/scalar_1
   Range: [(26,19)-(26,20)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/input.raml

--- a/amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/output.txt.jvm
+++ b/amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/output.txt.jvm
@@ -8,7 +8,7 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected type: Number, found: String
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/input.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension_4/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/input.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension_4/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/input.raml#/web-api/endpoint/%2Fusers/customDomainProperties/intAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/input.raml#/web-api/endpoint/%2Fusers/customDomainProperties/intAnnotation/scalar_1
   Range: [(26,19)-(26,20)]
   Location: file://amf-cli/shared/src/test/resources/org/raml/parser/types/sugar/annotations/input.raml

--- a/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.expanded.jsonld
@@ -3417,7 +3417,7 @@
                                   "@value": "oas-body-name"
                                 }
                               ],
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
                               "@type": [
                                 "http://a.ml/vocabularies/data#Scalar",
                                 "http://a.ml/vocabularies/data#Node",
@@ -3440,13 +3440,13 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#sources": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map",
                                   "@type": [
                                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -3459,7 +3459,7 @@
                                       ]
                                     },
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/core#name"
@@ -3474,10 +3474,10 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
-                                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1"
+                                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1"
                                         }
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4222,7 +4222,7 @@
                       "@value": "oas-tags"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Array",
                     "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -4231,7 +4231,7 @@
                   ],
                   "http://www.w3.org/2000/01/rdf-schema#member": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2",
                       "@type": [
                         "http://a.ml/vocabularies/data#Scalar",
                         "http://a.ml/vocabularies/data#Node",
@@ -4254,13 +4254,13 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#sources": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map",
                           "@type": [
                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                           ],
                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -4273,7 +4273,7 @@
                               ]
                             },
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -4288,10 +4288,10 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
-                                  "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2"
+                                  "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2"
                                 }
                               ],
                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4312,16 +4312,16 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6761,7 +6761,7 @@
                                   "@value": "oas-body-name"
                                 }
                               ],
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
                               "@type": [
                                 "http://a.ml/vocabularies/data#Scalar",
                                 "http://a.ml/vocabularies/data#Node",
@@ -6784,13 +6784,13 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#sources": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map",
                                   "@type": [
                                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -6803,7 +6803,7 @@
                                       ]
                                     },
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/core#name"
@@ -6818,10 +6818,10 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
-                                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1"
+                                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1"
                                         }
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7553,7 +7553,7 @@
                       "@value": "oas-tags"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Array",
                     "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -7562,7 +7562,7 @@
                   ],
                   "http://www.w3.org/2000/01/rdf-schema#member": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2",
                       "@type": [
                         "http://a.ml/vocabularies/data#Scalar",
                         "http://a.ml/vocabularies/data#Node",
@@ -7585,13 +7585,13 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#sources": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map",
                           "@type": [
                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                           ],
                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -7604,7 +7604,7 @@
                               ]
                             },
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -7619,10 +7619,10 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
-                                  "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2"
+                                  "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2"
                                 }
                               ],
                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7643,16 +7643,16 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10195,7 +10195,7 @@
                       "@value": "oas-tags"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Array",
                     "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -10204,7 +10204,7 @@
                   ],
                   "http://www.w3.org/2000/01/rdf-schema#member": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2",
                       "@type": [
                         "http://a.ml/vocabularies/data#Scalar",
                         "http://a.ml/vocabularies/data#Node",
@@ -10227,13 +10227,13 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#sources": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map",
                           "@type": [
                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                           ],
                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -10246,7 +10246,7 @@
                               ]
                             },
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -10261,10 +10261,10 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
-                                  "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2"
+                                  "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2"
                                 }
                               ],
                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10285,16 +10285,16 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12765,7 +12765,7 @@
                       "@value": "oas-tags"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Array",
                     "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -12774,7 +12774,7 @@
                   ],
                   "http://www.w3.org/2000/01/rdf-schema#member": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2",
                       "@type": [
                         "http://a.ml/vocabularies/data#Scalar",
                         "http://a.ml/vocabularies/data#Node",
@@ -12797,13 +12797,13 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#sources": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map",
                           "@type": [
                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                           ],
                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -12816,7 +12816,7 @@
                               ]
                             },
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -12831,10 +12831,10 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
-                                  "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2"
+                                  "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2"
                                 }
                               ],
                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12855,16 +12855,16 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15300,7 +15300,7 @@
                                   "@value": "oas-body-name"
                                 }
                               ],
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
                               "@type": [
                                 "http://a.ml/vocabularies/data#Scalar",
                                 "http://a.ml/vocabularies/data#Node",
@@ -15323,13 +15323,13 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#sources": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map",
                                   "@type": [
                                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -15342,7 +15342,7 @@
                                       ]
                                     },
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/core#name"
@@ -15357,10 +15357,10 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
-                                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1"
+                                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1"
                                         }
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18564,7 +18564,7 @@
                                   "@value": "oas-body-name"
                                 }
                               ],
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
                               "@type": [
                                 "http://a.ml/vocabularies/data#Scalar",
                                 "http://a.ml/vocabularies/data#Node",
@@ -18587,13 +18587,13 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#sources": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map",
                                   "@type": [
                                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -18606,7 +18606,7 @@
                                       ]
                                     },
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/core#name"
@@ -18621,10 +18621,10 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
-                                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1"
+                                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1"
                                         }
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19356,7 +19356,7 @@
                       "@value": "oas-tags"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Array",
                     "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -19365,7 +19365,7 @@
                   ],
                   "http://www.w3.org/2000/01/rdf-schema#member": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2",
                       "@type": [
                         "http://a.ml/vocabularies/data#Scalar",
                         "http://a.ml/vocabularies/data#Node",
@@ -19388,13 +19388,13 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#sources": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map",
                           "@type": [
                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                           ],
                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -19407,7 +19407,7 @@
                               ]
                             },
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -19422,10 +19422,10 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
-                                  "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2"
+                                  "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2"
                                 }
                               ],
                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19446,16 +19446,16 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19603,13 +19603,1368 @@
             ]
           }
         ],
+        "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-externalDocs": {
+          "http://a.ml/vocabularies/core#extensionName": [
+            {
+              "@value": "oas-externalDocs"
+            }
+          ],
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1",
+          "@type": [
+            "http://a.ml/vocabularies/data#Object",
+            "http://a.ml/vocabularies/data#Node",
+            "http://a.ml/vocabularies/document#DomainElement"
+          ],
+          "http://a.ml/vocabularies/data#url": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url",
+              "@type": [
+                "http://a.ml/vocabularies/data#Scalar",
+                "http://a.ml/vocabularies/data#Node",
+                "http://a.ml/vocabularies/document#DomainElement"
+              ],
+              "http://a.ml/vocabularies/data#value": [
+                {
+                  "@value": "https://developers.google.com/prediction/docs/developer-guide"
+                }
+              ],
+              "http://www.w3.org/ns/shacl#datatype": [
+                {
+                  "@id": "http://www.w3.org/2001/XMLSchema#string"
+                }
+              ],
+              "http://a.ml/vocabularies/core#name": [
+                {
+                  "@value": "url"
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#sources": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map",
+                  "@type": [
+                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map/synthesized-field/element_1",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://www.w3.org/ns/shacl#datatype"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map/synthesized-field/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/core#name"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#lexical": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map/lexical/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(72,7)-(72,70)]"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "http://a.ml/vocabularies/core#name": [
+            {
+              "@value": "object_1"
+            }
+          ],
+          "http://a.ml/vocabularies/document-source-maps#sources": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map",
+              "@type": [
+                "http://a.ml/vocabularies/document-source-maps#SourceMap"
+              ],
+              "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map/synthesized-field/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/core#name"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "true"
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#lexical": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map/lexical/element_1",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(72,0)-(73,0)]"
+                    }
+                  ]
+                },
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map/lexical/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/data#url"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(72,2)-(73,0)]"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-info": {
+          "http://a.ml/vocabularies/core#extensionName": [
+            {
+              "@value": "oas-info"
+            }
+          ],
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1",
+          "@type": [
+            "http://a.ml/vocabularies/data#Object",
+            "http://a.ml/vocabularies/data#Node",
+            "http://a.ml/vocabularies/document#DomainElement"
+          ],
+          "http://a.ml/vocabularies/data#(oas-x-apiClientRegistration)": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)",
+              "@type": [
+                "http://a.ml/vocabularies/data#Object",
+                "http://a.ml/vocabularies/data#Node",
+                "http://a.ml/vocabularies/document#DomainElement"
+              ],
+              "http://a.ml/vocabularies/data#url": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url",
+                  "@type": [
+                    "http://a.ml/vocabularies/data#Scalar",
+                    "http://a.ml/vocabularies/data#Node",
+                    "http://a.ml/vocabularies/document#DomainElement"
+                  ],
+                  "http://a.ml/vocabularies/data#value": [
+                    {
+                      "@value": "https://console.developers.google.com"
+                    }
+                  ],
+                  "http://www.w3.org/ns/shacl#datatype": [
+                    {
+                      "@id": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/core#name": [
+                    {
+                      "@value": "url"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#sources": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map",
+                      "@type": [
+                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_1",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://www.w3.org/ns/shacl#datatype"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        },
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://a.ml/vocabularies/core#name"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#lexical": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map/lexical/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "[(58,9)-(58,48)]"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/core#name": [
+                {
+                  "@value": "(oas-x-apiClientRegistration)"
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#sources": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map",
+                  "@type": [
+                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map/synthesized-field/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/core#name"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#lexical": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_1",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(58,0)-(59,0)]"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/data#url"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(58,4)-(59,0)]"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "http://a.ml/vocabularies/data#(oas-x-logo)": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)",
+              "@type": [
+                "http://a.ml/vocabularies/data#Object",
+                "http://a.ml/vocabularies/data#Node",
+                "http://a.ml/vocabularies/document#DomainElement"
+              ],
+              "http://a.ml/vocabularies/data#url": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url",
+                  "@type": [
+                    "http://a.ml/vocabularies/data#Scalar",
+                    "http://a.ml/vocabularies/data#Node",
+                    "http://a.ml/vocabularies/document#DomainElement"
+                  ],
+                  "http://a.ml/vocabularies/data#value": [
+                    {
+                      "@value": "https://api.apis.guru/v2/cache/logo/https_www.google.com_images_icons_feature_predictionapi-64.png"
+                    }
+                  ],
+                  "http://www.w3.org/ns/shacl#datatype": [
+                    {
+                      "@id": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/core#name": [
+                    {
+                      "@value": "url"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#sources": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map",
+                      "@type": [
+                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_1",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://www.w3.org/ns/shacl#datatype"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        },
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://a.ml/vocabularies/core#name"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#lexical": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map/lexical/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "[(60,9)-(60,109)]"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/core#name": [
+                {
+                  "@value": "(oas-x-logo)"
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#sources": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map",
+                  "@type": [
+                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map/synthesized-field/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/core#name"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#lexical": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map/lexical/element_1",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(60,0)-(61,0)]"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map/lexical/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/data#url"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(60,4)-(61,0)]"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "http://a.ml/vocabularies/data#(oas-x-origin)": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)",
+              "@type": [
+                "http://a.ml/vocabularies/data#Object",
+                "http://a.ml/vocabularies/data#Node",
+                "http://a.ml/vocabularies/document#DomainElement"
+              ],
+              "http://a.ml/vocabularies/data#format": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format",
+                  "@type": [
+                    "http://a.ml/vocabularies/data#Scalar",
+                    "http://a.ml/vocabularies/data#Node",
+                    "http://a.ml/vocabularies/document#DomainElement"
+                  ],
+                  "http://a.ml/vocabularies/data#value": [
+                    {
+                      "@value": "google"
+                    }
+                  ],
+                  "http://www.w3.org/ns/shacl#datatype": [
+                    {
+                      "@id": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/core#name": [
+                    {
+                      "@value": "format"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#sources": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map",
+                      "@type": [
+                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_1",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://www.w3.org/ns/shacl#datatype"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        },
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://a.ml/vocabularies/core#name"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#lexical": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map/lexical/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "[(62,12)-(62,18)]"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/data#url": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url",
+                  "@type": [
+                    "http://a.ml/vocabularies/data#Scalar",
+                    "http://a.ml/vocabularies/data#Node",
+                    "http://a.ml/vocabularies/document#DomainElement"
+                  ],
+                  "http://a.ml/vocabularies/data#value": [
+                    {
+                      "@value": "https://www.googleapis.com/discovery/v1/apis/prediction/v1.2/rest"
+                    }
+                  ],
+                  "http://www.w3.org/ns/shacl#datatype": [
+                    {
+                      "@id": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/core#name": [
+                    {
+                      "@value": "url"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#sources": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map",
+                      "@type": [
+                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_1",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://www.w3.org/ns/shacl#datatype"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        },
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://a.ml/vocabularies/core#name"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#lexical": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map/lexical/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "[(63,9)-(63,76)]"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/data#version": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version",
+                  "@type": [
+                    "http://a.ml/vocabularies/data#Scalar",
+                    "http://a.ml/vocabularies/data#Node",
+                    "http://a.ml/vocabularies/document#DomainElement"
+                  ],
+                  "http://a.ml/vocabularies/data#value": [
+                    {
+                      "@value": "v1"
+                    }
+                  ],
+                  "http://www.w3.org/ns/shacl#datatype": [
+                    {
+                      "@id": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/core#name": [
+                    {
+                      "@value": "version"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#sources": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map",
+                      "@type": [
+                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_1",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://www.w3.org/ns/shacl#datatype"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        },
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://a.ml/vocabularies/core#name"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#lexical": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map/lexical/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "[(64,13)-(64,15)]"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/core#name": [
+                {
+                  "@value": "(oas-x-origin)"
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#sources": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map",
+                  "@type": [
+                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/synthesized-field/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/core#name"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#lexical": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_3",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/data#url"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(63,4)-(64,0)]"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_1",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/data#format"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(62,4)-(63,0)]"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/data#version"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(64,4)-(65,0)]"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_2",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(62,0)-(65,0)]"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "http://a.ml/vocabularies/data#(oas-x-preferred)": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)",
+              "@type": [
+                "http://a.ml/vocabularies/data#Scalar",
+                "http://a.ml/vocabularies/data#Node",
+                "http://a.ml/vocabularies/document#DomainElement"
+              ],
+              "http://a.ml/vocabularies/data#value": [
+                {
+                  "@value": "false"
+                }
+              ],
+              "http://www.w3.org/ns/shacl#datatype": [
+                {
+                  "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+                }
+              ],
+              "http://a.ml/vocabularies/core#name": [
+                {
+                  "@value": "(oas-x-preferred)"
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#sources": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map",
+                  "@type": [
+                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map/synthesized-field/element_1",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://www.w3.org/ns/shacl#datatype"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map/synthesized-field/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/core#name"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#lexical": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map/lexical/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(65,21)-(65,26)]"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "http://a.ml/vocabularies/data#(oas-x-providerName)": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)",
+              "@type": [
+                "http://a.ml/vocabularies/data#Scalar",
+                "http://a.ml/vocabularies/data#Node",
+                "http://a.ml/vocabularies/document#DomainElement"
+              ],
+              "http://a.ml/vocabularies/data#value": [
+                {
+                  "@value": "googleapis.com"
+                }
+              ],
+              "http://www.w3.org/ns/shacl#datatype": [
+                {
+                  "@id": "http://www.w3.org/2001/XMLSchema#string"
+                }
+              ],
+              "http://a.ml/vocabularies/core#name": [
+                {
+                  "@value": "(oas-x-providerName)"
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#sources": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map",
+                  "@type": [
+                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map/synthesized-field/element_1",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://www.w3.org/ns/shacl#datatype"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map/synthesized-field/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/core#name"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#lexical": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map/lexical/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(66,24)-(66,38)]"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "http://a.ml/vocabularies/data#(oas-x-serviceName)": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)",
+              "@type": [
+                "http://a.ml/vocabularies/data#Scalar",
+                "http://a.ml/vocabularies/data#Node",
+                "http://a.ml/vocabularies/document#DomainElement"
+              ],
+              "http://a.ml/vocabularies/data#value": [
+                {
+                  "@value": "prediction"
+                }
+              ],
+              "http://www.w3.org/ns/shacl#datatype": [
+                {
+                  "@id": "http://www.w3.org/2001/XMLSchema#string"
+                }
+              ],
+              "http://a.ml/vocabularies/core#name": [
+                {
+                  "@value": "(oas-x-serviceName)"
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#sources": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map",
+                  "@type": [
+                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_1",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://www.w3.org/ns/shacl#datatype"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/core#name"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#lexical": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map/lexical/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(67,23)-(67,33)]"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "http://a.ml/vocabularies/data#contact": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact",
+              "@type": [
+                "http://a.ml/vocabularies/data#Object",
+                "http://a.ml/vocabularies/data#Node",
+                "http://a.ml/vocabularies/document#DomainElement"
+              ],
+              "http://a.ml/vocabularies/data#name": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name",
+                  "@type": [
+                    "http://a.ml/vocabularies/data#Scalar",
+                    "http://a.ml/vocabularies/data#Node",
+                    "http://a.ml/vocabularies/document#DomainElement"
+                  ],
+                  "http://a.ml/vocabularies/data#value": [
+                    {
+                      "@value": "Google"
+                    }
+                  ],
+                  "http://www.w3.org/ns/shacl#datatype": [
+                    {
+                      "@id": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/core#name": [
+                    {
+                      "@value": "name"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#sources": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map",
+                      "@type": [
+                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map/synthesized-field/element_1",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://www.w3.org/ns/shacl#datatype"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        },
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map/synthesized-field/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://a.ml/vocabularies/core#name"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#lexical": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map/lexical/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "[(69,10)-(69,16)]"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/data#url": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url",
+                  "@type": [
+                    "http://a.ml/vocabularies/data#Scalar",
+                    "http://a.ml/vocabularies/data#Node",
+                    "http://a.ml/vocabularies/document#DomainElement"
+                  ],
+                  "http://a.ml/vocabularies/data#value": [
+                    {
+                      "@value": "https://google.com"
+                    }
+                  ],
+                  "http://www.w3.org/ns/shacl#datatype": [
+                    {
+                      "@id": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/core#name": [
+                    {
+                      "@value": "url"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#sources": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map",
+                      "@type": [
+                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map/synthesized-field/element_1",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://www.w3.org/ns/shacl#datatype"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        },
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map/synthesized-field/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "http://a.ml/vocabularies/core#name"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "true"
+                            }
+                          ]
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#lexical": [
+                        {
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map/lexical/element_0",
+                          "http://a.ml/vocabularies/document-source-maps#element": [
+                            {
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url"
+                            }
+                          ],
+                          "http://a.ml/vocabularies/document-source-maps#value": [
+                            {
+                              "@value": "[(70,9)-(70,29)]"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/core#name": [
+                {
+                  "@value": "contact"
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#sources": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map",
+                  "@type": [
+                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/synthesized-field/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/core#name"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#lexical": [
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/lexical/element_2",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/data#name"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(69,4)-(70,0)]"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/lexical/element_0",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "http://a.ml/vocabularies/data#url"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(70,4)-(71,0)]"
+                        }
+                      ]
+                    },
+                    {
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/lexical/element_1",
+                      "http://a.ml/vocabularies/document-source-maps#element": [
+                        {
+                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact"
+                        }
+                      ],
+                      "http://a.ml/vocabularies/document-source-maps#value": [
+                        {
+                          "@value": "[(69,0)-(71,0)]"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "http://a.ml/vocabularies/core#name": [
+            {
+              "@value": "object_1"
+            }
+          ],
+          "http://a.ml/vocabularies/document-source-maps#sources": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map",
+              "@type": [
+                "http://a.ml/vocabularies/document-source-maps#SourceMap"
+              ],
+              "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/synthesized-field/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/core#name"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "true"
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#lexical": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_7",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/data#(oas-x-serviceName)"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(67,2)-(68,0)]"
+                    }
+                  ]
+                },
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_5",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/data#(oas-x-logo)"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(59,2)-(61,0)]"
+                    }
+                  ]
+                },
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_3",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/data#(oas-x-apiClientRegistration)"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(57,2)-(59,0)]"
+                    }
+                  ]
+                },
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_1",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/data#(oas-x-providerName)"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(66,2)-(67,0)]"
+                    }
+                  ]
+                },
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/data#contact"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(68,2)-(71,0)]"
+                    }
+                  ]
+                },
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_2",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/data#(oas-x-origin)"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(61,2)-(65,0)]"
+                    }
+                  ]
+                },
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_4",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(57,0)-(71,0)]"
+                    }
+                  ]
+                },
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_6",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/data#(oas-x-preferred)"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(65,2)-(66,0)]"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
         "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags-definition": {
           "http://a.ml/vocabularies/core#extensionName": [
             {
               "@value": "oas-tags-definition"
             }
           ],
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1",
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1",
           "@type": [
             "http://a.ml/vocabularies/data#Array",
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -19618,7 +20973,7 @@
           ],
           "http://www.w3.org/2000/01/rdf-schema#member": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2",
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2",
               "@type": [
                 "http://a.ml/vocabularies/data#Object",
                 "http://a.ml/vocabularies/data#Node",
@@ -19626,7 +20981,7 @@
               ],
               "http://a.ml/vocabularies/data#name": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4",
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -19649,13 +21004,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -19668,7 +21023,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -19683,10 +21038,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4"
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19707,13 +21062,13 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map/synthesized-field/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map/synthesized-field/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/core#name"
@@ -19728,10 +21083,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map/lexical/element_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map/lexical/element_1",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2"
+                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19741,7 +21096,7 @@
                       ]
                     },
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/data#name"
@@ -19758,7 +21113,7 @@
               ]
             },
             {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4",
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4",
               "@type": [
                 "http://a.ml/vocabularies/data#Object",
                 "http://a.ml/vocabularies/data#Node",
@@ -19766,7 +21121,7 @@
               ],
               "http://a.ml/vocabularies/data#name": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5",
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -19789,13 +21144,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -19808,7 +21163,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -19823,10 +21178,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5"
+                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19847,13 +21202,13 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map/synthesized-field/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map/synthesized-field/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/core#name"
@@ -19868,10 +21223,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map/lexical/element_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map/lexical/element_1",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4"
+                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19881,7 +21236,7 @@
                       ]
                     },
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/data#name"
@@ -19905,16 +21260,16 @@
           ],
           "http://a.ml/vocabularies/document-source-maps#sources": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/source-map",
+              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/source-map",
               "@type": [
                 "http://a.ml/vocabularies/document-source-maps#SourceMap"
               ],
               "http://a.ml/vocabularies/document-source-maps#lexical": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/source-map/lexical/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/source-map/lexical/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
-                      "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1"
+                      "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1"
                     }
                   ],
                   "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19927,1370 +21282,15 @@
             }
           ]
         },
-        "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-info": {
-          "http://a.ml/vocabularies/core#extensionName": [
-            {
-              "@value": "oas-info"
-            }
-          ],
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1",
-          "@type": [
-            "http://a.ml/vocabularies/data#Object",
-            "http://a.ml/vocabularies/data#Node",
-            "http://a.ml/vocabularies/document#DomainElement"
-          ],
-          "http://a.ml/vocabularies/data#(oas-x-apiClientRegistration)": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)",
-              "@type": [
-                "http://a.ml/vocabularies/data#Object",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#url": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url",
-                  "@type": [
-                    "http://a.ml/vocabularies/data#Scalar",
-                    "http://a.ml/vocabularies/data#Node",
-                    "http://a.ml/vocabularies/document#DomainElement"
-                  ],
-                  "http://a.ml/vocabularies/data#value": [
-                    {
-                      "@value": "https://console.developers.google.com"
-                    }
-                  ],
-                  "http://www.w3.org/ns/shacl#datatype": [
-                    {
-                      "@id": "http://www.w3.org/2001/XMLSchema#string"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/core#name": [
-                    {
-                      "@value": "url"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#sources": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map",
-                      "@type": [
-                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_1",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://www.w3.org/ns/shacl#datatype"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        },
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://a.ml/vocabularies/core#name"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#lexical": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map/lexical/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "[(58,9)-(58,48)]"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "(oas-x-apiClientRegistration)"
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#sources": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map",
-                  "@type": [
-                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map/synthesized-field/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/core#name"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#lexical": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_1",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(58,0)-(59,0)]"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/data#url"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(58,4)-(59,0)]"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "http://a.ml/vocabularies/data#(oas-x-logo)": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)",
-              "@type": [
-                "http://a.ml/vocabularies/data#Object",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#url": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url",
-                  "@type": [
-                    "http://a.ml/vocabularies/data#Scalar",
-                    "http://a.ml/vocabularies/data#Node",
-                    "http://a.ml/vocabularies/document#DomainElement"
-                  ],
-                  "http://a.ml/vocabularies/data#value": [
-                    {
-                      "@value": "https://api.apis.guru/v2/cache/logo/https_www.google.com_images_icons_feature_predictionapi-64.png"
-                    }
-                  ],
-                  "http://www.w3.org/ns/shacl#datatype": [
-                    {
-                      "@id": "http://www.w3.org/2001/XMLSchema#string"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/core#name": [
-                    {
-                      "@value": "url"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#sources": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map",
-                      "@type": [
-                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_1",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://www.w3.org/ns/shacl#datatype"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        },
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://a.ml/vocabularies/core#name"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#lexical": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map/lexical/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "[(60,9)-(60,109)]"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "(oas-x-logo)"
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#sources": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map",
-                  "@type": [
-                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map/synthesized-field/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/core#name"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#lexical": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map/lexical/element_1",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(60,0)-(61,0)]"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map/lexical/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/data#url"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(60,4)-(61,0)]"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "http://a.ml/vocabularies/data#(oas-x-origin)": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)",
-              "@type": [
-                "http://a.ml/vocabularies/data#Object",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#format": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format",
-                  "@type": [
-                    "http://a.ml/vocabularies/data#Scalar",
-                    "http://a.ml/vocabularies/data#Node",
-                    "http://a.ml/vocabularies/document#DomainElement"
-                  ],
-                  "http://a.ml/vocabularies/data#value": [
-                    {
-                      "@value": "google"
-                    }
-                  ],
-                  "http://www.w3.org/ns/shacl#datatype": [
-                    {
-                      "@id": "http://www.w3.org/2001/XMLSchema#string"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/core#name": [
-                    {
-                      "@value": "format"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#sources": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map",
-                      "@type": [
-                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_1",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://www.w3.org/ns/shacl#datatype"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        },
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://a.ml/vocabularies/core#name"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#lexical": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map/lexical/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "[(62,12)-(62,18)]"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/data#url": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url",
-                  "@type": [
-                    "http://a.ml/vocabularies/data#Scalar",
-                    "http://a.ml/vocabularies/data#Node",
-                    "http://a.ml/vocabularies/document#DomainElement"
-                  ],
-                  "http://a.ml/vocabularies/data#value": [
-                    {
-                      "@value": "https://www.googleapis.com/discovery/v1/apis/prediction/v1.2/rest"
-                    }
-                  ],
-                  "http://www.w3.org/ns/shacl#datatype": [
-                    {
-                      "@id": "http://www.w3.org/2001/XMLSchema#string"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/core#name": [
-                    {
-                      "@value": "url"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#sources": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map",
-                      "@type": [
-                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_1",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://www.w3.org/ns/shacl#datatype"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        },
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://a.ml/vocabularies/core#name"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#lexical": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map/lexical/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "[(63,9)-(63,76)]"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/data#version": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version",
-                  "@type": [
-                    "http://a.ml/vocabularies/data#Scalar",
-                    "http://a.ml/vocabularies/data#Node",
-                    "http://a.ml/vocabularies/document#DomainElement"
-                  ],
-                  "http://a.ml/vocabularies/data#value": [
-                    {
-                      "@value": "v1"
-                    }
-                  ],
-                  "http://www.w3.org/ns/shacl#datatype": [
-                    {
-                      "@id": "http://www.w3.org/2001/XMLSchema#string"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/core#name": [
-                    {
-                      "@value": "version"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#sources": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map",
-                      "@type": [
-                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_1",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://www.w3.org/ns/shacl#datatype"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        },
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://a.ml/vocabularies/core#name"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#lexical": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map/lexical/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "[(64,13)-(64,15)]"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "(oas-x-origin)"
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#sources": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map",
-                  "@type": [
-                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/synthesized-field/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/core#name"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#lexical": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_3",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/data#url"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(63,4)-(64,0)]"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_1",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/data#format"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(62,4)-(63,0)]"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/data#version"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(64,4)-(65,0)]"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_2",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(62,0)-(65,0)]"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "http://a.ml/vocabularies/data#(oas-x-preferred)": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)",
-              "@type": [
-                "http://a.ml/vocabularies/data#Scalar",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#value": [
-                {
-                  "@value": "false"
-                }
-              ],
-              "http://www.w3.org/ns/shacl#datatype": [
-                {
-                  "@id": "http://www.w3.org/2001/XMLSchema#boolean"
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "(oas-x-preferred)"
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#sources": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map",
-                  "@type": [
-                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map/synthesized-field/element_1",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://www.w3.org/ns/shacl#datatype"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map/synthesized-field/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/core#name"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#lexical": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map/lexical/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(65,21)-(65,26)]"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "http://a.ml/vocabularies/data#(oas-x-providerName)": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)",
-              "@type": [
-                "http://a.ml/vocabularies/data#Scalar",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#value": [
-                {
-                  "@value": "googleapis.com"
-                }
-              ],
-              "http://www.w3.org/ns/shacl#datatype": [
-                {
-                  "@id": "http://www.w3.org/2001/XMLSchema#string"
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "(oas-x-providerName)"
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#sources": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map",
-                  "@type": [
-                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map/synthesized-field/element_1",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://www.w3.org/ns/shacl#datatype"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map/synthesized-field/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/core#name"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#lexical": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map/lexical/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(66,24)-(66,38)]"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "http://a.ml/vocabularies/data#(oas-x-serviceName)": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)",
-              "@type": [
-                "http://a.ml/vocabularies/data#Scalar",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#value": [
-                {
-                  "@value": "prediction"
-                }
-              ],
-              "http://www.w3.org/ns/shacl#datatype": [
-                {
-                  "@id": "http://www.w3.org/2001/XMLSchema#string"
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "(oas-x-serviceName)"
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#sources": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map",
-                  "@type": [
-                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_1",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://www.w3.org/ns/shacl#datatype"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/core#name"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#lexical": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map/lexical/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(67,23)-(67,33)]"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "http://a.ml/vocabularies/data#contact": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact",
-              "@type": [
-                "http://a.ml/vocabularies/data#Object",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#name": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name",
-                  "@type": [
-                    "http://a.ml/vocabularies/data#Scalar",
-                    "http://a.ml/vocabularies/data#Node",
-                    "http://a.ml/vocabularies/document#DomainElement"
-                  ],
-                  "http://a.ml/vocabularies/data#value": [
-                    {
-                      "@value": "Google"
-                    }
-                  ],
-                  "http://www.w3.org/ns/shacl#datatype": [
-                    {
-                      "@id": "http://www.w3.org/2001/XMLSchema#string"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/core#name": [
-                    {
-                      "@value": "name"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#sources": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map",
-                      "@type": [
-                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map/synthesized-field/element_1",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://www.w3.org/ns/shacl#datatype"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        },
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map/synthesized-field/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://a.ml/vocabularies/core#name"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#lexical": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map/lexical/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "[(69,10)-(69,16)]"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/data#url": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url",
-                  "@type": [
-                    "http://a.ml/vocabularies/data#Scalar",
-                    "http://a.ml/vocabularies/data#Node",
-                    "http://a.ml/vocabularies/document#DomainElement"
-                  ],
-                  "http://a.ml/vocabularies/data#value": [
-                    {
-                      "@value": "https://google.com"
-                    }
-                  ],
-                  "http://www.w3.org/ns/shacl#datatype": [
-                    {
-                      "@id": "http://www.w3.org/2001/XMLSchema#string"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/core#name": [
-                    {
-                      "@value": "url"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#sources": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map",
-                      "@type": [
-                        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map/synthesized-field/element_1",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://www.w3.org/ns/shacl#datatype"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        },
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map/synthesized-field/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "http://a.ml/vocabularies/core#name"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "true"
-                            }
-                          ]
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#lexical": [
-                        {
-                          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map/lexical/element_0",
-                          "http://a.ml/vocabularies/document-source-maps#element": [
-                            {
-                              "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url"
-                            }
-                          ],
-                          "http://a.ml/vocabularies/document-source-maps#value": [
-                            {
-                              "@value": "[(70,9)-(70,29)]"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "contact"
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#sources": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map",
-                  "@type": [
-                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/synthesized-field/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/core#name"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#lexical": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/lexical/element_2",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/data#name"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(69,4)-(70,0)]"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/lexical/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/data#url"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(70,4)-(71,0)]"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/lexical/element_1",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(69,0)-(71,0)]"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "http://a.ml/vocabularies/core#name": [
-            {
-              "@value": "object_1"
-            }
-          ],
-          "http://a.ml/vocabularies/document-source-maps#sources": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map",
-              "@type": [
-                "http://a.ml/vocabularies/document-source-maps#SourceMap"
-              ],
-              "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/synthesized-field/element_0",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/core#name"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "true"
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#lexical": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_7",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/data#(oas-x-serviceName)"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(67,2)-(68,0)]"
-                    }
-                  ]
-                },
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_5",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/data#(oas-x-logo)"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(59,2)-(61,0)]"
-                    }
-                  ]
-                },
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_3",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/data#(oas-x-apiClientRegistration)"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(57,2)-(59,0)]"
-                    }
-                  ]
-                },
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_1",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/data#(oas-x-providerName)"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(66,2)-(67,0)]"
-                    }
-                  ]
-                },
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_0",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/data#contact"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(68,2)-(71,0)]"
-                    }
-                  ]
-                },
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_2",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/data#(oas-x-origin)"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(61,2)-(65,0)]"
-                    }
-                  ]
-                },
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_4",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(57,0)-(71,0)]"
-                    }
-                  ]
-                },
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_6",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/data#(oas-x-preferred)"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(65,2)-(66,0)]"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-externalDocs": {
-          "http://a.ml/vocabularies/core#extensionName": [
-            {
-              "@value": "oas-externalDocs"
-            }
-          ],
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1",
-          "@type": [
-            "http://a.ml/vocabularies/data#Object",
-            "http://a.ml/vocabularies/data#Node",
-            "http://a.ml/vocabularies/document#DomainElement"
-          ],
-          "http://a.ml/vocabularies/data#url": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url",
-              "@type": [
-                "http://a.ml/vocabularies/data#Scalar",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#value": [
-                {
-                  "@value": "https://developers.google.com/prediction/docs/developer-guide"
-                }
-              ],
-              "http://www.w3.org/ns/shacl#datatype": [
-                {
-                  "@id": "http://www.w3.org/2001/XMLSchema#string"
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "url"
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#sources": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map",
-                  "@type": [
-                    "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map/synthesized-field/element_1",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://www.w3.org/ns/shacl#datatype"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    },
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map/synthesized-field/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "http://a.ml/vocabularies/core#name"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "true"
-                        }
-                      ]
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#lexical": [
-                    {
-                      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map/lexical/element_0",
-                      "http://a.ml/vocabularies/document-source-maps#element": [
-                        {
-                          "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url"
-                        }
-                      ],
-                      "http://a.ml/vocabularies/document-source-maps#value": [
-                        {
-                          "@value": "[(72,7)-(72,70)]"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "http://a.ml/vocabularies/core#name": [
-            {
-              "@value": "object_1"
-            }
-          ],
-          "http://a.ml/vocabularies/document-source-maps#sources": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map",
-              "@type": [
-                "http://a.ml/vocabularies/document-source-maps#SourceMap"
-              ],
-              "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map/synthesized-field/element_0",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/core#name"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "true"
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#lexical": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map/lexical/element_1",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(72,0)-(73,0)]"
-                    }
-                  ]
-                },
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map/lexical/element_0",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/data#url"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(72,2)-(73,0)]"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
         "http://a.ml/vocabularies/document#customDomainProperties": [
           {
-            "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags-definition"
+            "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-externalDocs"
           },
           {
             "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-info"
           },
           {
-            "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-externalDocs"
+            "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags-definition"
           }
         ],
         "http://a.ml/vocabularies/document-source-maps#sources": [

--- a/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.flattened.jsonld
@@ -48,24 +48,24 @@
           "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict"
         }
       ],
-      "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags-definition": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1"
+      "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-externalDocs": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1"
       },
       "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-info": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1"
       },
-      "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-externalDocs": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1"
+      "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags-definition": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags-definition"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-externalDocs"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-info"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-externalDocs"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags-definition"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -198,8 +198,62 @@
       ]
     },
     {
+      "http://a.ml/vocabularies/core#extensionName": "oas-externalDocs",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#url": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map"
+        }
+      ]
+    },
+    {
+      "http://a.ml/vocabularies/core#extensionName": "oas-info",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#(oas-x-apiClientRegistration)": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)"
+      },
+      "http://a.ml/vocabularies/data#(oas-x-logo)": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)"
+      },
+      "http://a.ml/vocabularies/data#(oas-x-origin)": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)"
+      },
+      "http://a.ml/vocabularies/data#(oas-x-preferred)": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)"
+      },
+      "http://a.ml/vocabularies/data#(oas-x-providerName)": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)"
+      },
+      "http://a.ml/vocabularies/data#(oas-x-serviceName)": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)"
+      },
+      "http://a.ml/vocabularies/data#contact": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map"
+        }
+      ]
+    },
+    {
       "http://a.ml/vocabularies/core#extensionName": "oas-tags-definition",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1",
       "@type": [
         "http://a.ml/vocabularies/data#Array",
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -208,70 +262,16 @@
       ],
       "http://www.w3.org/2000/01/rdf-schema#member": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4"
         }
       ],
       "http://a.ml/vocabularies/core#name": "array_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/source-map"
-        }
-      ]
-    },
-    {
-      "http://a.ml/vocabularies/core#extensionName": "oas-info",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1",
-      "@type": [
-        "http://a.ml/vocabularies/data#Object",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#(oas-x-apiClientRegistration)": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)"
-      },
-      "http://a.ml/vocabularies/data#(oas-x-logo)": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)"
-      },
-      "http://a.ml/vocabularies/data#(oas-x-origin)": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)"
-      },
-      "http://a.ml/vocabularies/data#(oas-x-preferred)": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)"
-      },
-      "http://a.ml/vocabularies/data#(oas-x-providerName)": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)"
-      },
-      "http://a.ml/vocabularies/data#(oas-x-serviceName)": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)"
-      },
-      "http://a.ml/vocabularies/data#contact": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact"
-      },
-      "http://a.ml/vocabularies/core#name": "object_1",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map"
-        }
-      ]
-    },
-    {
-      "http://a.ml/vocabularies/core#extensionName": "oas-externalDocs",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1",
-      "@type": [
-        "http://a.ml/vocabularies/data#Object",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#url": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url"
-      },
-      "http://a.ml/vocabularies/core#name": "object_1",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/source-map"
         }
       ]
     },
@@ -342,7 +342,7 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -397,7 +397,7 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -435,7 +435,7 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -473,7 +473,7 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -624,7 +624,7 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-tags": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -660,226 +660,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2",
-      "@type": [
-        "http://a.ml/vocabularies/data#Object",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#name": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4"
-      },
-      "http://a.ml/vocabularies/core#name": "object_2",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4",
-      "@type": [
-        "http://a.ml/vocabularies/data#Object",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#name": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5"
-      },
-      "http://a.ml/vocabularies/core#name": "object_4",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)",
-      "@type": [
-        "http://a.ml/vocabularies/data#Object",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#url": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url"
-      },
-      "http://a.ml/vocabularies/core#name": "(oas-x-apiClientRegistration)",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)",
-      "@type": [
-        "http://a.ml/vocabularies/data#Object",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#url": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url"
-      },
-      "http://a.ml/vocabularies/core#name": "(oas-x-logo)",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)",
-      "@type": [
-        "http://a.ml/vocabularies/data#Object",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#format": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format"
-      },
-      "http://a.ml/vocabularies/data#url": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url"
-      },
-      "http://a.ml/vocabularies/data#version": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version"
-      },
-      "http://a.ml/vocabularies/core#name": "(oas-x-origin)",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)",
-      "@type": [
-        "http://a.ml/vocabularies/data#Scalar",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#value": "false",
-      "http://www.w3.org/ns/shacl#datatype": [
-        {
-          "@id": "http://www.w3.org/2001/XMLSchema#boolean"
-        }
-      ],
-      "http://a.ml/vocabularies/core#name": "(oas-x-preferred)",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)",
-      "@type": [
-        "http://a.ml/vocabularies/data#Scalar",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#value": "googleapis.com",
-      "http://www.w3.org/ns/shacl#datatype": [
-        {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
-        }
-      ],
-      "http://a.ml/vocabularies/core#name": "(oas-x-providerName)",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)",
-      "@type": [
-        "http://a.ml/vocabularies/data#Scalar",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#value": "prediction",
-      "http://www.w3.org/ns/shacl#datatype": [
-        {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
-        }
-      ],
-      "http://a.ml/vocabularies/core#name": "(oas-x-serviceName)",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact",
-      "@type": [
-        "http://a.ml/vocabularies/data#Object",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#name": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name"
-      },
-      "http://a.ml/vocabularies/data#url": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url"
-      },
-      "http://a.ml/vocabularies/core#name": "contact",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/synthesized-field/element_0"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_7"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_5"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_1"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_0"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_2"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_4"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_6"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -894,26 +675,245 @@
       "http://a.ml/vocabularies/core#name": "url",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map/lexical/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#url": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url"
+      },
+      "http://a.ml/vocabularies/core#name": "(oas-x-apiClientRegistration)",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#url": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url"
+      },
+      "http://a.ml/vocabularies/core#name": "(oas-x-logo)",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#format": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format"
+      },
+      "http://a.ml/vocabularies/data#url": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url"
+      },
+      "http://a.ml/vocabularies/data#version": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version"
+      },
+      "http://a.ml/vocabularies/core#name": "(oas-x-origin)",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "false",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "(oas-x-preferred)",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "googleapis.com",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "(oas-x-providerName)",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "prediction",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "(oas-x-serviceName)",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name"
+      },
+      "http://a.ml/vocabularies/data#url": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url"
+      },
+      "http://a.ml/vocabularies/core#name": "contact",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_7"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_5"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_4"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_6"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2"
+      },
+      "http://a.ml/vocabularies/core#name": "object_2",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#name": {
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3"
+      },
+      "http://a.ml/vocabularies/core#name": "object_4",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -1041,7 +1041,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "oas-tags",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1",
       "@type": [
         "http://a.ml/vocabularies/data#Array",
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -1050,13 +1050,13 @@
       ],
       "http://www.w3.org/2000/01/rdf-schema#member": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2"
         }
       ],
       "http://a.ml/vocabularies/core#name": "array_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map"
         }
       ]
     },
@@ -1181,7 +1181,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "oas-tags",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1",
       "@type": [
         "http://a.ml/vocabularies/data#Array",
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -1190,13 +1190,13 @@
       ],
       "http://www.w3.org/2000/01/rdf-schema#member": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2"
         }
       ],
       "http://a.ml/vocabularies/core#name": "array_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/source-map"
         }
       ]
     },
@@ -1296,7 +1296,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "oas-tags",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1",
       "@type": [
         "http://a.ml/vocabularies/data#Array",
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -1305,13 +1305,13 @@
       ],
       "http://www.w3.org/2000/01/rdf-schema#member": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2"
         }
       ],
       "http://a.ml/vocabularies/core#name": "array_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/source-map"
         }
       ]
     },
@@ -1406,7 +1406,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "oas-tags",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1",
       "@type": [
         "http://a.ml/vocabularies/data#Array",
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -1415,13 +1415,13 @@
       ],
       "http://www.w3.org/2000/01/rdf-schema#member": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2"
         }
       ],
       "http://a.ml/vocabularies/core#name": "array_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/source-map"
         }
       ]
     },
@@ -1710,7 +1710,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "oas-tags",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1",
       "@type": [
         "http://a.ml/vocabularies/data#Array",
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -1719,13 +1719,13 @@
       ],
       "http://www.w3.org/2000/01/rdf-schema#member": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2"
         }
       ],
       "http://a.ml/vocabularies/core#name": "array_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map"
         }
       ]
     },
@@ -1770,90 +1770,41 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(212,4)-(241,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4",
-      "@type": [
-        "http://a.ml/vocabularies/data#Scalar",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#value": "hostedmodels",
-      "http://www.w3.org/ns/shacl#datatype": [
-        {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
-        }
-      ],
-      "http://a.ml/vocabularies/core#name": "name",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map/synthesized-field/element_1"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map/lexical/element_1"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5",
-      "@type": [
-        "http://a.ml/vocabularies/data#Scalar",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#value": "training",
-      "http://www.w3.org/ns/shacl#datatype": [
-        {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
-        }
-      ],
-      "http://a.ml/vocabularies/core#name": "name",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map"
-        }
-      ]
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map/synthesized-field/element_0"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map/lexical/element_1"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map/lexical/element_0"
-        }
-      ]
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(72,0)-(73,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(8,22)-(11,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#url",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(72,2)-(73,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1868,31 +1819,31 @@
       "http://a.ml/vocabularies/core#name": "url",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1907,31 +1858,31 @@
       "http://a.ml/vocabularies/core#name": "url",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map/lexical/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1946,12 +1897,12 @@
       "http://a.ml/vocabularies/core#name": "format",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1966,12 +1917,12 @@
       "http://a.ml/vocabularies/core#name": "url",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1986,94 +1937,94 @@
       "http://a.ml/vocabularies/core#name": "version",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_3"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_3"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_2"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2088,12 +2039,12 @@
       "http://a.ml/vocabularies/core#name": "name",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2108,110 +2059,159 @@
       "http://a.ml/vocabularies/core#name": "url",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/lexical/element_2"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_7",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_7",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#(oas-x-serviceName)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,2)-(68,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_5",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_5",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#(oas-x-logo)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(59,2)-(61,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#(oas-x-apiClientRegistration)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(57,2)-(59,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#(oas-x-providerName)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(66,2)-(67,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#contact",
       "http://a.ml/vocabularies/document-source-maps#value": "[(68,2)-(71,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#(oas-x-origin)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,2)-(65,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_4",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(57,0)-(71,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_6",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/source-map/lexical/element_6",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#(oas-x-preferred)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(65,2)-(66,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "hostedmodels",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map/synthesized-field/element_1"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map/synthesized-field/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "training",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "name",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map"
+        }
+      ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(72,0)-(73,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map/lexical/element_0"
+        }
+      ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#url",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(72,2)-(73,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(8,22)-(11,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/parameter/parameter/query/data",
@@ -2467,7 +2467,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2482,18 +2482,18 @@
       "http://a.ml/vocabularies/core#name": "scalar_2",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -2768,7 +2768,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2783,18 +2783,18 @@
       "http://a.ml/vocabularies/core#name": "scalar_2",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -3022,7 +3022,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -3037,18 +3037,18 @@
       "http://a.ml/vocabularies/core#name": "scalar_2",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -3257,7 +3257,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -3272,18 +3272,18 @@
       "http://a.ml/vocabularies/core#name": "scalar_2",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -3827,7 +3827,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -3842,18 +3842,18 @@
       "http://a.ml/vocabularies/core#name": "scalar_2",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -3878,340 +3878,340 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(214,6)-(233,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map/synthesized-field/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-externalDocs/object_1/url",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(72,7)-(72,70)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(9,4)-(10,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(9,4)-(10,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map/synthesized-field/element_1"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map/synthesized-field/element_0"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map/synthesized-field/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(10,4)-(11,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(10,4)-(11,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_1"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_0"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map/synthesized-field/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(58,0)-(59,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(58,4)-(59,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,0)-(61,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/source-map/lexical/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,4)-(61,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(63,4)-(64,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#format",
       "http://a.ml/vocabularies/document-source-maps#value": "[(62,4)-(63,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(64,4)-(65,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(62,0)-(65,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-preferred)",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-preferred)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(65,21)-(65,26)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-providerName)",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-providerName)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(66,24)-(66,38)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-serviceName)",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-serviceName)",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,23)-(67,33)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(69,4)-(70,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/lexical/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(70,4)-(71,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact",
       "http://a.ml/vocabularies/document-source-maps#value": "[(69,0)-(71,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map/synthesized-field/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map/synthesized-field/element_1"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map/lexical/element_0"
+        }
+      ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_2/object_1/url",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(72,7)-(72,70)]"
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(9,4)-(10,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(9,4)-(10,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map/synthesized-field/element_1"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(10,4)-(11,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(10,4)-(11,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/parameter/parameter/query/data/scalar/schema",
@@ -4605,7 +4605,7 @@
       ],
       "http://www.w3.org/ns/shacl#name": "Training",
       "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-body-name": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -4755,27 +4755,27 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(195,8)-(198,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(198,15)-(200,0)]"
     },
     {
@@ -5164,7 +5164,7 @@
       ],
       "http://www.w3.org/ns/shacl#name": "Update",
       "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-body-name": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -5257,27 +5257,27 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(137,10)-(140,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(140,17)-(142,0)]"
     },
     {
@@ -5663,27 +5663,27 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(160,10)-(163,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(163,17)-(165,0)]"
     },
     {
@@ -6053,27 +6053,27 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(172,10)-(175,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(175,17)-(177,0)]"
     },
     {
@@ -6462,7 +6462,7 @@
       ],
       "http://www.w3.org/ns/shacl#name": "Input",
       "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-body-name": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -6968,7 +6968,7 @@
       ],
       "http://www.w3.org/ns/shacl#name": "Input",
       "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/declares/oas-body-name": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -7061,163 +7061,163 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(228,12)-(231,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(231,19)-(233,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_2/name_4",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(9,10)-(9,22)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map/synthesized-field/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map/synthesized-field/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension/array_1/member/object_4/name_5",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(10,10)-(10,18)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map/synthesized-field/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-apiClientRegistration)/url",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-apiClientRegistration)/url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(58,9)-(58,48)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-logo)/url",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-logo)/url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,9)-(60,109)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/format",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/format",
       "http://a.ml/vocabularies/document-source-maps#value": "[(62,12)-(62,18)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/url",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(63,9)-(63,76)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/(oas-x-origin)/version",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/(oas-x-origin)/version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(64,13)-(64,15)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/name",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(69,10)-(69,16)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/extension_1/object_1/contact/url",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-info/object_1/contact/url",
       "http://a.ml/vocabularies/document-source-maps#value": "[(70,9)-(70,29)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map/synthesized-field/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_2/name_2",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(9,10)-(9,22)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map/synthesized-field/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/customDomainProperties/oas-tags-definition/array_1/member/object_4/name_3",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(10,10)-(10,18)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/parameter/parameter/query/data/scalar/schema/source-map",
@@ -7739,7 +7739,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "oas-body-name",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -7754,7 +7754,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map"
         }
       ]
     },
@@ -7898,18 +7898,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(195,8)-(198,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2",
       "http://a.ml/vocabularies/document-source-maps#value": "[(199,8)-(199,16)]"
     },
     {
@@ -8365,7 +8365,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "oas-body-name",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -8380,7 +8380,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map"
         }
       ]
     },
@@ -8454,18 +8454,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(137,10)-(140,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/extension/array_1/member/scalar_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/customDomainProperties/oas-tags/array_1/member/scalar_2",
       "http://a.ml/vocabularies/document-source-maps#value": "[(141,10)-(141,18)]"
     },
     {
@@ -8868,18 +8868,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(160,10)-(163,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/extension/array_1/member/scalar_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/get/customDomainProperties/oas-tags/array_1/member/scalar_2",
       "http://a.ml/vocabularies/document-source-maps#value": "[(164,10)-(164,18)]"
     },
     {
@@ -9277,18 +9277,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(172,10)-(175,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/extension/array_1/member/scalar_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/delete/customDomainProperties/oas-tags/array_1/member/scalar_2",
       "http://a.ml/vocabularies/document-source-maps#value": "[(176,10)-(176,18)]"
     },
     {
@@ -9725,7 +9725,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "oas-body-name",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -9740,7 +9740,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map"
         }
       ]
     },
@@ -10361,7 +10361,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "oas-body-name",
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -10376,7 +10376,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map"
         }
       ]
     },
@@ -10450,18 +10450,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(228,12)-(231,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/extension/array_1/member/scalar_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/customDomainProperties/oas-tags/array_1/member/scalar_2",
       "http://a.ml/vocabularies/document-source-maps#value": "[(232,12)-(232,24)]"
     },
     {
@@ -10934,21 +10934,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -11411,21 +11411,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -12259,21 +12259,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -12819,21 +12819,21 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(336,6)-(338,87)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -13224,18 +13224,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(289,6)-(293,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(183,25)-(183,29)]"
     },
     {
@@ -13462,18 +13462,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(320,6)-(325,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D/supportedOperation/put/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(129,27)-(129,31)]"
     },
     {
@@ -13719,18 +13719,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(244,6)-(252,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Ftraining%2F%7Bdata%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(99,29)-(99,33)]"
     },
     {
@@ -14078,18 +14078,18 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml#/web-api/endpoint/%2Fhostedmodels%2F%7BhostedModelName%7D%2Fpredict/supportedOperation/post/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/oas-body-name/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(220,29)-(220,33)]"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/unions-example.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/unions-example.raml.expanded.jsonld
@@ -579,7 +579,7 @@
                                   "@value": "clearanceLevel"
                                 }
                               ],
-                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1",
                               "@type": [
                                 "http://a.ml/vocabularies/data#Object",
                                 "http://a.ml/vocabularies/data#Node",
@@ -587,7 +587,7 @@
                               ],
                               "http://a.ml/vocabularies/data#level": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level",
                                   "@type": [
                                     "http://a.ml/vocabularies/data#Scalar",
                                     "http://a.ml/vocabularies/data#Node",
@@ -610,13 +610,13 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#sources": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map",
                                       "@type": [
                                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                         {
-                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_1",
+                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_1",
                                           "http://a.ml/vocabularies/document-source-maps#element": [
                                             {
                                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -629,7 +629,7 @@
                                           ]
                                         },
                                         {
-                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_0",
+                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_0",
                                           "http://a.ml/vocabularies/document-source-maps#element": [
                                             {
                                               "@value": "http://a.ml/vocabularies/core#name"
@@ -644,10 +644,10 @@
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                                         {
-                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map/lexical/element_0",
+                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map/lexical/element_0",
                                           "http://a.ml/vocabularies/document-source-maps#element": [
                                             {
-                                              "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level"
+                                              "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level"
                                             }
                                           ],
                                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -663,7 +663,7 @@
                               ],
                               "http://a.ml/vocabularies/data#signature": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature",
                                   "@type": [
                                     "http://a.ml/vocabularies/data#Scalar",
                                     "http://a.ml/vocabularies/data#Node",
@@ -686,13 +686,13 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#sources": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map",
                                       "@type": [
                                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                         {
-                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_1",
+                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_1",
                                           "http://a.ml/vocabularies/document-source-maps#element": [
                                             {
                                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -705,7 +705,7 @@
                                           ]
                                         },
                                         {
-                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_0",
+                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_0",
                                           "http://a.ml/vocabularies/document-source-maps#element": [
                                             {
                                               "@value": "http://a.ml/vocabularies/core#name"
@@ -720,10 +720,10 @@
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                                         {
-                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map/lexical/element_0",
+                                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map/lexical/element_0",
                                           "http://a.ml/vocabularies/document-source-maps#element": [
                                             {
-                                              "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature"
+                                              "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature"
                                             }
                                           ],
                                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -744,13 +744,13 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#sources": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map",
                                   "@type": [
                                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/synthesized-field/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/synthesized-field/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/core#name"
@@ -765,7 +765,7 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/lexical/element_2",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_2",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/data#level"
@@ -778,7 +778,7 @@
                                       ]
                                     },
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/lexical/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/data#signature"
@@ -791,10 +791,10 @@
                                       ]
                                     },
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/lexical/element_1",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_1",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
-                                          "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1"
+                                          "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1"
                                         }
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -910,7 +910,7 @@
                               "@value": "clearanceLevel"
                             }
                           ],
-                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1",
                           "@type": [
                             "http://a.ml/vocabularies/data#Object",
                             "http://a.ml/vocabularies/data#Node",
@@ -918,7 +918,7 @@
                           ],
                           "http://a.ml/vocabularies/data#level": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level",
                               "@type": [
                                 "http://a.ml/vocabularies/data#Scalar",
                                 "http://a.ml/vocabularies/data#Node",
@@ -941,13 +941,13 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#sources": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map",
                                   "@type": [
                                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_1",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_1",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -960,7 +960,7 @@
                                       ]
                                     },
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/core#name"
@@ -975,10 +975,10 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map/lexical/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map/lexical/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
-                                          "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level"
+                                          "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level"
                                         }
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -994,7 +994,7 @@
                           ],
                           "http://a.ml/vocabularies/data#signature": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature",
                               "@type": [
                                 "http://a.ml/vocabularies/data#Scalar",
                                 "http://a.ml/vocabularies/data#Node",
@@ -1017,13 +1017,13 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#sources": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map",
                                   "@type": [
                                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_1",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_1",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1036,7 +1036,7 @@
                                       ]
                                     },
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/core#name"
@@ -1051,10 +1051,10 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map/lexical/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map/lexical/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
-                                          "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature"
+                                          "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature"
                                         }
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1075,13 +1075,13 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#sources": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map",
                               "@type": [
                                 "http://a.ml/vocabularies/document-source-maps#SourceMap"
                               ],
                               "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/synthesized-field/element_0",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/synthesized-field/element_0",
                                   "http://a.ml/vocabularies/document-source-maps#element": [
                                     {
                                       "@value": "http://a.ml/vocabularies/core#name"
@@ -1096,7 +1096,7 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#lexical": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/lexical/element_2",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_2",
                                   "http://a.ml/vocabularies/document-source-maps#element": [
                                     {
                                       "@value": "http://a.ml/vocabularies/data#level"
@@ -1109,7 +1109,7 @@
                                   ]
                                 },
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/lexical/element_0",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_0",
                                   "http://a.ml/vocabularies/document-source-maps#element": [
                                     {
                                       "@value": "http://a.ml/vocabularies/data#signature"
@@ -1122,10 +1122,10 @@
                                   ]
                                 },
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/lexical/element_1",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_1",
                                   "http://a.ml/vocabularies/document-source-maps#element": [
                                     {
-                                      "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1"
+                                      "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1"
                                     }
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2244,7 +2244,7 @@
                                   "@value": "deprecated"
                                 }
                               ],
-                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1",
                               "@type": [
                                 "http://a.ml/vocabularies/data#Scalar",
                                 "http://a.ml/vocabularies/data#Node",
@@ -2267,13 +2267,13 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#sources": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map",
                                   "@type": [
                                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_1",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -2286,7 +2286,7 @@
                                       ]
                                     },
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/core#name"
@@ -2301,10 +2301,10 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map/lexical/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
-                                          "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1"
+                                          "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1"
                                         }
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2394,7 +2394,7 @@
                               "@value": "deprecated"
                             }
                           ],
-                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1",
                           "@type": [
                             "http://a.ml/vocabularies/data#Scalar",
                             "http://a.ml/vocabularies/data#Node",
@@ -2417,13 +2417,13 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#sources": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map",
+                              "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map",
                               "@type": [
                                 "http://a.ml/vocabularies/document-source-maps#SourceMap"
                               ],
                               "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_1",
                                   "http://a.ml/vocabularies/document-source-maps#element": [
                                     {
                                       "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -2436,7 +2436,7 @@
                                   ]
                                 },
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_0",
                                   "http://a.ml/vocabularies/document-source-maps#element": [
                                     {
                                       "@value": "http://a.ml/vocabularies/core#name"
@@ -2451,10 +2451,10 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#lexical": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                                  "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map/lexical/element_0",
                                   "http://a.ml/vocabularies/document-source-maps#element": [
                                     {
-                                      "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1"
+                                      "@value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1"
                                     }
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#value": [

--- a/amf-cli/shared/src/test/resources/production/unions-example.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/unions-example.raml.flattened.jsonld
@@ -289,7 +289,7 @@
         "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema"
       },
       "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/declares/clearanceLevel": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -374,7 +374,7 @@
         "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema"
       },
       "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/declares/deprecated": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -604,7 +604,7 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/declares/clearanceLevel": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -619,22 +619,22 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "clearanceLevel",
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#level": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level"
+        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level"
       },
       "http://a.ml/vocabularies/data#signature": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature"
+        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map"
         }
       ]
     },
@@ -819,7 +819,7 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/declares/deprecated": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -834,7 +834,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "deprecated",
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -849,7 +849,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map"
         }
       ]
     },
@@ -1242,22 +1242,22 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "clearanceLevel",
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#level": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level"
+        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level"
       },
       "http://a.ml/vocabularies/data#signature": {
-        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature"
+        "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map"
         }
       ]
     },
@@ -1290,7 +1290,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1305,12 +1305,12 @@
       "http://a.ml/vocabularies/core#name": "level",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1325,29 +1325,29 @@
       "http://a.ml/vocabularies/core#name": "signature",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_2"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_1"
         }
       ]
     },
@@ -1583,7 +1583,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "deprecated",
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1598,7 +1598,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map"
         }
       ]
     },
@@ -1625,21 +1625,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -2088,7 +2088,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2103,12 +2103,12 @@
       "http://a.ml/vocabularies/core#name": "level",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -2123,29 +2123,29 @@
       "http://a.ml/vocabularies/core#name": "signature",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_2"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_1"
         }
       ]
     },
@@ -2180,61 +2180,61 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(68,8)-(69,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#level",
       "http://a.ml/vocabularies/document-source-maps#value": "[(66,10)-(67,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/lexical/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#signature",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,10)-(68,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(66,0)-(68,0)]"
     },
     {
@@ -2422,21 +2422,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -2461,18 +2461,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,6)-(64,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/customDomainProperties/deprecated/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,21)-(61,21)]"
     },
     {
@@ -2906,91 +2906,91 @@
       "http://a.ml/vocabularies/document-source-maps#value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#level",
       "http://a.ml/vocabularies/document-source-maps#value": "[(66,10)-(67,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/lexical/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#signature",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,10)-(68,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(66,0)-(68,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/level",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/level",
       "http://a.ml/vocabularies/document-source-maps#value": "[(66,17)-(66,21)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/extension/object_1/signature",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/customDomainProperties/clearanceLevel/object_1/signature",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,21)-(67,37)]"
     },
     {
@@ -3097,18 +3097,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/basic/scalar/schema/customDomainProperties/deprecated/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(61,21)-(61,21)]"
     },
     {
@@ -3334,33 +3334,33 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(70,17)-(70,40)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/level",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/level",
       "http://a.ml/vocabularies/document-source-maps#value": "[(66,17)-(66,21)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/extension/object_1/signature",
+      "@id": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/unions-example.raml#/web-api/endpoint/%2Fendpoint%2F%7BfileType%7D%2F%7BfileId%7D/supportedOperation/get/expects/request/parameter/parameter/query/optional/scalar/schema/customDomainProperties/clearanceLevel/object_1/signature",
       "http://a.ml/vocabularies/document-source-maps#value": "[(67,21)-(67,37)]"
     },
     {

--- a/amf-cli/shared/src/test/resources/semantic/api-nested-object.async.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/api-nested-object.async.yaml
@@ -1,0 +1,15 @@
+asyncapi: "2.0.0"
+info:
+  title: Something
+  version: 1.0.1
+
+channels:
+  /endpoint:
+    subscribe:
+      operationId: subs
+      message:
+        name: lightMeasured
+        x-tag:
+          name: SomeTag
+          type:
+            value: SomeTagType

--- a/amf-cli/shared/src/test/resources/semantic/api-nested-object.oas20.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/api-nested-object.oas20.yaml
@@ -1,0 +1,14 @@
+swagger: "2.0"
+info:
+  title: Something
+  version: '1.0'
+paths:
+  /endpoint:
+    get:
+      responses:
+        200:
+          description: Something
+          x-tag:
+            name: SomeTag
+            type:
+              value: SomeTagType

--- a/amf-cli/shared/src/test/resources/semantic/api-nested-object.oas30.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/api-nested-object.oas30.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  title: Something
+  version: '1.0'
+paths:
+  /endpoint:
+    get:
+      responses:
+        "200":
+          description: Something
+          x-tag:
+            name: SomeTag
+            type:
+              value: SomeTagType

--- a/amf-cli/shared/src/test/resources/semantic/api-nested-object.raml
+++ b/amf-cli/shared/src/test/resources/semantic/api-nested-object.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+title: Something
+/sample:
+  get:
+    responses:
+      200:
+        (tag):
+          name: SomeTag
+          type:
+            value: SomeTagType
+        description: A Response

--- a/amf-cli/shared/src/test/resources/semantic/instance-nested-object.raml.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance-nested-object.raml.jsonld
@@ -7,7 +7,7 @@
       ],
       "apiContract:modelVersion": "3.2.0",
       "doc:transformed": true,
-      "doc:sourceSpec": "OAS 2.0"
+      "doc:sourceSpec": "RAML 1.0"
     },
     {
       "@id": "/web-api",
@@ -18,28 +18,27 @@
         "doc:DomainElement"
       ],
       "core:name": "Something",
-      "core:version": "1.0",
       "apiContract:endpoint": [
         {
-          "@id": "#/web-api/endpoint/%2Fendpoint"
+          "@id": "#/web-api/endpoint/%2Fsample"
         }
       ]
     },
     {
-      "@id": "#/web-api/endpoint/%2Fendpoint",
+      "@id": "#/web-api/endpoint/%2Fsample",
       "@type": [
         "apiContract:EndPoint",
         "doc:DomainElement"
       ],
-      "apiContract:path": "/endpoint",
+      "apiContract:path": "/sample",
       "apiContract:supportedOperation": [
         {
-          "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get"
+          "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get"
         }
       ]
     },
     {
-      "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get",
+      "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get",
       "@type": [
         "apiContract:Operation",
         "doc:DomainElement"
@@ -47,12 +46,12 @@
       "apiContract:method": "get",
       "apiContract:returns": [
         {
-          "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200"
+          "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200"
         }
       ]
     },
     {
-      "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200",
+      "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200",
       "@type": [
         "apiContract:Response",
         "apiContract:Message",
@@ -60,20 +59,33 @@
       ],
       "apiContract:statusCode": "200",
       "core:name": "200",
-      "core:description": "Something",
-      "http://a.ml/vocab#pagination": {
-        "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/element"
+      "core:description": "A Response",
+      "http://a.ml/vocab#tag": {
+        "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/tag/element"
       }
     },
     {
-      "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/element",
+      "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/tag/element",
       "@type": [
-        "http://a.ml/vocab#Pagination",
-        "file://amf-cli/shared/src/test/resources/semantic/dialect.yaml#/declarations/Pagination",
+        "http://a.ml/vocab#Tag",
+        "file://amf-cli/shared/src/test/resources/semantic/nested-object-dialect.yaml#/declarations/Tag",
         "meta:DialectDomainElement",
         "doc:DomainElement"
       ],
-      "http://a.ml/vocab#PageSize": 5
+      "http://a.ml/vocab#Type": {
+        "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/tag/element/element"
+      },
+      "http://a.ml/vocab#Tag": "SomeTag"
+    },
+    {
+      "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/tag/element/element",
+      "@type": [
+        "http://a.ml/vocab#TagType",
+        "file://amf-cli/shared/src/test/resources/semantic/nested-object-dialect.yaml#/declarations/TagType",
+        "meta:DialectDomainElement",
+        "doc:DomainElement"
+      ],
+      "http://a.ml/vocab#TagTypeValue": "SomeTagType"
     },
     {
       "@id": "",
@@ -93,7 +105,7 @@
     }
   ],
   "@context": {
-    "@base": "file://amf-cli/shared/src/test/resources/semantic/api.oas20.yaml",
+    "@base": "file://amf-cli/shared/src/test/resources/semantic/api-nested-object.raml",
     "doc": "http://a.ml/vocabularies/document#",
     "apiContract": "http://a.ml/vocabularies/apiContract#",
     "core": "http://a.ml/vocabularies/core#",

--- a/amf-cli/shared/src/test/resources/semantic/instance.async.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.async.jsonld
@@ -61,11 +61,11 @@
       ],
       "core:displayName": "lightMeasured",
       "http://a.ml/vocab#pagination": {
-        "@id": "#/async-api/endpoint/%2Fendpoint/supportedOperation/subscribe/subs/returns/resp/default-response/customDomainProperties/pagination/"
+        "@id": "#/async-api/endpoint/%2Fendpoint/supportedOperation/subscribe/subs/returns/resp/default-response/customDomainProperties/pagination/element"
       }
     },
     {
-      "@id": "#/async-api/endpoint/%2Fendpoint/supportedOperation/subscribe/subs/returns/resp/default-response/customDomainProperties/pagination/",
+      "@id": "#/async-api/endpoint/%2Fendpoint/supportedOperation/subscribe/subs/returns/resp/default-response/customDomainProperties/pagination/element",
       "@type": [
         "http://a.ml/vocab#Pagination",
         "file://amf-cli/shared/src/test/resources/semantic/dialect.yaml#/declarations/Pagination",

--- a/amf-cli/shared/src/test/resources/semantic/instance.async.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.async.jsonld
@@ -61,11 +61,11 @@
       ],
       "core:displayName": "lightMeasured",
       "http://a.ml/vocab#pagination": {
-        "@id": "#/async-api/endpoint/%2Fendpoint/supportedOperation/subscribe/subs/returns/resp/default-response/customDomainProperties/extension/"
+        "@id": "#/async-api/endpoint/%2Fendpoint/supportedOperation/subscribe/subs/returns/resp/default-response/customDomainProperties/pagination/"
       }
     },
     {
-      "@id": "#/async-api/endpoint/%2Fendpoint/supportedOperation/subscribe/subs/returns/resp/default-response/customDomainProperties/extension/",
+      "@id": "#/async-api/endpoint/%2Fendpoint/supportedOperation/subscribe/subs/returns/resp/default-response/customDomainProperties/pagination/",
       "@type": [
         "http://a.ml/vocab#Pagination",
         "file://amf-cli/shared/src/test/resources/semantic/dialect.yaml#/declarations/Pagination",

--- a/amf-cli/shared/src/test/resources/semantic/instance.oas20.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.oas20.jsonld
@@ -62,11 +62,11 @@
       "core:name": "200",
       "core:description": "Something",
       "http://a.ml/vocab#pagination": {
-        "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/extension/"
+        "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/"
       }
     },
     {
-      "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/extension/",
+      "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/",
       "@type": [
         "http://a.ml/vocab#Pagination",
         "file://amf-cli/shared/src/test/resources/semantic/dialect.yaml#/declarations/Pagination",

--- a/amf-cli/shared/src/test/resources/semantic/instance.oas30.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.oas30.jsonld
@@ -62,11 +62,11 @@
       "core:name": "200",
       "core:description": "Something",
       "http://a.ml/vocab#pagination": {
-        "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/"
+        "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/element"
       }
     },
     {
-      "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/",
+      "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/element",
       "@type": [
         "http://a.ml/vocab#Pagination",
         "file://amf-cli/shared/src/test/resources/semantic/dialect.yaml#/declarations/Pagination",

--- a/amf-cli/shared/src/test/resources/semantic/instance.oas30.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.oas30.jsonld
@@ -62,11 +62,11 @@
       "core:name": "200",
       "core:description": "Something",
       "http://a.ml/vocab#pagination": {
-        "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/extension/"
+        "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/"
       }
     },
     {
-      "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/extension/",
+      "@id": "#/web-api/endpoint/%2Fendpoint/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/",
       "@type": [
         "http://a.ml/vocab#Pagination",
         "file://amf-cli/shared/src/test/resources/semantic/dialect.yaml#/declarations/Pagination",

--- a/amf-cli/shared/src/test/resources/semantic/instance.raml.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.raml.jsonld
@@ -61,11 +61,11 @@
       "core:name": "200",
       "core:description": "A Response",
       "http://a.ml/vocab#pagination": {
-        "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/"
+        "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/element"
       }
     },
     {
-      "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/",
+      "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/element",
       "@type": [
         "http://a.ml/vocab#Pagination",
         "file://amf-cli/shared/src/test/resources/semantic/dialect.yaml#/declarations/Pagination",

--- a/amf-cli/shared/src/test/resources/semantic/instance.raml.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.raml.jsonld
@@ -61,11 +61,11 @@
       "core:name": "200",
       "core:description": "A Response",
       "http://a.ml/vocab#pagination": {
-        "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/extension/"
+        "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/"
       }
     },
     {
-      "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/extension/",
+      "@id": "#/web-api/endpoint/%2Fsample/supportedOperation/get/returns/resp/200/customDomainProperties/pagination/",
       "@type": [
         "http://a.ml/vocab#Pagination",
         "file://amf-cli/shared/src/test/resources/semantic/dialect.yaml#/declarations/Pagination",

--- a/amf-cli/shared/src/test/resources/semantic/nested-object-dialect.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/nested-object-dialect.yaml
@@ -1,0 +1,39 @@
+#%Dialect 1.0
+dialect: Pagination Test
+version: 1.0
+
+external:
+  apiContract: http://a.ml/vocabularies/apiContract#
+  aml: http://a.ml/vocab#
+
+documents: {}
+
+annotationMappings:
+  TagAnnotation:
+    domain: apiContract.Response
+    propertyTerm: aml.tag
+    range:  Tag
+
+nodeMappings:
+  Tag:
+    classTerm: aml.Tag
+    mapping:
+      name:
+        propertyTerm: aml.Tag
+        range: string
+        mandatory: true
+      type:
+        propertyTerm: aml.Type
+        range: TagType
+        mandatory: true
+
+  TagType:
+    classTerm: aml.TagType
+    mapping:
+      value:
+        propertyTerm: aml.TagTypeValue
+        range: string
+        mandatory: true
+
+extensions:
+  tag: TagAnnotation

--- a/amf-cli/shared/src/test/resources/upanddown/annotations.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/annotations.json.expanded.jsonld
@@ -27,92 +27,13 @@
           }
         ],
         "http://a.ml/vocabularies/apiContract#endpoint": [],
-        "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/wadus": {
-          "http://a.ml/vocabularies/core#extensionName": [
-            {
-              "@value": "wadus"
-            }
-          ],
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1",
-          "@type": [
-            "http://a.ml/vocabularies/data#Scalar",
-            "http://a.ml/vocabularies/data#Node",
-            "http://a.ml/vocabularies/document#DomainElement"
-          ],
-          "http://a.ml/vocabularies/data#value": [
-            {
-              "@value": "hello"
-            }
-          ],
-          "http://www.w3.org/ns/shacl#datatype": [
-            {
-              "@id": "http://www.w3.org/2001/XMLSchema#string"
-            }
-          ],
-          "http://a.ml/vocabularies/core#name": [
-            {
-              "@value": "scalar_1"
-            }
-          ],
-          "http://a.ml/vocabularies/document-source-maps#sources": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map",
-              "@type": [
-                "http://a.ml/vocabularies/document-source-maps#SourceMap"
-              ],
-              "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://www.w3.org/ns/shacl#datatype"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "true"
-                    }
-                  ]
-                },
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/core#name"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "true"
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#lexical": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(7,13)-(7,20)]"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/foo": {
+        "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/foo": {
           "http://a.ml/vocabularies/core#extensionName": [
             {
               "@value": "foo"
             }
           ],
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1",
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1",
           "@type": [
             "http://a.ml/vocabularies/data#Object",
             "http://a.ml/vocabularies/data#Node",
@@ -120,7 +41,7 @@
           ],
           "http://a.ml/vocabularies/data#a": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a",
               "@type": [
                 "http://a.ml/vocabularies/data#Scalar",
                 "http://a.ml/vocabularies/data#Node",
@@ -143,13 +64,13 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_1",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -162,7 +83,7 @@
                       ]
                     },
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/core#name"
@@ -177,10 +98,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -196,7 +117,7 @@
           ],
           "http://a.ml/vocabularies/data#b": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b",
               "@type": [
                 "http://a.ml/vocabularies/data#Array",
                 "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -205,7 +126,7 @@
               ],
               "http://www.w3.org/2000/01/rdf-schema#member": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -228,13 +149,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -247,7 +168,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -262,10 +183,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -279,7 +200,7 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -302,13 +223,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -321,7 +242,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -336,10 +257,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -360,16 +281,16 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -390,13 +311,13 @@
           ],
           "http://a.ml/vocabularies/document-source-maps#sources": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map",
               "@type": [
                 "http://a.ml/vocabularies/document-source-maps#SourceMap"
               ],
               "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/synthesized-field/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/synthesized-field/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/core#name"
@@ -411,7 +332,7 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#lexical": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_2",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_2",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/data#a"
@@ -424,7 +345,7 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/data#b"
@@ -437,10 +358,10 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_1",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
-                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1"
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1"
                     }
                   ],
                   "http://a.ml/vocabularies/document-source-maps#value": [
@@ -453,12 +374,91 @@
             }
           ]
         },
+        "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/wadus": {
+          "http://a.ml/vocabularies/core#extensionName": [
+            {
+              "@value": "wadus"
+            }
+          ],
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1",
+          "@type": [
+            "http://a.ml/vocabularies/data#Scalar",
+            "http://a.ml/vocabularies/data#Node",
+            "http://a.ml/vocabularies/document#DomainElement"
+          ],
+          "http://a.ml/vocabularies/data#value": [
+            {
+              "@value": "hello"
+            }
+          ],
+          "http://www.w3.org/ns/shacl#datatype": [
+            {
+              "@id": "http://www.w3.org/2001/XMLSchema#string"
+            }
+          ],
+          "http://a.ml/vocabularies/core#name": [
+            {
+              "@value": "scalar_1"
+            }
+          ],
+          "http://a.ml/vocabularies/document-source-maps#sources": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map",
+              "@type": [
+                "http://a.ml/vocabularies/document-source-maps#SourceMap"
+              ],
+              "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_1",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://www.w3.org/ns/shacl#datatype"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "true"
+                    }
+                  ]
+                },
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/core#name"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "true"
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#lexical": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map/lexical/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(7,13)-(7,20)]"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
         "http://a.ml/vocabularies/document#customDomainProperties": [
           {
-            "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/wadus"
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/foo"
           },
           {
-            "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/foo"
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/wadus"
           }
         ],
         "http://a.ml/vocabularies/document-source-maps#sources": [

--- a/amf-cli/shared/src/test/resources/upanddown/annotations.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/annotations.json.flattened.jsonld
@@ -19,18 +19,18 @@
       "http://a.ml/vocabularies/core#name": "test api",
       "http://a.ml/vocabularies/core#version": "1.0",
       "http://a.ml/vocabularies/apiContract#endpoint": [],
-      "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/wadus": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/foo": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1"
       },
-      "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/foo": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/wadus": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/wadus"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/foo"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/foo"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/wadus"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -40,8 +40,29 @@
       ]
     },
     {
+      "http://a.ml/vocabularies/core#extensionName": "foo",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#a": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a"
+      },
+      "http://a.ml/vocabularies/data#b": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map"
+        }
+      ]
+    },
+    {
       "http://a.ml/vocabularies/core#extensionName": "wadus",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -56,28 +77,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map"
-        }
-      ]
-    },
-    {
-      "http://a.ml/vocabularies/core#extensionName": "foo",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1",
-      "@type": [
-        "http://a.ml/vocabularies/data#Object",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#a": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a"
-      },
-      "http://a.ml/vocabularies/data#b": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b"
-      },
-      "http://a.ml/vocabularies/core#name": "object_1",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map"
         }
       ]
     },
@@ -102,26 +102,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -136,12 +117,12 @@
       "http://a.ml/vocabularies/core#name": "a",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b",
       "@type": [
         "http://a.ml/vocabularies/data#Array",
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -150,38 +131,57 @@
       ],
       "http://www.w3.org/2000/01/rdf-schema#member": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5"
         }
       ],
       "http://a.ml/vocabularies/core#name": "b",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_2"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_1"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -206,41 +206,26 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(1,0)-(16,1)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension/scalar_1",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(7,13)-(7,20)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -255,12 +240,12 @@
       "http://a.ml/vocabularies/core#name": "scalar_4",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -275,127 +260,142 @@
       "http://a.ml/vocabularies/core#name": "scalar_5",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#a",
       "http://a.ml/vocabularies/document-source-maps#value": "[(9,4)-(9,13)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#b",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,4)-(13,5)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,11)-(14,3)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/a",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/wadus/scalar_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(7,13)-(7,20)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/a",
       "http://a.ml/vocabularies/document-source-maps#value": "[(9,9)-(9,13)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,9)-(13,5)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4",
       "http://a.ml/vocabularies/document-source-maps#value": "[(11,6)-(11,7)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/annotations.json#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5",
       "http://a.ml/vocabularies/document-source-maps#value": "[(12,6)-(12,7)]"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml.expanded.jsonld
@@ -100,13 +100,13 @@
                 "@value": "/customers"
               }
             ],
-            "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/AnnotationInCustomer": {
+            "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/AnnotationInCustomer": {
               "http://a.ml/vocabularies/core#extensionName": [
                 {
                   "@value": "AnnotationInCustomer"
                 }
               ],
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1",
               "@type": [
                 "http://a.ml/vocabularies/data#Scalar",
                 "http://a.ml/vocabularies/data#Node",
@@ -129,13 +129,13 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map/synthesized-field/element_1",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -148,7 +148,7 @@
                       ]
                     },
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map/synthesized-field/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/core#name"
@@ -163,10 +163,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -181,7 +181,7 @@
             },
             "http://a.ml/vocabularies/document#customDomainProperties": [
               {
-                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/AnnotationInCustomer"
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/AnnotationInCustomer"
               }
             ],
             "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -396,13 +396,13 @@
                     ]
                   }
                 ],
-                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/AnnotationInGet": {
+                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/AnnotationInGet": {
                   "http://a.ml/vocabularies/core#extensionName": [
                     {
                       "@value": "AnnotationInGet"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -425,13 +425,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -444,7 +444,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -459,10 +459,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -477,7 +477,7 @@
                 },
                 "http://a.ml/vocabularies/document#customDomainProperties": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/AnnotationInGet"
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/AnnotationInGet"
                   }
                 ],
                 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -631,13 +631,13 @@
                         "@value": "schema"
                       }
                     ],
-                    "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter": {
+                    "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
                       "http://a.ml/vocabularies/core#extensionName": [
                         {
                           "@value": "AnnotationInParameter"
                         }
                       ],
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1",
                       "@type": [
                         "http://a.ml/vocabularies/data#Scalar",
                         "http://a.ml/vocabularies/data#Node",
@@ -660,13 +660,13 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#sources": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
                           "@type": [
                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                           ],
                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -679,7 +679,7 @@
                               ]
                             },
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -694,10 +694,10 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
-                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1"
+                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1"
                                 }
                               ],
                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -712,7 +712,7 @@
                     },
                     "http://a.ml/vocabularies/document#customDomainProperties": [
                       {
-                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter"
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -755,13 +755,13 @@
                     ]
                   }
                 ],
-                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter": {
+                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
                   "http://a.ml/vocabularies/core#extensionName": [
                     {
                       "@value": "AnnotationInParameter"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -784,13 +784,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -803,7 +803,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -818,10 +818,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -836,7 +836,7 @@
                 },
                 "http://a.ml/vocabularies/document#customDomainProperties": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter"
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
                   }
                 ],
                 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -1243,13 +1243,13 @@
                         "@value": "schema"
                       }
                     ],
-                    "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter": {
+                    "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
                       "http://a.ml/vocabularies/core#extensionName": [
                         {
                           "@value": "AnnotationInParameter"
                         }
                       ],
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1",
                       "@type": [
                         "http://a.ml/vocabularies/data#Scalar",
                         "http://a.ml/vocabularies/data#Node",
@@ -1272,13 +1272,13 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#sources": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
                           "@type": [
                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                           ],
                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1291,7 +1291,7 @@
                               ]
                             },
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -1306,10 +1306,10 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
-                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1"
+                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1"
                                 }
                               ],
                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1324,7 +1324,7 @@
                     },
                     "http://a.ml/vocabularies/document#customDomainProperties": [
                       {
-                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter"
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -1367,13 +1367,13 @@
                     ]
                   }
                 ],
-                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter": {
+                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
                   "http://a.ml/vocabularies/core#extensionName": [
                     {
                       "@value": "AnnotationInParameter"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -1396,13 +1396,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1415,7 +1415,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -1430,10 +1430,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1448,7 +1448,7 @@
                 },
                 "http://a.ml/vocabularies/document#customDomainProperties": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter"
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
                   }
                 ],
                 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -1640,13 +1640,13 @@
                         "@value": "schema"
                       }
                     ],
-                    "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter": {
+                    "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
                       "http://a.ml/vocabularies/core#extensionName": [
                         {
                           "@value": "AnnotationInParameter"
                         }
                       ],
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1",
                       "@type": [
                         "http://a.ml/vocabularies/data#Scalar",
                         "http://a.ml/vocabularies/data#Node",
@@ -1669,13 +1669,13 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#sources": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
                           "@type": [
                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                           ],
                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1688,7 +1688,7 @@
                               ]
                             },
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -1703,10 +1703,10 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
-                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1"
+                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1"
                                 }
                               ],
                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1721,7 +1721,7 @@
                     },
                     "http://a.ml/vocabularies/document#customDomainProperties": [
                       {
-                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter"
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -1764,13 +1764,13 @@
                     ]
                   }
                 ],
-                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter": {
+                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
                   "http://a.ml/vocabularies/core#extensionName": [
                     {
                       "@value": "AnnotationInParameter"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -1793,13 +1793,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1812,7 +1812,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -1827,10 +1827,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1845,7 +1845,7 @@
                 },
                 "http://a.ml/vocabularies/document#customDomainProperties": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter"
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
                   }
                 ],
                 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -2463,13 +2463,13 @@
                         "@value": "schema"
                       }
                     ],
-                    "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter": {
+                    "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
                       "http://a.ml/vocabularies/core#extensionName": [
                         {
                           "@value": "AnnotationInParameter"
                         }
                       ],
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1",
                       "@type": [
                         "http://a.ml/vocabularies/data#Scalar",
                         "http://a.ml/vocabularies/data#Node",
@@ -2492,13 +2492,13 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#sources": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
                           "@type": [
                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                           ],
                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -2511,7 +2511,7 @@
                               ]
                             },
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -2526,10 +2526,10 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
-                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1"
+                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1"
                                 }
                               ],
                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2544,7 +2544,7 @@
                     },
                     "http://a.ml/vocabularies/document#customDomainProperties": [
                       {
-                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter"
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -2587,13 +2587,13 @@
                     ]
                   }
                 ],
-                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter": {
+                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
                   "http://a.ml/vocabularies/core#extensionName": [
                     {
                       "@value": "AnnotationInParameter"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -2616,13 +2616,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -2635,7 +2635,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -2650,10 +2650,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2668,7 +2668,7 @@
                 },
                 "http://a.ml/vocabularies/document#customDomainProperties": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter"
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
                   }
                 ],
                 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -2803,13 +2803,13 @@
             ]
           }
         ],
-        "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/AnnotationInRoot": {
+        "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/AnnotationInRoot": {
           "http://a.ml/vocabularies/core#extensionName": [
             {
               "@value": "AnnotationInRoot"
             }
           ],
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1",
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1",
           "@type": [
             "http://a.ml/vocabularies/data#Scalar",
             "http://a.ml/vocabularies/data#Node",
@@ -2832,13 +2832,13 @@
           ],
           "http://a.ml/vocabularies/document-source-maps#sources": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map",
               "@type": [
                 "http://a.ml/vocabularies/document-source-maps#SourceMap"
               ],
               "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_1",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -2851,7 +2851,7 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/core#name"
@@ -2866,10 +2866,10 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#lexical": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/lexical/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
-                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1"
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1"
                     }
                   ],
                   "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2884,7 +2884,7 @@
         },
         "http://a.ml/vocabularies/document#customDomainProperties": [
           {
-            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/AnnotationInRoot"
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/AnnotationInRoot"
           }
         ],
         "http://a.ml/vocabularies/document-source-maps#sources": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml.flattened.jsonld
@@ -46,12 +46,12 @@
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D%2Fcards%2Fdebit"
         }
       ],
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/AnnotationInRoot": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/AnnotationInRoot": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/AnnotationInRoot"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/AnnotationInRoot"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -80,12 +80,12 @@
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/apiContract#path": "/customers",
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/AnnotationInCustomer": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/AnnotationInCustomer": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/AnnotationInCustomer"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/AnnotationInCustomer"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -189,7 +189,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInRoot",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -204,7 +204,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map"
         }
       ]
     },
@@ -260,7 +260,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInCustomer",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -275,7 +275,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map"
         }
       ]
     },
@@ -306,12 +306,12 @@
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/returns/resp/200"
         }
       ],
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/AnnotationInGet": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/AnnotationInGet": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/AnnotationInGet"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/AnnotationInGet"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -347,12 +347,12 @@
       "http://a.ml/vocabularies/shapes#schema": {
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema"
       },
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -415,12 +415,12 @@
       "http://a.ml/vocabularies/shapes#schema": {
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D%2Faccounts/parameter/parameter/path/customer_id/scalar/schema"
       },
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -461,12 +461,12 @@
       "http://a.ml/vocabularies/shapes#schema": {
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D%2Fcards/parameter/parameter/path/customer_id/scalar/schema"
       },
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -545,12 +545,12 @@
       "http://a.ml/vocabularies/shapes#schema": {
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D%2Fcards%2Fdebit/parameter/parameter/path/customer_id/scalar/schema"
       },
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -579,21 +579,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -648,21 +648,21 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -698,7 +698,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInGet",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -713,7 +713,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map"
         }
       ]
     },
@@ -763,12 +763,12 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "schema",
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -779,7 +779,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInParameter",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -794,7 +794,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map"
         }
       ]
     },
@@ -892,12 +892,12 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "schema",
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -961,12 +961,12 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "schema",
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -1099,12 +1099,12 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "schema",
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -1154,33 +1154,33 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(31,6)-(31,12)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(3,20)-(3,25)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInCustomer/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,26)-(8,31)]"
     },
     {
@@ -1214,21 +1214,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -1259,7 +1259,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInParameter",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1274,7 +1274,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map"
         }
       ]
     },
@@ -1295,21 +1295,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -1620,36 +1620,36 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(19,10)-(21,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInGet/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(16,25)-(16,30)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -1664,18 +1664,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(11,6)-(14,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(12,33)-(12,38)]"
     },
     {
@@ -1839,18 +1839,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(20,12)-(21,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(12,33)-(12,38)]"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml.expanded.jsonld
@@ -105,13 +105,13 @@
                 "@value": "Documentation content"
               }
             ],
-            "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/AnnotationInDocumentationRoot": {
+            "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/AnnotationInDocumentationRoot": {
               "http://a.ml/vocabularies/core#extensionName": [
                 {
                   "@value": "AnnotationInDocumentationRoot"
                 }
               ],
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1",
               "@type": [
                 "http://a.ml/vocabularies/data#Scalar",
                 "http://a.ml/vocabularies/data#Node",
@@ -134,13 +134,13 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map/synthesized-field/element_1",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -153,7 +153,7 @@
                       ]
                     },
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map/synthesized-field/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/core#name"
@@ -168,10 +168,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -354,7 +354,7 @@
             },
             "http://a.ml/vocabularies/document#customDomainProperties": [
               {
-                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/AnnotationInDocumentationRoot"
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/AnnotationInDocumentationRoot"
               },
               {
                 "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/scalar-valued/1/AnnotationInDocumentationTitle"
@@ -436,13 +436,13 @@
                 "@value": "EndPoint description"
               }
             ],
-            "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/AnnotationInEndPointAlpha": {
+            "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/AnnotationInEndPointAlpha": {
               "http://a.ml/vocabularies/core#extensionName": [
                 {
                   "@value": "AnnotationInEndPointAlpha"
                 }
               ],
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1",
               "@type": [
                 "http://a.ml/vocabularies/data#Scalar",
                 "http://a.ml/vocabularies/data#Node",
@@ -465,13 +465,13 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map/synthesized-field/element_1",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -484,7 +484,7 @@
                       ]
                     },
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map/synthesized-field/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/core#name"
@@ -499,10 +499,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -515,13 +515,13 @@
                 }
               ]
             },
-            "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/AnnotationInEndPointBeta": {
+            "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/AnnotationInEndPointBeta": {
               "http://a.ml/vocabularies/core#extensionName": [
                 {
                   "@value": "AnnotationInEndPointBeta"
                 }
               ],
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1",
               "@type": [
                 "http://a.ml/vocabularies/data#Scalar",
                 "http://a.ml/vocabularies/data#Node",
@@ -544,13 +544,13 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map/synthesized-field/element_1",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -563,7 +563,7 @@
                       ]
                     },
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map/synthesized-field/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/core#name"
@@ -578,10 +578,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -764,10 +764,10 @@
             },
             "http://a.ml/vocabularies/document#customDomainProperties": [
               {
-                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/AnnotationInEndPointAlpha"
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/AnnotationInEndPointAlpha"
               },
               {
-                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/AnnotationInEndPointBeta"
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/AnnotationInEndPointBeta"
               },
               {
                 "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/scalar-valued/1/AnnotationInEndPointDisplayName"
@@ -1121,13 +1121,13 @@
                     ]
                   }
                 ],
-                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/AnnotationInOperation": {
+                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/AnnotationInOperation": {
                   "http://a.ml/vocabularies/core#extensionName": [
                     {
                       "@value": "AnnotationInOperation"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -1150,13 +1150,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1169,7 +1169,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -1184,10 +1184,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1286,7 +1286,7 @@
                 },
                 "http://a.ml/vocabularies/document#customDomainProperties": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/AnnotationInOperation"
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/AnnotationInOperation"
                   },
                   {
                     "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/scalar-valued/1/AnnotationInOperationDescription"
@@ -1390,13 +1390,13 @@
                         "@value": "schema"
                       }
                     ],
-                    "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter": {
+                    "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
                       "http://a.ml/vocabularies/core#extensionName": [
                         {
                           "@value": "AnnotationInParameter"
                         }
                       ],
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1",
                       "@type": [
                         "http://a.ml/vocabularies/data#Scalar",
                         "http://a.ml/vocabularies/data#Node",
@@ -1419,13 +1419,13 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#sources": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
                           "@type": [
                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                           ],
                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1438,7 +1438,7 @@
                               ]
                             },
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -1453,10 +1453,10 @@
                           ],
                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                             {
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
                               "http://a.ml/vocabularies/document-source-maps#element": [
                                 {
-                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1"
+                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1"
                                 }
                               ],
                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1471,7 +1471,7 @@
                     },
                     "http://a.ml/vocabularies/document#customDomainProperties": [
                       {
-                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter"
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -1527,13 +1527,13 @@
                     ]
                   }
                 ],
-                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter": {
+                "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
                   "http://a.ml/vocabularies/core#extensionName": [
                     {
                       "@value": "AnnotationInParameter"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -1556,13 +1556,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1575,7 +1575,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -1590,10 +1590,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1608,7 +1608,7 @@
                 },
                 "http://a.ml/vocabularies/document#customDomainProperties": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter"
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
                   }
                 ],
                 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -1730,13 +1730,13 @@
             ]
           }
         ],
-        "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/AnnotationInRoot": {
+        "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/AnnotationInRoot": {
           "http://a.ml/vocabularies/core#extensionName": [
             {
               "@value": "AnnotationInRoot"
             }
           ],
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1",
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1",
           "@type": [
             "http://a.ml/vocabularies/data#Scalar",
             "http://a.ml/vocabularies/data#Node",
@@ -1759,13 +1759,13 @@
           ],
           "http://a.ml/vocabularies/document-source-maps#sources": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map",
               "@type": [
                 "http://a.ml/vocabularies/document-source-maps#SourceMap"
               ],
               "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_1",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1778,7 +1778,7 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/core#name"
@@ -1793,10 +1793,10 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#lexical": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/lexical/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
-                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1"
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1"
                     }
                   ],
                   "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1979,7 +1979,7 @@
         },
         "http://a.ml/vocabularies/document#customDomainProperties": [
           {
-            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/AnnotationInRoot"
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/AnnotationInRoot"
           },
           {
             "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/scalar-valued/1/AnnotationInTitle"

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml.flattened.jsonld
@@ -42,8 +42,8 @@
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D"
         }
       ],
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/AnnotationInRoot": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/AnnotationInRoot": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1"
       },
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/scalar-valued/1/AnnotationInTitle": {
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/scalar-valued/1/AnnotationInTitle/scalar_1"
@@ -53,7 +53,7 @@
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/AnnotationInRoot"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/AnnotationInRoot"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/scalar-valued/1/AnnotationInTitle"
@@ -89,8 +89,8 @@
       ],
       "http://a.ml/vocabularies/core#title": "Documentation title",
       "http://a.ml/vocabularies/core#description": "Documentation content",
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/AnnotationInDocumentationRoot": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/AnnotationInDocumentationRoot": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1"
       },
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/scalar-valued/1/AnnotationInDocumentationTitle": {
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/scalar-valued/1/AnnotationInDocumentationTitle/scalar_1"
@@ -100,7 +100,7 @@
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/AnnotationInDocumentationRoot"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/AnnotationInDocumentationRoot"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/scalar-valued/1/AnnotationInDocumentationTitle"
@@ -124,11 +124,11 @@
       "http://a.ml/vocabularies/apiContract#path": "/customers",
       "http://a.ml/vocabularies/core#name": "EndPoint display name",
       "http://a.ml/vocabularies/core#description": "EndPoint description",
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/AnnotationInEndPointAlpha": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/AnnotationInEndPointAlpha": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1"
       },
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/AnnotationInEndPointBeta": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/AnnotationInEndPointBeta": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1"
       },
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/scalar-valued/1/AnnotationInEndPointDisplayName": {
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/scalar-valued/1/AnnotationInEndPointDisplayName/scalar_1"
@@ -138,10 +138,10 @@
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/AnnotationInEndPointAlpha"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/AnnotationInEndPointAlpha"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/AnnotationInEndPointBeta"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/AnnotationInEndPointBeta"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/scalar-valued/1/AnnotationInEndPointDisplayName"
@@ -181,7 +181,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInRoot",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -196,7 +196,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map"
         }
       ]
     },
@@ -299,7 +299,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInDocumentationRoot",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -314,7 +314,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map"
         }
       ]
     },
@@ -381,7 +381,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInEndPointAlpha",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -396,13 +396,13 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map"
         }
       ]
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInEndPointBeta",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -417,7 +417,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map"
         }
       ]
     },
@@ -498,15 +498,15 @@
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/returns/resp/200"
         }
       ],
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/AnnotationInOperation": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/AnnotationInOperation": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1"
       },
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/scalar-valued/1/AnnotationInOperationDescription": {
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/scalar-valued/1/AnnotationInOperationDescription/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/AnnotationInOperation"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/AnnotationInOperation"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/scalar-valued/1/AnnotationInOperationDescription"
@@ -531,12 +531,12 @@
       "http://a.ml/vocabularies/shapes#schema": {
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema"
       },
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/AnnotationInParameter"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -568,21 +568,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -680,21 +680,21 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -752,40 +752,40 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,0)-(17,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -878,7 +878,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInOperation",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -893,7 +893,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map"
         }
       ]
     },
@@ -951,12 +951,12 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "schema",
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/AnnotationInParameter"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/AnnotationInParameter"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -967,7 +967,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInParameter",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -982,7 +982,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map"
         }
       ]
     },
@@ -1026,18 +1026,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(26,2)-(43,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/customDomainProperties/AnnotationInRoot/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(45,20)-(45,23)]"
     },
     {
@@ -1071,18 +1071,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,25)-(7,28)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/documentation/creative-work/Documentation%20title/customDomainProperties/AnnotationInDocumentationRoot/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,37)-(10,40)]"
     },
     {
@@ -1116,33 +1116,33 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(16,42)-(16,45)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointAlpha/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(43,31)-(43,36)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/extension_1/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers/customDomainProperties/AnnotationInEndPointBeta/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(44,30)-(44,34)]"
     },
     {
@@ -1231,21 +1231,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -1285,7 +1285,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "AnnotationInParameter",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1300,7 +1300,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map"
         }
       ]
     },
@@ -1324,21 +1324,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -1418,18 +1418,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(36,8)-(42,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/supportedOperation/get/customDomainProperties/AnnotationInOperation/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(42,31)-(42,34)]"
     },
     {
@@ -1448,21 +1448,21 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(34,44)-(34,47)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -1482,18 +1482,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(29,8)-(30,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/customDomainProperties/AnnotationInParameter/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(30,33)-(30,36)]"
     },
     {
@@ -1533,18 +1533,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(39,47)-(39,50)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml#/web-api/endpoint/%2Fcustomers%2F%7Bcustomer_id%7D/parameter/parameter/path/customer_id/scalar/schema/customDomainProperties/AnnotationInParameter/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(30,33)-(30,36)]"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.expanded.jsonld
@@ -21,92 +21,13 @@
             "@value": "test api"
           }
         ],
-        "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/wadus": {
-          "http://a.ml/vocabularies/core#extensionName": [
-            {
-              "@value": "wadus"
-            }
-          ],
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1",
-          "@type": [
-            "http://a.ml/vocabularies/data#Scalar",
-            "http://a.ml/vocabularies/data#Node",
-            "http://a.ml/vocabularies/document#DomainElement"
-          ],
-          "http://a.ml/vocabularies/data#value": [
-            {
-              "@value": "hello"
-            }
-          ],
-          "http://www.w3.org/ns/shacl#datatype": [
-            {
-              "@id": "http://www.w3.org/2001/XMLSchema#string"
-            }
-          ],
-          "http://a.ml/vocabularies/core#name": [
-            {
-              "@value": "scalar_1"
-            }
-          ],
-          "http://a.ml/vocabularies/document-source-maps#sources": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map",
-              "@type": [
-                "http://a.ml/vocabularies/document-source-maps#SourceMap"
-              ],
-              "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://www.w3.org/ns/shacl#datatype"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "true"
-                    }
-                  ]
-                },
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "http://a.ml/vocabularies/core#name"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "true"
-                    }
-                  ]
-                }
-              ],
-              "http://a.ml/vocabularies/document-source-maps#lexical": [
-                {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-                  "http://a.ml/vocabularies/document-source-maps#element": [
-                    {
-                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1"
-                    }
-                  ],
-                  "http://a.ml/vocabularies/document-source-maps#value": [
-                    {
-                      "@value": "[(3,9)-(3,14)]"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/foo": {
+        "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/foo": {
           "http://a.ml/vocabularies/core#extensionName": [
             {
               "@value": "foo"
             }
           ],
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1",
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1",
           "@type": [
             "http://a.ml/vocabularies/data#Object",
             "http://a.ml/vocabularies/data#Node",
@@ -114,7 +35,7 @@
           ],
           "http://a.ml/vocabularies/data#a": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a",
               "@type": [
                 "http://a.ml/vocabularies/data#Scalar",
                 "http://a.ml/vocabularies/data#Node",
@@ -137,13 +58,13 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_1",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -156,7 +77,7 @@
                       ]
                     },
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/core#name"
@@ -171,10 +92,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -190,7 +111,7 @@
           ],
           "http://a.ml/vocabularies/data#b": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b",
               "@type": [
                 "http://a.ml/vocabularies/data#Array",
                 "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -199,7 +120,7 @@
               ],
               "http://www.w3.org/2000/01/rdf-schema#member": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -222,13 +143,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -241,7 +162,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -256,10 +177,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -273,7 +194,7 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -296,13 +217,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -315,7 +236,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -330,10 +251,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -354,16 +275,16 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -384,13 +305,13 @@
           ],
           "http://a.ml/vocabularies/document-source-maps#sources": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map",
               "@type": [
                 "http://a.ml/vocabularies/document-source-maps#SourceMap"
               ],
               "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/synthesized-field/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/synthesized-field/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/core#name"
@@ -405,7 +326,7 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#lexical": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_2",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_2",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/data#a"
@@ -418,7 +339,7 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/data#b"
@@ -431,10 +352,10 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_1",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
-                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1"
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1"
                     }
                   ],
                   "http://a.ml/vocabularies/document-source-maps#value": [
@@ -447,12 +368,91 @@
             }
           ]
         },
+        "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/wadus": {
+          "http://a.ml/vocabularies/core#extensionName": [
+            {
+              "@value": "wadus"
+            }
+          ],
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1",
+          "@type": [
+            "http://a.ml/vocabularies/data#Scalar",
+            "http://a.ml/vocabularies/data#Node",
+            "http://a.ml/vocabularies/document#DomainElement"
+          ],
+          "http://a.ml/vocabularies/data#value": [
+            {
+              "@value": "hello"
+            }
+          ],
+          "http://www.w3.org/ns/shacl#datatype": [
+            {
+              "@id": "http://www.w3.org/2001/XMLSchema#string"
+            }
+          ],
+          "http://a.ml/vocabularies/core#name": [
+            {
+              "@value": "scalar_1"
+            }
+          ],
+          "http://a.ml/vocabularies/document-source-maps#sources": [
+            {
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map",
+              "@type": [
+                "http://a.ml/vocabularies/document-source-maps#SourceMap"
+              ],
+              "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_1",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://www.w3.org/ns/shacl#datatype"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "true"
+                    }
+                  ]
+                },
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "http://a.ml/vocabularies/core#name"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "true"
+                    }
+                  ]
+                }
+              ],
+              "http://a.ml/vocabularies/document-source-maps#lexical": [
+                {
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map/lexical/element_0",
+                  "http://a.ml/vocabularies/document-source-maps#element": [
+                    {
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1"
+                    }
+                  ],
+                  "http://a.ml/vocabularies/document-source-maps#value": [
+                    {
+                      "@value": "[(3,9)-(3,14)]"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
         "http://a.ml/vocabularies/document#customDomainProperties": [
           {
-            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/wadus"
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/foo"
           },
           {
-            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/foo"
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/wadus"
           }
         ],
         "http://a.ml/vocabularies/document-source-maps#sources": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.flattened.jsonld
@@ -17,18 +17,18 @@
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/core#name": "test api",
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/wadus": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/foo": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1"
       },
-      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/foo": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/wadus": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/wadus"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/foo"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/foo"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/wadus"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -38,8 +38,29 @@
       ]
     },
     {
+      "http://a.ml/vocabularies/core#extensionName": "foo",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#a": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a"
+      },
+      "http://a.ml/vocabularies/data#b": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b"
+      },
+      "http://a.ml/vocabularies/core#name": "object_1",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map"
+        }
+      ]
+    },
+    {
       "http://a.ml/vocabularies/core#extensionName": "wadus",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -54,28 +75,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map"
-        }
-      ]
-    },
-    {
-      "http://a.ml/vocabularies/core#extensionName": "foo",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1",
-      "@type": [
-        "http://a.ml/vocabularies/data#Object",
-        "http://a.ml/vocabularies/data#Node",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/data#a": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a"
-      },
-      "http://a.ml/vocabularies/data#b": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b"
-      },
-      "http://a.ml/vocabularies/core#name": "object_1",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map"
         }
       ]
     },
@@ -94,26 +94,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -128,12 +109,12 @@
       "http://a.ml/vocabularies/core#name": "a",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b",
       "@type": [
         "http://a.ml/vocabularies/data#Array",
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -142,38 +123,57 @@
       ],
       "http://www.w3.org/2000/01/rdf-schema#member": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5"
         }
       ],
       "http://a.ml/vocabularies/core#name": "b",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_2"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_1"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -188,41 +188,26 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(3,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "true"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension/scalar_1",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(3,9)-(3,14)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -237,12 +222,12 @@
       "http://a.ml/vocabularies/core#name": "scalar_4",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -257,127 +242,142 @@
       "http://a.ml/vocabularies/core#name": "scalar_5",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#a",
       "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(6,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#b",
       "http://a.ml/vocabularies/document-source-maps#value": "[(6,2)-(8,6)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(5,0)-(8,6)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/a",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/wadus/scalar_1",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(3,9)-(3,14)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map/synthesized-field/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "true"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/a",
       "http://a.ml/vocabularies/document-source-maps#value": "[(5,5)-(5,7)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b",
       "http://a.ml/vocabularies/document-source-maps#value": "[(6,4)-(8,6)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_4",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_4",
       "http://a.ml/vocabularies/document-source-maps#value": "[(7,5)-(7,6)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/extension_1/object_1/b/member/scalar_5",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml#/web-api/customDomainProperties/foo/object_1/b/member/scalar_5",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,5)-(8,6)]"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.jsonld.raml
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.jsonld.raml
@@ -1,8 +1,8 @@
 #%RAML 1.0
 title: test api
-(wadus): hello
 (foo):
   a: is
   b:
     - 1
     - 2
+(wadus): hello

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml.expanded.jsonld
@@ -120,7 +120,7 @@
                                           "@value": "a"
                                         }
                                       ],
-                                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1",
+                                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1",
                                       "@type": [
                                         "http://a.ml/vocabularies/data#Scalar",
                                         "http://a.ml/vocabularies/data#Node",
@@ -143,13 +143,13 @@
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#sources": [
                                         {
-                                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map",
+                                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map",
                                           "@type": [
                                             "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                           ],
                                           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                             {
-                                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
                                               "http://a.ml/vocabularies/document-source-maps#element": [
                                                 {
                                                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -162,7 +162,7 @@
                                               ]
                                             },
                                             {
-                                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
                                               "http://a.ml/vocabularies/document-source-maps#element": [
                                                 {
                                                   "@value": "http://a.ml/vocabularies/core#name"
@@ -177,10 +177,10 @@
                                           ],
                                           "http://a.ml/vocabularies/document-source-maps#lexical": [
                                             {
-                                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
                                               "http://a.ml/vocabularies/document-source-maps#element": [
                                                 {
-                                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1"
+                                                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1"
                                                 }
                                               ],
                                               "http://a.ml/vocabularies/document-source-maps#value": [
@@ -325,7 +325,7 @@
                                   "@value": "a"
                                 }
                               ],
-                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+                              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1",
                               "@type": [
                                 "http://a.ml/vocabularies/data#Scalar",
                                 "http://a.ml/vocabularies/data#Node",
@@ -348,13 +348,13 @@
                               ],
                               "http://a.ml/vocabularies/document-source-maps#sources": [
                                 {
-                                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map",
+                                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map",
                                   "@type": [
                                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -367,7 +367,7 @@
                                       ]
                                     },
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
                                           "@value": "http://a.ml/vocabularies/core#name"
@@ -382,10 +382,10 @@
                                   ],
                                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                                     {
-                                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
                                       "http://a.ml/vocabularies/document-source-maps#element": [
                                         {
-                                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1"
+                                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1"
                                         }
                                       ],
                                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -542,7 +542,7 @@
                       "@value": "a"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -565,13 +565,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -584,7 +584,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -599,10 +599,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -651,7 +651,7 @@
                   "@value": "a"
                 }
               ],
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1",
               "@type": [
                 "http://a.ml/vocabularies/data#Scalar",
                 "http://a.ml/vocabularies/data#Node",
@@ -674,13 +674,13 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -693,7 +693,7 @@
                       ]
                     },
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/core#name"
@@ -708,10 +708,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -992,7 +992,7 @@
                       "@value": "a"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -1015,13 +1015,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1034,7 +1034,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -1049,10 +1049,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1197,7 +1197,7 @@
               "@value": "a"
             }
           ],
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1",
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1",
           "@type": [
             "http://a.ml/vocabularies/data#Scalar",
             "http://a.ml/vocabularies/data#Node",
@@ -1220,13 +1220,13 @@
           ],
           "http://a.ml/vocabularies/document-source-maps#sources": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map",
               "@type": [
                 "http://a.ml/vocabularies/document-source-maps#SourceMap"
               ],
               "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1239,7 +1239,7 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/core#name"
@@ -1254,10 +1254,10 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#lexical": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
-                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1"
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1"
                     }
                   ],
                   "http://a.ml/vocabularies/document-source-maps#value": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml.flattened.jsonld
@@ -41,7 +41,7 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/a": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -81,7 +81,7 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/a": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -96,7 +96,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "a",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -111,7 +111,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map"
         }
       ]
     },
@@ -159,7 +159,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "a",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -174,7 +174,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map"
         }
       ]
     },
@@ -190,21 +190,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -246,21 +246,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -270,18 +270,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(15,2)-(23,29)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/customDomainProperties/a/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(14,7)-(14,19)]"
     },
     {
@@ -301,7 +301,7 @@
       ],
       "http://www.w3.org/ns/shacl#name": "schema",
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/a": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -331,18 +331,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(17,4)-(23,29)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/customDomainProperties/a/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(16,9)-(16,21)]"
     },
     {
@@ -371,7 +371,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "a",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -386,7 +386,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map"
         }
       ]
     },
@@ -440,7 +440,7 @@
       ],
       "http://www.w3.org/ns/shacl#name": "p2",
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/a": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -476,21 +476,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -521,7 +521,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "a",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -536,7 +536,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map"
         }
       ]
     },
@@ -577,36 +577,36 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(22,13)-(23,29)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/customDomainProperties/a/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(19,13)-(19,25)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -621,18 +621,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(22,10)-(23,29)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/web-api/endpoint/%2Fresource/supportedOperation/get/expects/request/payload/application%2Fjson/shape/schema/property/property/p2/scalar/p2/customDomainProperties/a/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(23,17)-(23,29)]"
     },
     {
@@ -693,7 +693,7 @@
       ],
       "http://www.w3.org/ns/shacl#name": "MyType",
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/a": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -772,7 +772,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "a",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -787,7 +787,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map"
         }
       ]
     },
@@ -860,7 +860,7 @@
       ],
       "http://www.w3.org/ns/shacl#name": "p1",
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/a": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -896,21 +896,21 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -946,7 +946,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "a",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -961,7 +961,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map"
         }
       ]
     },
@@ -1002,36 +1002,36 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(11,9)-(13,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/customDomainProperties/a/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(9,9)-(9,21)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -1046,18 +1046,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(11,6)-(13,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml#/declares/shape/MyType/property/property/p1/scalar/p1/customDomainProperties/a/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(12,13)-(12,25)]"
     }
   ]

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.expanded.jsonld
@@ -34,7 +34,7 @@
           "@value": "someVeryCoolAnnotation"
         }
       ],
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -57,13 +57,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map",
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map",
           "@type": [
             "http://a.ml/vocabularies/document-source-maps#SourceMap"
           ],
           "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map/synthesized-field/element_1",
               "http://a.ml/vocabularies/document-source-maps#element": [
                 {
                   "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -76,7 +76,7 @@
               ]
             },
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map/synthesized-field/element_0",
               "http://a.ml/vocabularies/document-source-maps#element": [
                 {
                   "@value": "http://a.ml/vocabularies/core#name"
@@ -91,10 +91,10 @@
           ],
           "http://a.ml/vocabularies/document-source-maps#lexical": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map/lexical/element_0",
               "http://a.ml/vocabularies/document-source-maps#element": [
                 {
-                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1"
+                  "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1"
                 }
               ],
               "http://a.ml/vocabularies/document-source-maps#value": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.flattened.jsonld
@@ -9,7 +9,7 @@
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation",
       "@type": [
         "http://a.ml/vocabularies/apiContract#DomainExtension",
         "http://a.ml/vocabularies/document#DomainElement"
@@ -19,11 +19,11 @@
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declares/someVeryCoolAnnotation"
       },
       "http://a.ml/vocabularies/document#extension": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1"
       },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/source-map"
         }
       ]
     },
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -65,18 +65,18 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/source-map/lexical/element_0"
         }
       ]
     },
@@ -132,27 +132,27 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation",
       "http://a.ml/vocabularies/document-source-maps#value": "[(3,0)-(5,0)]"
     },
     {
@@ -205,18 +205,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(3,26)-(3,37)]"
     },
     {
@@ -253,7 +253,7 @@
         "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/BaseUnitProcessingData"
       },
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/declares/someVeryCoolAnnotation": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml#/customDomainProperties/someVeryCoolAnnotation/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml.expanded.jsonld
@@ -758,7 +758,7 @@
                       "@value": "annotA"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -781,13 +781,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -800,7 +800,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -815,10 +815,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -837,7 +837,7 @@
                       "@value": "annotB"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -860,13 +860,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -879,7 +879,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -894,10 +894,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml.flattened.jsonld
@@ -124,10 +124,10 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/declares/annotA": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1"
       },
       "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/declares/annotB": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -273,7 +273,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "annotA",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -288,13 +288,13 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map"
         }
       ]
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "annotB",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -309,7 +309,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map"
         }
       ]
     },
@@ -484,40 +484,40 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -670,33 +670,33 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,8)-(27,15)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(35,14)-(35,17)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(36,14)-(36,17)]"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.expanded.jsonld
@@ -214,13 +214,13 @@
                     ]
                   }
                 ],
-                "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/responses-extension": {
+                "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/responses-extension": {
                   "http://a.ml/vocabularies/core#extensionName": [
                     {
                       "@value": "responses-extension"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -243,13 +243,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -262,7 +262,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -277,10 +277,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -292,10 +292,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#orphan-oas-extension": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/orphan-oas-extension/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/orphan-oas-extension/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -310,7 +310,7 @@
                 },
                 "http://a.ml/vocabularies/document#customDomainProperties": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/responses-extension"
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/responses-extension"
                   }
                 ],
                 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -389,13 +389,13 @@
             ]
           }
         ],
-        "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/paths-extension": {
+        "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/paths-extension": {
           "http://a.ml/vocabularies/core#extensionName": [
             {
               "@value": "paths-extension"
             }
           ],
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1",
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1",
           "@type": [
             "http://a.ml/vocabularies/data#Scalar",
             "http://a.ml/vocabularies/data#Node",
@@ -418,13 +418,13 @@
           ],
           "http://a.ml/vocabularies/document-source-maps#sources": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map",
               "@type": [
                 "http://a.ml/vocabularies/document-source-maps#SourceMap"
               ],
               "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/synthesized-field/element_1",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -437,7 +437,7 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/synthesized-field/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/core#name"
@@ -452,10 +452,10 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#lexical": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/lexical/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
-                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1"
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1"
                     }
                   ],
                   "http://a.ml/vocabularies/document-source-maps#value": [
@@ -467,10 +467,10 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#orphan-oas-extension": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/orphan-oas-extension/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/orphan-oas-extension/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
-                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1"
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1"
                     }
                   ],
                   "http://a.ml/vocabularies/document-source-maps#value": [
@@ -485,7 +485,7 @@
         },
         "http://a.ml/vocabularies/document#customDomainProperties": [
           {
-            "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/paths-extension"
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/paths-extension"
           }
         ],
         "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -802,13 +802,13 @@
                 ]
               }
             ],
-            "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scopes-extension": {
+            "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scopes-extension": {
               "http://a.ml/vocabularies/core#extensionName": [
                 {
                   "@value": "scopes-extension"
                 }
               ],
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1",
               "@type": [
                 "http://a.ml/vocabularies/data#Scalar",
                 "http://a.ml/vocabularies/data#Node",
@@ -831,13 +831,13 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#sources": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map",
                   "@type": [
                     "http://a.ml/vocabularies/document-source-maps#SourceMap"
                   ],
                   "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/synthesized-field/element_1",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -850,7 +850,7 @@
                       ]
                     },
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/synthesized-field/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
                           "@value": "http://a.ml/vocabularies/core#name"
@@ -865,10 +865,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#lexical": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/lexical/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -880,10 +880,10 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#orphan-oas-extension": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/orphan-oas-extension/element_0",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/orphan-oas-extension/element_0",
                       "http://a.ml/vocabularies/document-source-maps#element": [
                         {
-                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1"
+                          "@value": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1"
                         }
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
@@ -898,7 +898,7 @@
             },
             "http://a.ml/vocabularies/document#customDomainProperties": [
               {
-                "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scopes-extension"
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scopes-extension"
               }
             ],
             "http://a.ml/vocabularies/document-source-maps#sources": [

--- a/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.flattened.jsonld
@@ -38,12 +38,12 @@
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero"
         }
       ],
-      "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/paths-extension": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/paths-extension": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/paths-extension"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/paths-extension"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -86,7 +86,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "paths-extension",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -101,7 +101,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map"
         }
       ]
     },
@@ -167,12 +167,12 @@
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/returns/resp/200"
         }
       ],
-      "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/responses-extension": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/responses-extension": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/responses-extension"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/responses-extension"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -196,26 +196,26 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#orphan-oas-extension": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/orphan-oas-extension/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/orphan-oas-extension/element_0"
         }
       ]
     },
@@ -287,7 +287,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "responses-extension",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -302,7 +302,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map"
         }
       ]
     },
@@ -331,23 +331,23 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(21,6)-(21,33)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(31,25)-(31,30)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1/source-map/orphan-oas-extension/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1/source-map/orphan-oas-extension/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/customDomainProperties/paths-extension/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "paths"
     },
     {
@@ -368,26 +368,26 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#orphan-oas-extension": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/orphan-oas-extension/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/orphan-oas-extension/element_0"
         }
       ]
     },
@@ -417,23 +417,23 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,10)-(26,11)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,35)-(27,40)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/orphan-oas-extension/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1/source-map/orphan-oas-extension/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/web-api/endpoint/%2Flevelzero/supportedOperation/get/customDomainProperties/responses-extension/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "responses"
     },
     {
@@ -486,12 +486,12 @@
           "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/flows/implicit"
         }
       ],
-      "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scopes-extension": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scopes-extension": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scopes-extension"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scopes-extension"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -549,7 +549,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "scopes-extension",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -564,7 +564,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map"
         }
       ]
     },
@@ -653,26 +653,26 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#orphan-oas-extension": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/orphan-oas-extension/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/orphan-oas-extension/element_0"
         }
       ]
     },
@@ -724,23 +724,23 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(34,21)-(43,5)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(41,30)-(41,35)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1/source-map/orphan-oas-extension/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/orphan-oas-extension/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "scopes"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/type-facets.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/type-facets.json.expanded.jsonld
@@ -528,13 +528,13 @@
             "@value": "PossibleMeetingDate"
           }
         ],
-        "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/amf-facet-noHolidays": {
+        "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/amf-facet-noHolidays": {
           "http://a.ml/vocabularies/core#extensionName": [
             {
               "@value": "amf-facet-noHolidays"
             }
           ],
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1",
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1",
           "@type": [
             "http://a.ml/vocabularies/data#Scalar",
             "http://a.ml/vocabularies/data#Node",
@@ -557,13 +557,13 @@
           ],
           "http://a.ml/vocabularies/document-source-maps#sources": [
             {
-              "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map",
+              "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map",
               "@type": [
                 "http://a.ml/vocabularies/document-source-maps#SourceMap"
               ],
               "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map/synthesized-field/element_1",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -576,7 +576,7 @@
                   ]
                 },
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map/synthesized-field/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
                       "@value": "http://a.ml/vocabularies/core#name"
@@ -591,10 +591,10 @@
               ],
               "http://a.ml/vocabularies/document-source-maps#lexical": [
                 {
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map/lexical/element_0",
                   "http://a.ml/vocabularies/document-source-maps#element": [
                     {
-                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1"
+                      "@value": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1"
                     }
                   ],
                   "http://a.ml/vocabularies/document-source-maps#value": [
@@ -609,7 +609,7 @@
         },
         "http://a.ml/vocabularies/document#customDomainProperties": [
           {
-            "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/amf-facet-noHolidays"
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/amf-facet-noHolidays"
           }
         ],
         "http://a.ml/vocabularies/document-source-maps#sources": [

--- a/amf-cli/shared/src/test/resources/upanddown/type-facets.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/type-facets.json.flattened.jsonld
@@ -135,12 +135,12 @@
       ],
       "http://a.ml/vocabularies/shapes#format": "date",
       "http://www.w3.org/ns/shacl#name": "PossibleMeetingDate",
-      "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/amf-facet-noHolidays": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1"
+      "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/amf-facet-noHolidays": {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/amf-facet-noHolidays"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/amf-facet-noHolidays"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -229,7 +229,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "amf-facet-noHolidays",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -244,7 +244,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map"
         }
       ]
     },
@@ -383,21 +383,21 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(18,6)-(18,12)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -490,18 +490,18 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(14,8)-(16,9)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/type-facets.json#/declares/scalar/PossibleMeetingDate/customDomainProperties/amf-facet-noHolidays/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(22,32)-(22,36)]"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/with_references_resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/with_references_resolved.expanded.jsonld
@@ -1198,7 +1198,7 @@
                       "@value": "annotA"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -1221,13 +1221,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1240,7 +1240,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -1255,10 +1255,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1277,7 +1277,7 @@
                       "@value": "annotB"
                     }
                   ],
-                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1",
+                  "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1",
                   "@type": [
                     "http://a.ml/vocabularies/data#Scalar",
                     "http://a.ml/vocabularies/data#Node",
@@ -1300,13 +1300,13 @@
                   ],
                   "http://a.ml/vocabularies/document-source-maps#sources": [
                     {
-                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map",
+                      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map",
                       "@type": [
                         "http://a.ml/vocabularies/document-source-maps#SourceMap"
                       ],
                       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_1",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_1",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://www.w3.org/ns/shacl#datatype"
@@ -1319,7 +1319,7 @@
                           ]
                         },
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
                               "@value": "http://a.ml/vocabularies/core#name"
@@ -1334,10 +1334,10 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#lexical": [
                         {
-                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/lexical/element_0",
+                          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/lexical/element_0",
                           "http://a.ml/vocabularies/document-source-maps#element": [
                             {
-                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1"
+                              "@value": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1"
                             }
                           ],
                           "http://a.ml/vocabularies/document-source-maps#value": [

--- a/amf-cli/shared/src/test/resources/upanddown/with_references_resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/with_references_resolved.flattened.jsonld
@@ -117,10 +117,10 @@
         }
       ],
       "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/declares/annotA": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1"
       },
       "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/declares/annotB": {
-        "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1"
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1"
       },
       "http://a.ml/vocabularies/document#customDomainProperties": [
         {
@@ -232,7 +232,7 @@
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "annotA",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -247,13 +247,13 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map"
         }
       ]
     },
     {
       "http://a.ml/vocabularies/core#extensionName": "annotB",
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -268,7 +268,7 @@
       "http://a.ml/vocabularies/core#name": "scalar_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map"
         }
       ]
     },
@@ -374,40 +374,40 @@
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/lexical/element_0"
+          "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/lexical/element_0"
         }
       ]
     },
@@ -516,33 +516,33 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,8)-(27,15)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotA/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(35,14)-(35,17)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/synthesized-field/element_0",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension_1/scalar_1",
+      "@id": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/with_references.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/annotB/scalar_1",
       "http://a.ml/vocabularies/document-source-maps#value": "[(36,14)-(36,17)]"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/annotations.report.js
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/annotations.report.js
@@ -8,7 +8,7 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be integer
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations.raml#/web-api/customDomainProperties/extension_1/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations.raml#/web-api/customDomainProperties/extension_1/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations.raml#/web-api/customDomainProperties/b/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations.raml#/web-api/customDomainProperties/b/scalar_1
   Range: [(10,5)-(10,7)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotations.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/annotations.report.jvm
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/annotations.report.jvm
@@ -8,7 +8,7 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected type: Integer, found: String
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations.raml#/web-api/customDomainProperties/extension_1/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations.raml#/web-api/customDomainProperties/extension_1/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations.raml#/web-api/customDomainProperties/b/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations.raml#/web-api/customDomainProperties/b/scalar_1
   Range: [(10,5)-(10,7)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotations.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/annotations_enum.report.js
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/annotations_enum.report.js
@@ -8,15 +8,15 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: items should be equal to one of the allowed values
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/extension/object_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/extension/object_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/test/object_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/test/object_1
   Range: [(23,0)-(25,0)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: items should be equal to one of the allowed values
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/extension_1/object_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/extension_1/object_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/testInt/object_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/testInt/object_1
   Range: [(26,0)-(28,0)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/annotations_enum.report.jvm
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/annotations_enum.report.jvm
@@ -8,15 +8,15 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: /items E is not a valid enum value
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/extension/object_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/extension/object_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/test/object_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/test/object_1
   Range: [(23,0)-(25,0)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: /items 4 is not a valid enum value
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/extension_1/object_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/extension_1/object_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/testInt/object_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml#/web-api/customDomainProperties/testInt/object_1
   Range: [(26,0)-(28,0)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotations_enum.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/invalid-annotation-value.report.js
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/invalid-annotation-value.report.js
@@ -8,7 +8,7 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be number
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/examples/invalid-annotation-value.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension_4/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/examples/invalid-annotation-value.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension_4/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/examples/invalid-annotation-value.raml#/web-api/endpoint/%2Fusers/customDomainProperties/intAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/examples/invalid-annotation-value.raml#/web-api/endpoint/%2Fusers/customDomainProperties/intAnnotation/scalar_1
   Range: [(26,19)-(26,20)]
   Location: file://amf-cli/shared/src/test/resources/validations/examples/invalid-annotation-value.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/invalid-annotation-value.report.jvm
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/invalid-annotation-value.report.jvm
@@ -8,7 +8,7 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected type: Number, found: String
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/examples/invalid-annotation-value.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension_4/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/examples/invalid-annotation-value.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension_4/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/examples/invalid-annotation-value.raml#/web-api/endpoint/%2Fusers/customDomainProperties/intAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/examples/invalid-annotation-value.raml#/web-api/endpoint/%2Fusers/customDomainProperties/intAnnotation/scalar_1
   Range: [(26,19)-(26,20)]
   Location: file://amf-cli/shared/src/test/resources/validations/examples/invalid-annotation-value.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/pattern-invalid.report.js
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/pattern-invalid.report.js
@@ -8,7 +8,7 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: signature should match pattern "^\d{3}-\w{12}$"
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/examples/pattern-invalid.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension/object_1
-  Property: file://amf-cli/shared/src/test/resources/validations/examples/pattern-invalid.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension/object_1
+  Target: file://amf-cli/shared/src/test/resources/validations/examples/pattern-invalid.raml#/web-api/endpoint/%2Fusers/customDomainProperties/clearanceLevel/object_1
+  Property: file://amf-cli/shared/src/test/resources/validations/examples/pattern-invalid.raml#/web-api/endpoint/%2Fusers/customDomainProperties/clearanceLevel/object_1
   Range: [(15,0)-(16,23)]
   Location: file://amf-cli/shared/src/test/resources/validations/examples/pattern-invalid.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/pattern-invalid.report.jvm
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/pattern-invalid.report.jvm
@@ -8,7 +8,7 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: /signature string [aaa-5555] does not match pattern ^\d{3}-\w{12}$
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/examples/pattern-invalid.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension/object_1
-  Property: file://amf-cli/shared/src/test/resources/validations/examples/pattern-invalid.raml#/web-api/endpoint/%2Fusers/customDomainProperties/extension/object_1
+  Target: file://amf-cli/shared/src/test/resources/validations/examples/pattern-invalid.raml#/web-api/endpoint/%2Fusers/customDomainProperties/clearanceLevel/object_1
+  Property: file://amf-cli/shared/src/test/resources/validations/examples/pattern-invalid.raml#/web-api/endpoint/%2Fusers/customDomainProperties/clearanceLevel/object_1
   Range: [(15,0)-(16,23)]
   Location: file://amf-cli/shared/src/test/resources/validations/examples/pattern-invalid.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/rest_connect_bad.report.js
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/rest_connect_bad.report.js
@@ -11,7 +11,7 @@ should be string
 should match some schema in anyOf
 
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/production/rest_connect/apibad.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/production/rest_connect/apibad.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/production/rest_connect/apibad.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/ignored/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/production/rest_connect/apibad.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/ignored/scalar_1
   Range: [(26,28)-(26,32)]
   Location: file://amf-cli/shared/src/test/resources/validations/production/rest_connect/apibad.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/rest_connect_bad.report.jvm
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/rest_connect_bad.report.jvm
@@ -10,7 +10,7 @@ Level: Violation
 expected: null, found: Boolean
 
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/production/rest_connect/apibad.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/production/rest_connect/apibad.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/production/rest_connect/apibad.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/ignored/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/production/rest_connect/apibad.raml#/web-api/endpoint/%2Ftest/supportedOperation/get/customDomainProperties/ignored/scalar_1
   Range: [(26,28)-(26,32)]
   Location: file://amf-cli/shared/src/test/resources/validations/production/rest_connect/apibad.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/multi-plat-model/annotating-scalar-valued-nodes.report.js
+++ b/amf-cli/shared/src/test/resources/validations/reports/multi-plat-model/annotating-scalar-valued-nodes.report.js
@@ -8,31 +8,31 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be string
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/customDomainProperties/stringAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/customDomainProperties/stringAnnotation/scalar_1
   Range: [(6,20)-(6,21)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be string
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/customDomainProperties/stringAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/customDomainProperties/stringAnnotation/scalar_1
   Range: [(10,22)-(10,23)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be string
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/name/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/name/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/name/stringAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/name/stringAnnotation/scalar_1
   Range: [(14,24)-(14,25)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be string
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/description/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/description/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/description/stringAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/description/stringAnnotation/scalar_1
   Range: [(18,24)-(18,25)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/multi-plat-model/annotating-scalar-valued-nodes.report.jvm
+++ b/amf-cli/shared/src/test/resources/validations/reports/multi-plat-model/annotating-scalar-valued-nodes.report.jvm
@@ -8,31 +8,31 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected type: String, found: Integer
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/customDomainProperties/stringAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/customDomainProperties/stringAnnotation/scalar_1
   Range: [(6,20)-(6,21)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected type: String, found: Integer
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/customDomainProperties/stringAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/customDomainProperties/stringAnnotation/scalar_1
   Range: [(10,22)-(10,23)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected type: String, found: Integer
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/name/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/name/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/name/stringAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/name/stringAnnotation/scalar_1
   Range: [(14,24)-(14,25)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml
 
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected type: String, found: Integer
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/description/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/description/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/description/stringAnnotation/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml#/web-api/endpoint/%2Fresource/description/stringAnnotation/scalar_1
   Range: [(18,24)-(18,25)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotations/annotating-scalar-valued-nodes.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/multi-plat-model/annotation-types-invalid-example.report.js
+++ b/amf-cli/shared/src/test/resources/validations/reports/multi-plat-model/annotation-types-invalid-example.report.js
@@ -8,7 +8,7 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: should be number
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotation-types-invalid-example.raml#/web-api/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotation-types-invalid-example.raml#/web-api/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotation-types-invalid-example.raml#/web-api/customDomainProperties/apigateway-integration/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotation-types-invalid-example.raml#/web-api/customDomainProperties/apigateway-integration/scalar_1
   Range: [(9,26)-(9,28)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotation-types-invalid-example.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/multi-plat-model/annotation-types-invalid-example.report.jvm
+++ b/amf-cli/shared/src/test/resources/validations/reports/multi-plat-model/annotation-types-invalid-example.report.jvm
@@ -8,7 +8,7 @@ Level: Violation
 - Constraint: http://a.ml/vocabularies/amf/validation#example-validation-error
   Message: expected type: Number, found: String
   Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/validations/annotation-types-invalid-example.raml#/web-api/customDomainProperties/extension/scalar_1
-  Property: file://amf-cli/shared/src/test/resources/validations/annotation-types-invalid-example.raml#/web-api/customDomainProperties/extension/scalar_1
+  Target: file://amf-cli/shared/src/test/resources/validations/annotation-types-invalid-example.raml#/web-api/customDomainProperties/apigateway-integration/scalar_1
+  Property: file://amf-cli/shared/src/test/resources/validations/annotation-types-invalid-example.raml#/web-api/customDomainProperties/apigateway-integration/scalar_1
   Range: [(9,26)-(9,28)]
   Location: file://amf-cli/shared/src/test/resources/validations/annotation-types-invalid-example.raml

--- a/amf-cli/shared/src/test/scala/amf/semantic/JsonLdSemanticExtensionsParseTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/semantic/JsonLdSemanticExtensionsParseTest.scala
@@ -48,6 +48,10 @@ class JsonLdSemanticExtensionsParseTest extends AsyncFunSuite with Matchers {
     assertParsedModel("scalar-dialect.yaml", "instance-scalar.async.jsonld", lookupScalarPagination)
   }
 
+  test("Parse JSON-LD with nested object semantic extensions for RAML 1.0") {
+    assertParsedModel("nested-object-dialect.yaml", "instance-nested-object.raml.jsonld", lookupNestedTagType)
+  }
+
   private def assertParsedModel(dialectPath: String,
                                 jsonLdPath: String,
                                 assertion: Document => Assertion): Future[Assertion] = {
@@ -91,5 +95,20 @@ class JsonLdSemanticExtensionsParseTest extends AsyncFunSuite with Matchers {
     extension.graph
       .scalarByProperty("http://a.ml/vocab#pagination")
       .head shouldBe 5
+  }
+
+  private def lookupNestedTagType(document: Document): Assertion = {
+    val extension =
+      document.encodes.asInstanceOf[Api].endPoints.head.operations.head.responses.head
+
+    extension.graph.containsProperty("http://a.ml/vocab#tag") shouldBe true
+    extension.graph
+      .getObjectByProperty("http://a.ml/vocab#tag")
+      .head
+      .graph
+      .getObjectByProperty("http://a.ml/vocab#Type")
+      .head
+      .graph
+      .containsProperty("http://a.ml/vocab#TagTypeValue") shouldBe true
   }
 }

--- a/amf-cli/shared/src/test/scala/amf/semantic/JsonLdSemanticExtensionsRenderTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/semantic/JsonLdSemanticExtensionsRenderTest.scala
@@ -83,6 +83,16 @@ class JsonLdSemanticExtensionsRenderTest extends FunSuiteCycleTests {
     }
   }
 
+  test("Render flattened nested object semantic extensions to JSON-LD in a RAML 1.0 spec") {
+    getConfig("nested-object-dialect.yaml", RAMLConfiguration.RAML10()).flatMap { config =>
+      cycle("api-nested-object.raml",
+            golden = "instance-nested-object.raml.jsonld",
+            Raml10YamlHint,
+            AmfJsonHint,
+            amfConfig = Some(config))
+    }
+  }
+
   /** Method for transforming parsed unit. Override if necessary. */
   override def transform(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): BaseUnit = {
     APIConfiguration.fromSpec(unit.sourceSpec.get).baseUnitClient().transform(unit).baseUnit

--- a/amf-cli/shared/src/test/scala/amf/semantic/SemanticExtensionDuplicateIdTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/semantic/SemanticExtensionDuplicateIdTest.scala
@@ -1,0 +1,81 @@
+package amf.semantic
+
+import amf.apicontract.client.scala.AsyncAPIConfiguration
+import amf.apicontract.client.scala.{AMFConfiguration, APIConfiguration, OASConfiguration, RAMLConfiguration}
+import amf.core.client.scala.config.RenderOptions
+import amf.core.client.scala.errorhandling.UnhandledErrorHandler
+import amf.core.client.scala.model.document.BaseUnit
+import amf.core.client.scala.model.domain.{AmfObject, DomainElement}
+import amf.core.client.scala.traversal.iterator.{AmfElementStrategy, InstanceCollector}
+import org.mulesoft.common.collections.FilterType
+import org.scalatest.{Assertion, AsyncFunSuite, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait DuplicateIdTest extends Matchers {
+
+  def checkDuplicateIds(unit: BaseUnit): Assertion = lookForDuplicates(unit) shouldBe empty
+
+  private def lookForDuplicates(unit: BaseUnit): Set[String] = {
+    val idMap: Map[String, List[AmfObject]] = buildIdMap(unit)
+    idsWithMoreThanOneAssociatedElement(idMap)
+  }
+
+  private def buildIdMap(unit: BaseUnit) = {
+    val idMap = unit
+      .iterator(visited = InstanceCollector())
+      .toSeq
+      .filterType[AmfObject]
+      .foldLeft(Map[String, List[AmfObject]]()) { (acc, curr) =>
+        acc + (curr.id -> acc.get(curr.id).map(x => x ++ List(curr)).getOrElse(List(curr)))
+      }
+    idMap
+  }
+
+  private def idsWithMoreThanOneAssociatedElement(idMap: Map[String, List[AmfObject]]) = {
+    idMap.filter {
+      case (_: String, value: List[AmfObject]) => value.size > 1
+    }.keySet
+  }
+}
+
+class SemanticExtensionDuplicateIdTest extends AsyncFunSuite with Matchers with DuplicateIdTest {
+
+  override implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  val basePath: String = "amf-cli/shared/src/test/resources/semantic/"
+
+  test("Raml10 - Nested object semantic extensions don't have duplicate ids") {
+    check("api-nested-object.raml", RAMLConfiguration.RAML10())
+  }
+
+  test("Oas20 - Nested object semantic extensions don't have duplicate ids") {
+    check("api-nested-object.oas20.yaml", OASConfiguration.OAS20())
+  }
+
+  test("Oas30 - Nested object semantic extensions don't have duplicate ids") {
+    check("api-nested-object.oas30.yaml", OASConfiguration.OAS30())
+  }
+
+  test("Async20 - Nested object semantic extensions don't have duplicate ids") {
+    check("api-nested-object.async.yaml", AsyncAPIConfiguration.Async20())
+  }
+
+  private def check(apiPath: String, baseConfig: AMFConfiguration): Future[Assertion] = {
+    getConfig("nested-object-dialect.yaml", baseConfig).flatMap { config =>
+      val client = config.baseUnitClient()
+      client.parse(s"file://${basePath}/${apiPath}").map { parseResult =>
+        val transformed = client.transform(parseResult.baseUnit).baseUnit
+        checkDuplicateIds(transformed)
+      }
+    }
+  }
+
+  private def getConfig(dialect: String,
+                        baseConfig: AMFConfiguration = APIConfiguration.API()): Future[AMFConfiguration] = {
+    baseConfig
+      .withRenderOptions(RenderOptions().withPrettyPrint.withCompactUris)
+      .withErrorHandlerProvider(() => UnhandledErrorHandler)
+      .withDialect(s"file://$basePath" + dialect)
+  }
+}


### PR DESCRIPTION
- Test: golden changes due to componentId change in DomainExtensions
- APIMF-3519 (test): added tests for duplicate ids in semantic extensions with nested objects

Related to: https://github.com/aml-org/amf-aml/pull/427
