### PR TITLE
APIMF-3573: removed semantic extension flattening stage from compatibility pipelines

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/AmfEditingPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/AmfEditingPipeline.scala
@@ -32,7 +32,7 @@ class AmfEditingPipeline private[amf] (urlShortening: Boolean = true, override v
       new ResponseExamplesResolutionStage(),
       new PayloadAndParameterResolutionStage(profileName),
       new AnnotationRemovalStage(),
-      SemanticExtensionFlatteningStage
+      new SemanticExtensionFlatteningStage
     ) ++ url :+ SourceInformationStage // source info stage must be invoked after url shortening
   }
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/AmfTransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/AmfTransformationPipeline.scala
@@ -38,7 +38,7 @@ class AmfTransformationPipeline private[amf] (override val name: String) extends
       new CleanReferencesStage(),
       new DeclarationsRemovalStage(),
       new AnnotationRemovalStage(),
-      SemanticExtensionFlatteningStage,
+      new SemanticExtensionFlatteningStage,
       SourceInformationStage
     )
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Async20EditingPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Async20EditingPipeline.scala
@@ -40,7 +40,7 @@ class Async20EditingPipeline private (urlShortening: Boolean = true, override va
       new ServerVariableExampleResolutionStage(),
       new PathDescriptionNormalizationStage(profileName, keepEditingInfo = true),
       new AnnotationRemovalStage(),
-      SemanticExtensionFlatteningStage
+      new SemanticExtensionFlatteningStage
     ) ++ url :+ SourceInformationStage
 }
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Async20TransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Async20TransformationPipeline.scala
@@ -40,7 +40,7 @@ class Async20TransformationPipeline private (override val name: String) extends 
       new CleanReferencesStage(),
       new DeclarationsRemovalStage(),
       new AnnotationRemovalStage(),
-      SemanticExtensionFlatteningStage,
+      new SemanticExtensionFlatteningStage,
       SourceInformationStage
     )
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ValidationTransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ValidationTransformationPipeline.scala
@@ -26,7 +26,7 @@ class ValidationTransformationPipeline private[amf] (profile: ProfileName,
       new MediaTypeResolutionStage(profile, isValidation = true),
       new ResponseExamplesResolutionStage(),
       new PayloadAndParameterResolutionStage(profile),
-      SemanticExtensionFlatteningStage,
+      new SemanticExtensionFlatteningStage,
       SourceInformationStage,
       new AnnotationRemovalStage(),
     )

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas20CompatibilityPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas20CompatibilityPipeline.scala
@@ -1,18 +1,23 @@
 package amf.apicontract.internal.transformation.compatibility
 
 import amf.apicontract.internal.transformation.Oas20TransformationPipeline
+import amf.apicontract.internal.transformation.compatibility.common.SemanticFlattenFilter
 import amf.apicontract.internal.transformation.compatibility.oas._
-import amf.apicontract.internal.transformation.compatibility.oas3.{CleanRepeatedOperationIds, SetValidConsumesForFileParam}
+import amf.apicontract.internal.transformation.compatibility.oas3.{
+  CleanRepeatedOperationIds,
+  SetValidConsumesForFileParam
+}
 import amf.core.client.common.transform._
 import amf.core.client.scala.transform.{TransformationPipeline, TransformationStep}
-import amf.core.internal.remote.Oas20
 
