### PR TITLE
non breaking refactors

### DIFF
--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/ShapeHelpers.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/ShapeHelpers.scala
@@ -2,7 +2,7 @@ package amf.shapes.client.scala.model.domain
 
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.domain.{Linkable, RecursiveShape, Shape}
-import amf.core.client.scala.traversal.ModelTraversalRegistry
+import amf.core.client.scala.traversal.{ModelTraversalRegistry, ShapeTraversalRegistry}
 import amf.core.internal.annotations.ExplicitField
 import amf.core.internal.validation.CoreValidations.RecursiveShapeSpecification
 import amf.shapes.internal.annotations.ParsedFromTypeExpression
@@ -32,7 +32,7 @@ trait ShapeHelpers { this: Shape =>
 
   def cloneShape(recursionErrorHandler: Option[AMFErrorHandler],
                  withRecursionBase: Option[String] = None,
-                 traversal: ModelTraversalRegistry = ModelTraversalRegistry(),
+                 traversal: ShapeTraversalRegistry = ShapeTraversalRegistry(),
                  cloneExamples: Boolean = false): this.type = {
     if (traversal.isInCurrentPath(this.id)) {
       buildFixPoint(withRecursionBase, this.name.value(), this, recursionErrorHandler).asInstanceOf[this.type]

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/recursion/RecursionErrorRegister.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/recursion/RecursionErrorRegister.scala
@@ -2,7 +2,7 @@ package amf.shapes.internal.domain.resolution.recursion
 
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.domain.{RecursiveShape, Shape}
-import amf.core.client.scala.traversal.ModelTraversalRegistry
+import amf.core.client.scala.traversal.{ModelTraversalRegistry, ShapeTraversalRegistry}
 import amf.core.internal.validation.CoreValidations.RecursiveShapeSpecification
 
 import scala.collection.mutable.ListBuffer
@@ -19,13 +19,13 @@ class RecursionErrorRegister(errorHandler: AMFErrorHandler) {
   def recursionAndError(root: Shape,
                         base: Option[String],
                         s: Shape,
-                        traversal: ModelTraversalRegistry,
+                        traversal: ShapeTraversalRegistry,
                         criteria: RegisterCriteria = DefaultRegisterCriteria()): RecursiveShape = {
     val recursion = buildRecursion(base, s)
-    recursionError(root, recursion, traversal: ModelTraversalRegistry, Some(root.id), criteria)
+    recursionError(root, recursion, traversal: ShapeTraversalRegistry, Some(root.id), criteria)
   }
 
-  def avoidError(traversal: ModelTraversalRegistry, r: RecursiveShape, checkId: Option[String] = None): Boolean = {
+  def avoidError(traversal: ShapeTraversalRegistry, r: RecursiveShape, checkId: Option[String] = None): Boolean = {
     val recursiveShapeIsAllowListed = traversal.isAllowListed(r.id)
     val fixpointIsAllowListed       = r.fixpoint.option().exists(traversal.isAllowListed)
     val checkIdIsAllowListed        = checkId.exists(traversal.isAllowListed)
@@ -34,7 +34,7 @@ class RecursionErrorRegister(errorHandler: AMFErrorHandler) {
 
   def recursionError(original: Shape,
                      r: RecursiveShape,
-                     traversal: ModelTraversalRegistry,
+                     traversal: ShapeTraversalRegistry,
                      checkId: Option[String] = None,
                      criteria: RegisterCriteria = DefaultRegisterCriteria()): RecursiveShape = {
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/recursion/RecursionErrorRegister.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/recursion/RecursionErrorRegister.scala
@@ -21,6 +21,12 @@ class RecursionErrorRegister(errorHandler: AMFErrorHandler) {
                          checkId: Option[String] = None): Boolean = {
     val recursiveShapeIsAllowListed = traversal.isAllowListed(r.id)
     val fixpointIsAllowListed       = r.fixpoint.option().exists(traversal.isAllowListed)
+    /***
+      * TODO (Refactor needed)
+      * When calling ShapeExpander `checkId` some times gets set to the root shape ID from where the traversal started.
+      * Why do we need to opiotnally check if this root id is allow listed? Doesn't it suffice with checking the
+      * recursive shape ID or its fixpoint?
+      */
     val checkIdIsAllowListed        = checkId.exists(traversal.isAllowListed)
     recursiveShapeIsAllowListed || fixpointIsAllowListed || checkIdIsAllowListed
   }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/ShapeExpander.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/ShapeExpander.scala
@@ -42,7 +42,13 @@ sealed case class ShapeExpander(root: Shape, recursionRegister: RecursionErrorRe
   override def normalizeAction(shape: Shape): Shape = {
     shape match {
       case l: Linkable if l.isLink =>
-        // TODO: Why do we create a recursive shape when we find a linkable? Shouldn't this be subject only to traversals?
+        /***
+          * TODO: (Refactor needed)
+          * Why do we create a recursive shape when we find a linkable? Shouldn't this be subject only to traversals?
+          * The motivation is not explicit in the code. There is for sure some corner case where this case is needed.
+          * After finding the cocrete case please extract this to a function and make explicit the conditions where
+          * this is needed, otherwise delete this code.
+          */
         val recursiveShape = recursionRegister.buildRecursion(Some(root.id), shape)
         recursionRegister.checkRecursionError(root,
                                               recursiveShape,

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/ShapeExpander.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/ShapeExpander.scala
@@ -2,7 +2,7 @@ package amf.shapes.internal.domain.resolution.shape_normalization
 
 import amf.core.client.scala.model.domain._
 import amf.core.client.scala.model.domain.extensions.PropertyShape
-import amf.core.client.scala.traversal.ModelTraversalRegistry
+import amf.core.client.scala.traversal.{ModelTraversalRegistry, ShapeTraversalRegistry}
 import amf.core.internal.annotations.ExplicitField
 import amf.core.internal.metamodel.domain.ShapeModel
 import amf.core.internal.metamodel.domain.extensions.PropertyShapeModel
@@ -11,18 +11,7 @@ import amf.core.internal.validation.CoreValidations.TransformationValidation
 import amf.shapes.internal.domain.metamodel._
 import amf.shapes.internal.domain.resolution.recursion.{LinkableRegisterCriteria, RecursionErrorRegister}
 import amf.shapes.client.scala.model.domain.UnresolvedShape
-import amf.shapes.client.scala.model.domain.{
-  AnyShape,
-  ArrayShape,
-  FileShape,
-  MatrixShape,
-  NilShape,
-  NodeShape,
-  ScalarShape,
-  TupleShape,
-  UnionShape,
-  UnresolvedShape
-}
+import amf.shapes.client.scala.model.domain.{AnyShape, ArrayShape, FileShape, MatrixShape, NilShape, NodeShape, ScalarShape, TupleShape, UnionShape, UnresolvedShape}
 
 private[resolution] object ShapeExpander {
   def apply(s: Shape, context: NormalizationContext, recursionRegister: RecursionErrorRegister): Shape =
@@ -35,8 +24,8 @@ sealed case class ShapeExpander(root: Shape, recursionRegister: RecursionErrorRe
 
   def normalize(): Shape = normalize(root)
 
-  protected val traversal: ModelTraversalRegistry =
-    ModelTraversalRegistry().withAllowedCyclesInstances(Seq(classOf[UnresolvedShape]))
+  protected val traversal: ShapeTraversalRegistry =
+    ShapeTraversalRegistry().withAllowedCyclesInstances(Seq(classOf[UnresolvedShape]))
 
   protected def ensureHasId(shape: Shape): Unit = {
     if (Option(shape.id).isEmpty) {


### PR DESCRIPTION
- Moved avoidError from ModelTraversalRegistry to RecursionErrorRegister
- Split ShapeTraversalRegistry from ModelTraversalRegistry with Shape specific logic
- Refactor: aggregate allowList logic into allow method
- Some refactors:  - Split recursionAndError method into single responsibility method calls  - Rename RegisterCriteria -> ThrowRecursionValidationCriteria (more specific)  - Rename shouldFailIfRecursive -> foundRecursion (does not necessarily fail)  - Rename recursionError -> checkRecursionError (checks if an error should be thrown)
- Add some TODO comments with required refactors
