### PR TITLE
APIMF-3540: include Raml 10 as reference parse plugin in async config

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/AMFConfiguration.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/AMFConfiguration.scala
@@ -29,6 +29,7 @@ import amf.core.client.scala.config._
 import amf.core.client.scala.errorhandling.ErrorHandlerProvider
 import amf.core.client.scala.execution.ExecutionEnvironment
 import amf.core.client.scala.model.domain.AnnotationGraphLoader
+import amf.core.client.scala.parse.AMFParsePlugin
 import amf.core.client.scala.resource.ResourceLoader
 import amf.core.client.scala.transform.TransformationPipeline
 import amf.core.internal.metamodel.ModelDefaultBuilder
@@ -253,6 +254,7 @@ object AsyncAPIConfiguration extends APIConfigurationBuilder {
           PayloadValidationPlugin(ASYNC20)
         )
       )
+      .withReferenceParsePlugin(Raml10ParsePlugin)
       .withValidationProfile(Async20ValidationProfile, Async20EffectiveValidations)
       .withTransformationPipelines(
         List(
@@ -343,6 +345,9 @@ class AMFConfiguration private[amf] (override private[amf] val resolvers: AMFRes
 
   override def withPlugin(amfPlugin: AMFPlugin[_]): AMFConfiguration =
     super._withPlugin(amfPlugin)
+
+  override def withReferenceParsePlugin(amfPlugin: AMFParsePlugin): AMFConfiguration =
+    super._withReferenceParsePlugin(amfPlugin)
 
   override def withPlugins(plugins: List[AMFPlugin[_]]): AMFConfiguration =
     super._withPlugins(plugins)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/plugins/ApiContractFallbackPlugin.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/plugins/ApiContractFallbackPlugin.scala
@@ -53,7 +53,7 @@ case class ApiContractFallbackPlugin(strict: Boolean = true, skipWarnings: Boole
     private def throwUserFriendlyWarnings(document: Root, ctx: ParserContext) = {
       if (isRoot) ctx.eh.warning(CouldntGuessRoot, "", None, s"Couldn't guess spec for root file", None, Some(document.location))
       else if (!skipWarnings){
-        pluginThatMatches(document, ctx.config.sortedParsePlugins).foreach { spec =>
+        pluginThatMatches(document, ctx.config.sortedReferenceParsePlugins).foreach { spec =>
           ctx.eh.warning(CantReferenceSpecInFileTree, "", None, s"Document identified as ${spec.id} is of different spec from root", None, Some(document.location))
         }
       }

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-without-schema-format.yaml
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-without-schema-format.yaml
@@ -1,0 +1,10 @@
+asyncapi: '2.0.0'
+info:
+  title: AsyncAPI_8733879276737
+  version: '1.0.0'
+channels:
+  /course:
+    subscribe:
+      message:
+        payload:
+          $ref: external-data-type.raml

--- a/amf-cli/shared/src/test/scala/amf/validation/UniquePlatformReportGenTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/UniquePlatformReportGenTest.scala
@@ -124,7 +124,9 @@ trait ValidModelTest extends MultiPlatformReportGenTest {
   override val basePath: String    = "file://amf-cli/shared/src/test/resources/validations/"
   override val reportsPath: String = "file://amf-cli/shared/src/test/resources/validations/reports/"
 
-  protected def checkValid(api: String, profile: ProfileName = Raml10Profile): Future[Assertion] =
-    super.validate(api, None, profile, None)
+  protected def checkValid(api: String,
+                           profile: ProfileName = Raml10Profile,
+                           configOverride: Option[AMFConfiguration] = None): Future[Assertion] =
+    super.validate(api, None, profile, None, configOverride = configOverride)
 
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/ValidAsyncModelParserTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/ValidAsyncModelParserTest.scala
@@ -1,5 +1,6 @@
 package amf.validation
 
+import amf.apicontract.client.scala.AsyncAPIConfiguration
 import amf.core.client.common.validation.Async20Profile
 import amf.core.internal.remote.{Async20YamlHint, Hint}
 
@@ -103,6 +104,16 @@ class ValidAsyncModelParserTest extends ValidModelTest {
 
   test("Referencing raml content with $ref - type defined in external json") {
     checkValid("raml-data-type-references/ref-external-json.yaml", Async20Profile)
+  }
+
+  test("Referencing raml content with $ref without specifying format - async config") {
+    checkValid("raml-data-type-references/ref-without-schema-format.yaml",
+               Async20Profile,
+               Some(AsyncAPIConfiguration.Async20()))
+  }
+
+  test("Referencing raml content with $ref without specifying format - composite config") {
+    checkValid("raml-data-type-references/ref-without-schema-format.yaml", Async20Profile)
   }
 
   override val basePath: String = "file://amf-cli/shared/src/test/resources/validations/async20/"

--- a/amf-grpc/shared/src/main/scala/amf/grpc/client/scala/GRPCConfiguration.scala
+++ b/amf-grpc/shared/src/main/scala/amf/grpc/client/scala/GRPCConfiguration.scala
@@ -2,8 +2,8 @@ package amf.grpc.client.scala
 
 import amf.antlr.internal.plugins.syntax.{AntlrSyntaxParsePlugin, AntlrSyntaxRenderPlugin}
 import amf.apicontract.client.scala.{AMFConfiguration, APIConfigurationBuilder}
-import amf.grpc.plugins.parse.GrpcParsePlugin
-import amf.grpc.plugins.render.GrpcRenderPlugin
+import amf.grpc.internal.plugins.parse.GrpcParsePlugin
+import amf.grpc.internal.plugins.render.GrpcRenderPlugin
 
 object GRPCConfiguration extends APIConfigurationBuilder {
   def GRPC(): AMFConfiguration =

--- a/amf-grpc/shared/src/main/scala/amf/grpc/internal/plugins/parse/GrpcParsePlugin.scala
+++ b/amf-grpc/shared/src/main/scala/amf/grpc/internal/plugins/parse/GrpcParsePlugin.scala
@@ -1,4 +1,4 @@
-package amf.grpc.plugins.parse
+package amf.grpc.internal.plugins.parse
 
 import amf.antlr.client.scala.parse.document.AntlrParsedDocument
 import amf.apicontract.internal.plugins.ApiParsePlugin

--- a/amf-grpc/shared/src/main/scala/amf/grpc/internal/plugins/parse/GrpcReferenceHandler.scala
+++ b/amf-grpc/shared/src/main/scala/amf/grpc/internal/plugins/parse/GrpcReferenceHandler.scala
@@ -1,4 +1,4 @@
-package amf.grpc.plugins.parse
+package amf.grpc.internal.plugins.parse
 
 import amf.antlr.client.scala.parse.document.AntlrParsedDocument
 import amf.core.client.scala.parse.document._

--- a/amf-grpc/shared/src/main/scala/amf/grpc/internal/plugins/render/GrpcRenderPlugin.scala
+++ b/amf-grpc/shared/src/main/scala/amf/grpc/internal/plugins/render/GrpcRenderPlugin.scala
@@ -1,4 +1,4 @@
-package amf.grpc.plugins.render
+package amf.grpc.internal.plugins.render
 
 import amf.core.client.common.{NormalPriority, PluginPriority}
 import amf.core.client.scala.model.document.BaseUnit

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/ShapesConfiguration.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/ShapesConfiguration.scala
@@ -10,6 +10,7 @@ import amf.core.client.scala.config._
 import amf.core.client.scala.errorhandling.{DefaultErrorHandlerProvider, ErrorHandlerProvider}
 import amf.core.client.scala.execution.ExecutionEnvironment
 import amf.core.client.scala.model.domain.AnnotationGraphLoader
+import amf.core.client.scala.parse.AMFParsePlugin
 import amf.core.client.scala.resource.ResourceLoader
 import amf.core.client.scala.transform.TransformationPipeline
 import amf.core.internal.metamodel.ModelDefaultBuilder
@@ -95,6 +96,9 @@ class ShapesConfiguration private[amf] (override private[amf] val resolvers: AMF
 
   override def withPlugin(amfPlugin: AMFPlugin[_]): ShapesConfiguration =
     super._withPlugin(amfPlugin)
+
+  override def withReferenceParsePlugin(plugin: AMFParsePlugin): ShapesConfiguration =
+    super._withReferenceParsePlugin(plugin)
 
   override def withPlugins(plugins: List[AMFPlugin[_]]): ShapesConfiguration =
     super._withPlugins(plugins)


### PR DESCRIPTION
Defines new list of reference parse plugins in PluginsRegistry.
Improvements over APIMF-3540 branch:
 - there is no direct relation between parse plugins for handling references: this is important for aml use case of dialect instances parse plugins that use other parse plugins depending on the state of the config.

Drawbacks:
- The parse plugins used to handle references is now configured in 2 different places (AMFParsePlugin::validSpecsToReference, and plugins registered under referenceParsePlugins). This however is made very clear in the AMFCompiler::getDomainPluginFor.