-class Oas20CompatibilityPipeline private (override val name: String) extends TransformationPipeline() {
+class Oas20CompatibilityPipeline private (override val name: String)
+    extends TransformationPipeline()
+    with SemanticFlattenFilter {
 
-  private val resolution = Oas20TransformationPipeline()
+  private val baseSteps: Seq[TransformationStep] = filterOutSemanticStage(Oas20TransformationPipeline().steps)
 
   override def steps: Seq[TransformationStep] =
-    resolution.steps ++ Seq(
+    baseSteps ++ Seq(
       new LowercaseSchemes(),
       new Oas20SecuritySettingsMapper(),
       new MandatoryDocumentationUrl(),
@@ -24,7 +29,6 @@ class Oas20CompatibilityPipeline private (override val name: String) extends Tra
       new CleanRepeatedOperationIds(),
       new SetValidConsumesForFileParam()
     )
-
 }
 
 object Oas20CompatibilityPipeline {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas3CompatibilityPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas3CompatibilityPipeline.scala
@@ -1,17 +1,19 @@
 package amf.apicontract.internal.transformation.compatibility
 
 import amf.apicontract.internal.transformation.Oas30TransformationPipeline
+import amf.apicontract.internal.transformation.compatibility.common.SemanticFlattenFilter
 import amf.apicontract.internal.transformation.compatibility.oas3._
 import amf.core.client.common.transform._
 import amf.core.client.scala.transform.{TransformationPipeline, TransformationStep}
-import amf.core.internal.remote.Oas30
 
-class Oas3CompatibilityPipeline private (override val name: String) extends TransformationPipeline() {
+class Oas3CompatibilityPipeline private (override val name: String)
+    extends TransformationPipeline()
+    with SemanticFlattenFilter {
 
-  val resolution = Oas30TransformationPipeline()
+  private val baseSteps: Seq[TransformationStep] = filterOutSemanticStage(Oas30TransformationPipeline().steps)
 
   override def steps: Seq[TransformationStep] =
-    resolution.steps ++ Seq(
+    baseSteps ++ Seq(
       new CleanNullSecurity(),
       new CleanSchemes(),
       new MandatoryDocumentationUrl(),

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/common/SemanticFlattenFilter.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/common/SemanticFlattenFilter.scala
@@ -1,0 +1,14 @@
+package amf.apicontract.internal.transformation.compatibility.common
+
+import amf.aml.internal.transform.steps.SemanticExtensionFlatteningStage
+import amf.core.client.scala.transform.TransformationStep
+
+trait SemanticFlattenFilter {
+
+  protected def filterOutSemanticStage(steps: Seq[TransformationStep]): Seq[TransformationStep] = {
+    steps.collect {
+      case _: SemanticExtensionFlatteningStage => None
+      case other                               => Some(other)
+    }.flatten
+  }
+}

--- a/amf-cli/shared/src/test/resources/semantic/compatibility/api.oas20.json
+++ b/amf-cli/shared/src/test/resources/semantic/compatibility/api.oas20.json
@@ -1,0 +1,9 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Something",
+    "version": "1.0"
+  },
+  "x-project": "My OAS Test Project",
+  "paths": {}
+}

--- a/amf-cli/shared/src/test/resources/semantic/compatibility/api.oas30.json
+++ b/amf-cli/shared/src/test/resources/semantic/compatibility/api.oas30.json
@@ -1,0 +1,9 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Something",
+    "version": "1.0"
+  },
+  "x-project": "My OAS Test Project",
+  "paths": {}
+}

--- a/amf-cli/shared/src/test/resources/semantic/compatibility/api.raml
+++ b/amf-cli/shared/src/test/resources/semantic/compatibility/api.raml
@@ -1,0 +1,3 @@
+#%RAML 1.0
+title: Something
+(project): My Test Project

--- a/amf-cli/shared/src/test/resources/semantic/compatibility/dialect.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/compatibility/dialect.yaml
@@ -1,0 +1,19 @@
+#%Dialect 1.0
+dialect: Pagination Test
+version: 1.0
+
+external:
+  apiContract: http://a.ml/vocabularies/apiContract#
+  aml: http://a.ml/vocab#
+
+documents: {}
+
+annotationMappings:
+  ProjectAnnotation:
+    domain: apiContract.WebAPI
+    propertyTerm: aml.project
+    range: string
+    mandatory: true
+
+extensions:
+  project: ProjectAnnotation

--- a/amf-cli/shared/src/test/scala/amf/semantic/SemanticCompatibilitySettingsTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/semantic/SemanticCompatibilitySettingsTest.scala
@@ -1,0 +1,65 @@
+package amf.semantic
+
+import amf.apicontract.client.scala.model.domain.api.WebApi
+import amf.apicontract.client.scala.{AMFConfiguration, APIConfiguration, OASConfiguration, RAMLConfiguration}
+import amf.core.client.common.transform.PipelineId
+import amf.core.client.scala.config.RenderOptions
+import amf.core.client.scala.errorhandling.UnhandledErrorHandler
+import amf.core.client.scala.model.document.Document
+import org.scalatest.{Assertion, AsyncFunSuite, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SemanticCompatibilitySettingsTest extends AsyncFunSuite with Matchers {
+
+  private val basePath                                     = "amf-cli/shared/src/test/resources/semantic/compatibility/"
+  override implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  test("Conversion to RAML 1.0 from OAS 2.0 shouldn't flatten semantic extensions") {
+    run("api.oas20.json", RAMLConfiguration.RAML10())
+  }
+
+  test("Conversion to RAML 1.0 from OAS 3.0 shouldn't flatten semantic extensions") {
+    run("api.oas30.json", RAMLConfiguration.RAML10())
+  }
+
+  test("Conversion to OAS 2.0 shouldn't flatten semantic extensions") {
+    run("api.raml", OASConfiguration.OAS20())
+  }
+
+  test("Conversion to OAS 3.0 shouldn't flatten semantic extensions") {
+    run("api.raml", OASConfiguration.OAS30())
+  }
+
+  private def run(path: String, compatConfig: AMFConfiguration): Future[Assertion] = {
+    getConfig("dialect.yaml")
+      .flatMap { config =>
+        config.baseUnitClient().parseDocument(s"file://${basePath}${path}")
+      }
+      .map { result =>
+        result.conforms shouldBe true
+        hasSemanticExtensionInCustom(result.document) shouldBe true
+        val client      = compatConfig.baseUnitClient()
+        val transformed = client.transform(result.baseUnit, PipelineId.Compatibility)
+        transformed.conforms shouldBe true
+        hasSemanticExtensionInCustom(transformed.baseUnit.asInstanceOf[Document]) shouldBe true
+        hasFlattenedSemanticExtension(transformed.baseUnit.asInstanceOf[Document]) shouldBe false
+      }
+  }
+
+  private def getConfig(dialect: String,
+                        baseConfig: AMFConfiguration = APIConfiguration.API()): Future[AMFConfiguration] = {
+    baseConfig
+      .withRenderOptions(RenderOptions().withPrettyPrint.withCompactUris)
+      .withErrorHandlerProvider(() => UnhandledErrorHandler)
+      .withDialect(s"file://$basePath" + dialect)
+  }
+
+  private def hasFlattenedSemanticExtension(doc: Document): Boolean = {
+    doc.encodes.graph.containsProperty("http://a.ml/vocab#project")
+  }
+
+  private def hasSemanticExtensionInCustom(doc: Document): Boolean = {
+    doc.encodes.customDomainProperties.head.graph.containsProperty("http://a.ml/vocab#project")
+  }
+}


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-aml/pull/443