### PR TITLE
APIMF-3590: added tests to check unresolved references in semantic extensions

### DIFF
--- a/amf-cli/shared/src/test/resources/semantic/validation/object-extension.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/validation/object-extension.yaml
@@ -1,0 +1,42 @@
+#%Dialect 1.0
+dialect: Repository object extensions
+version: 1.0
+
+external:
+  aml: http://a.ml/vocab#
+  apiContract: http://a.ml/vocabularies/apiContract#
+
+documents:
+  root:
+    declares: {}
+
+annotationMappings:
+  MaintainerAnnotationMapping:
+    domain: apiContract.API
+    propertyTerm: aml.maintainer
+    range:  MaintainerGroup
+
+nodeMappings:
+
+  MaintainerGroup:
+    classTerm: aml.MaintainerGroup
+    mapping:
+      users:
+        range: Maintainer
+        allowMultiple: true
+        mandatory: true
+
+  Maintainer:
+    classTerm: aml.Maintainer
+    mapping:
+      username:
+        propertyTerm: aml.username
+        range: string
+        mandatory: true
+      contributor:
+        propertyTerm: aml.contributor
+        range: boolean
+        mandatory: true
+
+extensions:
+  maintainer: MaintainerAnnotationMapping

--- a/amf-cli/shared/src/test/resources/semantic/validation/reports/unresolved-link-api.oas30.report.js
+++ b/amf-cli/shared/src/test/resources/semantic/validation/reports/unresolved-link-api.oas30.report.js
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/semantic/validation/unresolved-link-api.oas30.yaml
+Profile: 
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/core#unresolved-reference
+  Message: Unresolved reference 'something'
+  Severity: Violation
+  Target: nonImportantId/x-maintainer/users/0
+  Property: 
+  Range: [(7,9)-(7,18)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/unresolved-link-api.oas30.yaml

--- a/amf-cli/shared/src/test/resources/semantic/validation/reports/unresolved-link-api.oas30.report.jvm
+++ b/amf-cli/shared/src/test/resources/semantic/validation/reports/unresolved-link-api.oas30.report.jvm
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/semantic/validation/unresolved-link-api.oas30.yaml
+Profile: 
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/core#unresolved-reference
+  Message: Unresolved reference 'something'
+  Severity: Violation
+  Target: nonImportantId/x-maintainer/users/0
+  Property: 
+  Range: [(7,9)-(7,18)]
+  Location: file://amf-cli/shared/src/test/resources/semantic/validation/unresolved-link-api.oas30.yaml

--- a/amf-cli/shared/src/test/resources/semantic/validation/unresolved-link-api.oas30.yaml
+++ b/amf-cli/shared/src/test/resources/semantic/validation/unresolved-link-api.oas30.yaml
@@ -1,0 +1,7 @@
+openapi: 3.0.0
+info:
+  title: Something
+  version: '1.0'
+paths: {}
+x-maintainer:
+  users: something

--- a/amf-cli/shared/src/test/scala/amf/semantic/SemanticExtensionValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/semantic/SemanticExtensionValidationTest.scala
@@ -8,7 +8,7 @@ import amf.apicontract.client.scala.{
   RAMLConfiguration
 }
 import amf.core.client.scala.config.RenderOptions
-import amf.core.client.scala.errorhandling.UnhandledErrorHandler
+import amf.core.client.scala.errorhandling.{DefaultErrorHandler, UnhandledErrorHandler}
 import amf.core.internal.remote.{AmfJsonHint, Async20YamlHint, Hint, Oas20YamlHint, Oas30YamlHint, Raml10YamlHint}
 import amf.validation.{MultiPlatformReportGenTest, UniquePlatformReportGenTest}
 
@@ -53,6 +53,17 @@ class SemanticExtensionValidationTest extends MultiPlatformReportGenTest {
                Some("api.async.report"),
                overridedHint = Some(Async20YamlHint),
                configOverride = Some(config))
+    }
+  }
+
+  test("Validate unresolved links in SemEx") {
+    getConfig("object-extension.yaml", OASConfiguration.OAS30()).flatMap { config =>
+      validate(
+        "unresolved-link-api.oas30.yaml",
+        Some("unresolved-link-api.oas30.report"),
+        overridedHint = Some(Oas30YamlHint),
+        configOverride = Some(config.withErrorHandlerProvider(() => DefaultErrorHandler()))
+      )
     }
   }
 


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-aml/pull/449
