### PR TITLE
publish 5.0.3 RC.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,7 @@ pipeline {
         anyOf {
           branch 'master'
           branch 'develop'
+          branch 'release/*'
         }
       }
       steps {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/WebApiDeclarations.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/WebApiDeclarations.scala
@@ -638,6 +638,7 @@ object OasWebApiDeclarations {
     declarations.traits = d.traits
     declarations.securitySchemes = d.securitySchemes
     declarations.responses = d.responses
+    declarations.annotations = d.annotations // FOR OAS -> RAML CONVERSION
     declarations // add withs methods?
   }
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/emitter/context/OasSpecEmitterContext.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/emitter/context/OasSpecEmitterContext.scala
@@ -21,7 +21,12 @@ import amf.core.internal.plugins.render.RenderConfiguration
 import amf.core.internal.remote.{Oas20, Oas30, Spec}
 import amf.core.internal.render.SpecOrdering
 import amf.core.internal.render.emitters._
-import amf.shapes.internal.spec.common.emitter.annotations.{FacetsInstanceEmitter, OasFacetsInstanceEmitter}
+import amf.shapes.internal.spec.common.emitter.annotations.{
+  AnnotationEmitter,
+  FacetsInstanceEmitter,
+  OasAnnotationEmitter,
+  OasFacetsInstanceEmitter
+}
 import amf.shapes.internal.spec.common.emitter._
 import amf.shapes.internal.spec.common.{OAS20SchemaVersion, OAS30SchemaVersion, SchemaPosition, SchemaVersion}
 import amf.shapes.internal.spec.contexts.emitter.oas.{CompactableEmissionContext, OasCompactEmitterFactory}

--- a/amf-apicontract.versions
+++ b/amf-apicontract.versions
@@ -1,3 +1,3 @@
-amf.apicontract=5.0.3-RC.0
+amf.apicontract=5.0.3-RC.1
 amf.aml=6.0.3-RC.0
 amf.model=3.2.0

--- a/amf-apicontract.versions
+++ b/amf-apicontract.versions
@@ -1,3 +1,3 @@
-amf.apicontract=5.1.0-SNAPSHOT
-amf.aml=6.1.0-SNAPSHOT
+amf.apicontract=5.0.3-RC.0
+amf.aml=6.0.3-RC.0
 amf.model=3.2.0

--- a/amf-cli/shared/src/test/resources/compatibility/oas20/tags-nested-annotations.json
+++ b/amf-cli/shared/src/test/resources/compatibility/oas20/tags-nested-annotations.json
@@ -1,0 +1,18 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "BulkSMS JSON",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "Message",
+      "x-displayName": "Messages"
+    },
+    {
+      "name": "Profile",
+      "x-displayName": "Profile"
+    }
+  ],
+  "paths": {}
+}

--- a/amf-cli/shared/src/test/resources/validations/raml/merge-resourceType.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/merge-resourceType.raml
@@ -1,0 +1,27 @@
+#%RAML 1.0
+title: EWB Api
+version: v1
+
+types:
+  Customer:
+    type: object
+    properties:
+      firstName: string
+    example:
+      firstName: asdf
+
+resourceTypes:
+  collection:
+    post?:
+      body:
+        application/json:
+          type: <<item>>
+
+/customers:
+  type:
+    collection:
+      item: Customer
+  post:
+    body:
+      application/json:
+        type:

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/ShapeCanonizer.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/ShapeCanonizer.scala
@@ -243,8 +243,7 @@ sealed case class ShapeCanonizer()(implicit val context: NormalizationContext) e
             ShapeModel.Description,
             AnyShapeModel.Examples,
             AnyShapeModel.Documentation,
-            AnyShapeModel.Comment,
-            ScalarShapeModel.DataType
+            AnyShapeModel.Comment
           )
         fieldsPresentInSuperType(shape, superType, ignoredFields)
       case _ => false


### PR DESCRIPTION
- APIMF-3646: added annotations to OasDeclarations for a weird round-trip case for annotations that AMF adds
- APIMF-3654: remove datatype field from simple inheritance logic
- Publish 5.0.3-RC.0
- publish 5.0.3-RC.1
