### PR TITLE
APIMF-3574: Add warning for duplicate parameters

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/Parameters.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/Parameters.scala
@@ -33,6 +33,14 @@ case class Parameters(query: Seq[Parameter] = Nil,
     )
   }
 
+  def findDuplicatesIn(inner: Parameters): List[Parameter] = {
+    findDuplicateParametersBetween(query, inner.query) ++
+      findDuplicateParametersBetween(path, inner.path) ++
+      findDuplicateParametersBetween(header, inner.header) ++
+      findDuplicateParametersBetween(cookie, inner.cookie) ++
+      findDuplicateParametersBetween(baseUri08, inner.baseUri08)
+  }
+
   private def mergeParams(global: Seq[Parameter], inner: Seq[Parameter]): Seq[Parameter] = {
     val globalMap = global.map(p => p.name.value() -> p).toMap
     val innerMap  = inner.map(p => p.name.value()  -> p).toMap
@@ -50,6 +58,14 @@ case class Parameters(query: Seq[Parameter] = Nil,
   }
 
   private def addPayloads(global: Seq[Payload], inner: Seq[Payload]): Seq[Payload] = global ++ inner
+
+  private def findDuplicateParametersBetween(global: Seq[Parameter], inner: Seq[Parameter]): List[Parameter] = {
+    val globalMap = global.map(p => p.name.value() -> p).toMap
+    inner.foldLeft(List[Parameter]())((list, parameter) => {
+      val parameterIsDuplicated = globalMap.contains(parameter.name.value())
+      if (parameterIsDuplicated) parameter :: list else list
+    })
+  }
 
   def nonEmpty: Boolean = query.nonEmpty || path.nonEmpty || header.nonEmpty || body.nonEmpty || cookie.nonEmpty
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/definitions/ResolutionSideValidations.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/definitions/ResolutionSideValidations.scala
@@ -62,9 +62,15 @@ object ResolutionSideValidations extends Validations {
     "When schema is undefined, 'examples' facet is invalid as no content is returned as part of the response"
   )
 
+  val DuplicatedParameterWarning = validation(
+    "duplicated-parameter-warning",
+    "An operation's parameter with the same name and binding as one from the endpoint was found"
+  )
+
   override val levels: Map[String, Map[ProfileName, String]] = Map(
     InvalidTypeInheritanceWarningSpecification.id -> all(WARNING),
-    InvalidConsumesWithFileParameter.id -> all(WARNING)
+    InvalidConsumesWithFileParameter.id -> all(WARNING),
+    DuplicatedParameterWarning.id -> all(WARNING)
   )
 
   override val validations: List[ValidationSpecification] = List(
@@ -75,6 +81,7 @@ object ResolutionSideValidations extends Validations {
     UnsupportedPipeline,
     InvalidConsumesWithFileParameter,
     ExamplesWithInvalidMimeType,
-    ExamplesWithNoSchemaDefined
+    ExamplesWithNoSchemaDefined,
+    DuplicatedParameterWarning
   )
 }

--- a/amf-cli/shared/src/test/resources/validations/duplicate-parameters/endpoint-parameter-duplicate-in-operation.json
+++ b/amf-cli/shared/src/test/resources/validations/duplicate-parameters/endpoint-parameter-duplicate-in-operation.json
@@ -1,0 +1,32 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "0.0.1",
+    "title": "api title"
+  },
+  "paths": {
+    "/somePath": {
+      "parameters": [
+        {
+          "name" : "queryParam",
+          "in" : "query",
+          "type" : "string"
+        }
+      ],
+      "get": {
+        "parameters": [
+          {
+            "name" : "queryParam",
+            "in" : "query",
+            "type" : "string"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/amf-cli/shared/src/test/resources/validations/reports/resolution/endpoint-parameter-duplicate-in-operation.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/resolution/endpoint-parameter-duplicate-in-operation.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/validations/duplicate-parameters/endpoint-parameter-duplicate-in-operation.json
+Profile: OAS 2.0
+Conforms: true
+Number of results: 1
+
+Level: Warning
+
+- Constraint: http://a.ml/vocabularies/amf/resolution#duplicated-parameter-warning
+  Message: An operation's parameter with the same name: queryParam and binding: query as one from the endpoint was found
+  Severity: Warning
+  Target: file://amf-cli/shared/src/test/resources/validations/duplicate-parameters/endpoint-parameter-duplicate-in-operation.json#/web-api/endpoint/%2FsomePath/supportedOperation/get/expects/request/parameter/parameter/query/queryParam
+  Property:
+  Range: [(18,10)-(22,11)]
+  Location: file://amf-cli/shared/src/test/resources/validations/duplicate-parameters/endpoint-parameter-duplicate-in-operation.json

--- a/amf-cli/shared/src/test/scala/amf/validation/ResolutionReportTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/ResolutionReportTest.scala
@@ -177,5 +177,13 @@ class ResolutionReportTest extends ResolutionForUniquePlatformReportTest {
     checkReport("/same-type-inheritance-recursion.raml", Some("same-type-inheritance-recursion.report"))
   }
 
+  test("Duplicated parameter warning") {
+    checkReport(
+      "/duplicate-parameters/endpoint-parameter-duplicate-in-operation.json",
+      Some("endpoint-parameter-duplicate-in-operation.report"),
+      profile = Oas20Profile
+    )
+  }
+
   override val hint: Hint = Raml10YamlHint
 }


### PR DESCRIPTION
- In transformation when an operation's parameter with the same name and binding as one from the endPoint is found, a warning is added.