### PR TITLE
Remove allowCycleClasses from ShapeTraversalRegistry

### DIFF
--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/ShapeExpander.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/ShapeExpander.scala
@@ -23,8 +23,7 @@ sealed case class ShapeExpander(root: Shape, recursionRegister: RecursionErrorRe
 
   def normalize(): Shape = normalize(root)
 
-  protected val traversal: ShapeTraversalRegistry =
-    ShapeTraversalRegistry().withAllowedCyclesInstances(Seq(classOf[UnresolvedShape]))
+  protected val traversal: ShapeTraversalRegistry = ShapeTraversalRegistry()
 
   protected def ensureHasId(shape: Shape): Unit = {
     if (Option(shape.id).isEmpty) {


### PR DESCRIPTION
The motivation for allowCycleClasses is unclear. We don't know what cases are addressed by this logic:
 * The necessity for this logic is not explicit in the code 
 * Removing it does not break any tests
 * Its origin is opaque in Git history (first edit dates back to June 2018 with a big refactor)
 * Running all major API sets without it produce no regressions

Removing this to improve maintainability
