### PR TITLE
WIP: Alternative to wrap transformation and support arrays as root in Dialect Instances

### DIFF
--- a/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/client/scala/JsonLDSchemaBaseUnitClient.scala
+++ b/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/client/scala/JsonLDSchemaBaseUnitClient.scala
@@ -1,0 +1,64 @@
+package amf.jsonldschema.client.scala
+
+import amf.aml.client.scala.AMLConfiguration
+import amf.aml.client.scala.model.document.{Dialect, DialectInstance}
+import amf.aml.client.scala.model.domain.DialectDomainElement
+import amf.core.client.scala.model.domain.AmfArray
+import amf.core.internal.parser.domain.Value
+import amf.jsonldschema.client.scala.model.JsonLdSchemaDocument
+import amf.jsonldschema.internal.scala.{JsonLDDialectWrapper, JsonLDSchemaPayloadWrapper, WrappedDialect}
+import amf.shapes.client.scala.config.SemanticBaseUnitClient
+import amf.shapes.internal.spec.jsonschema.semanticjsonschema.SemanticSchemaParser
+import org.yaml.model.{YDocument, YNode, YSequence}
+import org.yaml.render.JsonRender
+
+import scala.concurrent.Future
+
+class JsonLDSchemaBaseUnitClient private[amf] (override protected val configuration: JsonLDSchemaConfiguration)
+    extends SemanticBaseUnitClient(configuration) {
+
+  def parsePayloadWithDialect(payload: String, dialect: Dialect): Future[JsonLdSchemaDocument] = {
+    val isArray = payload.trim.startsWith("[") // better option is to add a flat ad AML encodes field (at root documents model) to mark as an array. If we need top level array constraints then we need some particular node (redundant against property mapping array constraints
+
+    val content        = JsonLDSchemaPayloadWrapper.wrap(payload, dialect.nameAndVersion())
+    val wrappedDialect = JsonLDDialectWrapper.wrap(dialect, isArray)
+    val client         = AMLConfiguration.predefined().withDialect(wrappedDialect.dialect).baseUnitClient()
+    client
+      .parseContent(content) // lexical info? parse by hand using syaml and initial line and column offset -2?
+      .map(r => {
+        r.baseUnit match {
+          case d: DialectInstance =>
+            JsonLDDialectWrapper.unWrap(wrappedDialect)
+            JsonLdSchemaDocument().withId(d.id).withEncodes(extractRootNode(d, wrappedDialect))
+          case _ => JsonLdSchemaDocument().withId("error")
+        }
+      })
+  }
+
+  def emitPayloadWithDialect(jsonLdSchemaDocument: JsonLdSchemaDocument, dialect: Dialect): String = {
+    val wrappedDialect    = JsonLDDialectWrapper.wrap(dialect, jsonLdSchemaDocument.encodes.length > 1) // what if we have an array of only 1 element?
+    val client            = AMLConfiguration.predefined().withDialect(wrappedDialect.dialect).elementClient()
+    val nodes: Seq[YNode] = jsonLdSchemaDocument.encodes.map(client.renderElement(_, Nil))
+    JsonLDDialectWrapper.unWrap(wrappedDialect)
+    renderRootElements(nodes)
+  }
+
+  private def renderRootElements(nodes: Seq[YNode]) = {
+    JsonRender.render(buildDocument(nodes))
+  }
+
+  private def buildDocument(nodes: Seq[YNode]) = {
+    if (nodes.length < 2) YDocument(nodes.head)
+    else {
+      val value = YSequence(nodes.toArray)
+      YDocument(YNode(value))
+    }
+  }
+  private def extractRootNode(d: DialectInstance, wrappedDialect: WrappedDialect) = {
+    d.encodes.fields.getValueAsOption(wrappedDialect.dataPropertyTerm) match {
+      case Some(Value(obj: DialectDomainElement, _)) => Seq(obj)
+      case Some(Value(arr: AmfArray, _))             => arr.values.collect({ case d: DialectDomainElement => d })
+      case _                                         => Seq.empty
+    }
+  }
+}

--- a/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/client/scala/JsonLDSchemaConfiguration.scala
+++ b/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/client/scala/JsonLDSchemaConfiguration.scala
@@ -1,0 +1,60 @@
+package amf.jsonldschema.client.scala
+
+import amf.aml.internal.registries.AMLRegistry
+import amf.core.client.scala.config.{AMFEventListener, AMFOptions}
+import amf.core.client.scala.errorhandling.{DefaultErrorHandlerProvider, ErrorHandlerProvider}
+import amf.core.internal.registries.AMFRegistry
+import amf.core.internal.resource.AMFResolvers
+import amf.jsonldschema.internal.scala.model.metamodel.JsonLdSchemaEncodesModel
+import amf.shapes.client.scala.config.{SemanticBaseUnitClient, SemanticJsonSchemaConfiguration}
+
+import scala.concurrent.ExecutionContext
+
+class JsonLDSchemaConfiguration private[amf] (override private[amf] val resolvers: AMFResolvers,
+                                              override private[amf] val errorHandlerProvider: ErrorHandlerProvider,
+                                              override private[amf] val registry: AMLRegistry,
+                                              override private[amf] val listeners: Set[AMFEventListener],
+                                              override private[amf] val options: AMFOptions)
+    extends SemanticJsonSchemaConfiguration(resolvers, errorHandlerProvider, registry, listeners, options) {
+
+  private implicit val ec: ExecutionContext = this.getExecutionContext
+
+  override protected[amf] def copy(resolvers: AMFResolvers = resolvers,
+                                   errorHandlerProvider: ErrorHandlerProvider = errorHandlerProvider,
+                                   registry: AMFRegistry = registry,
+                                   listeners: Set[AMFEventListener] = listeners,
+                                   options: AMFOptions = options): JsonLDSchemaConfiguration =
+    new JsonLDSchemaConfiguration(resolvers,
+                                  errorHandlerProvider,
+                                  registry.asInstanceOf[AMLRegistry],
+                                  listeners,
+                                  options)
+
+  override def baseUnitClient(): JsonLDSchemaBaseUnitClient = new JsonLDSchemaBaseUnitClient(this)
+
+}
+
+object JsonLDSchemaConfiguration {
+
+  def empty(): JsonLDSchemaConfiguration = {
+
+    new JsonLDSchemaConfiguration(
+      AMFResolvers.predefined(),
+      DefaultErrorHandlerProvider,
+      AMLRegistry.empty,
+      Set.empty,
+      AMFOptions.default()
+    )
+  }
+
+  def predefined(): JsonLDSchemaConfiguration = {
+    val shapesConfig = SemanticJsonSchemaConfiguration.predefined()
+    new JsonLDSchemaConfiguration(
+      shapesConfig.resolvers,
+      shapesConfig.errorHandlerProvider,
+      shapesConfig.registry.withEntities(Map(JsonLdSchemaEncodesModel.`type`.head.iri() -> JsonLdSchemaEncodesModel)),
+      shapesConfig.listeners,
+      shapesConfig.options
+    )
+  }
+}

--- a/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/client/scala/model/JsonLdSchemaDocument.scala
+++ b/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/client/scala/model/JsonLdSchemaDocument.scala
@@ -1,0 +1,43 @@
+package amf.jsonldschema.client.scala.model
+
+import amf.aml.client.scala.model.domain.DialectDomainElement
+import amf.core.client.scala.model.document.{BaseUnit, DeclaresModel}
+import amf.core.client.scala.model.domain.{AmfObject, DomainElement}
+import amf.core.internal.annotations.Declares
+import amf.core.internal.metamodel.document.DocumentModel.References
+import amf.core.internal.metamodel.document.{BaseUnitModel, FragmentModel}
+import amf.core.internal.parser.domain.{Annotations, Fields}
+import amf.jsonldschema.internal.scala.model.metamodel.JsonLdSchemaEncodesModel
+import amf.jsonldschema.internal.scala.model.metamodel.JsonLdSchemaEncodesModel.{Encodes, Declares}
+
+trait JsonLdSchemaEncodesModel extends AmfObject {
+  def encodes: Seq[DomainElement]
+
+  def withEncodes(encoded: Seq[DomainElement]): this.type =
+    setArrayWithoutId(JsonLdSchemaEncodesModel.Encodes, encoded)
+}
+
+case class JsonLdSchemaDocument(fields: Fields, annotations: Annotations)
+    extends BaseUnit
+    with DeclaresModel
+    with JsonLdSchemaEncodesModel {
+
+  /** Meta data for the document */
+  override def meta: BaseUnitModel = JsonLdSchemaEncodesModel
+
+  /** Returns the list document URIs referenced from the document that has been parsed to generate this model */
+  override def references: Seq[BaseUnit] = fields(References)
+
+  /** Declared DomainElements that can be re-used from other documents. */
+  override def declares: Seq[DomainElement] = fields(JsonLdSchemaEncodesModel.Declares)
+
+  override def encodes: Seq[DomainElement] = fields(Encodes)
+
+  /** Value , path + field value that is used to compose the id when the object its adopted */
+  override private[amf] def componentId = ""
+
+}
+
+object JsonLdSchemaDocument {
+  def apply() = new JsonLdSchemaDocument(Fields(), Annotations())
+}

--- a/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/internal/scala/JsonLDDialectWrapper.scala
+++ b/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/internal/scala/JsonLDDialectWrapper.scala
@@ -1,0 +1,33 @@
+package amf.jsonldschema.internal.scala
+
+import amf.aml.client.scala.model.document.Dialect
+import amf.aml.client.scala.model.domain.{NodeMapping, PropertyMapping}
+import amf.core.client.scala.vocabulary.Namespace
+import amf.jsonldschema.internal.scala.model.metamodel.JsonLdSchemaEncodesModel.base
+
+object JsonLDDialectWrapper {
+  def unWrap(wrappedDialect: WrappedDialect) = {
+    wrappedDialect.dialect.withDeclares(wrappedDialect.dialect.declares.filterNot(_ == rootNode))
+    wrappedDialect.dialect.documents().root().withEncoded(wrappedDialect.originalRoot)
+    wrappedDialect.dialect
+  }
+
+  val dataPropertyTerm = base + "dataPropertyMapping"
+  val propertyMapping  = PropertyMapping().withName("$data").withNodePropertyMapping(dataPropertyTerm)
+
+  val rootNode = NodeMapping()
+    .withNodeTypeMapping(base + "jsonldSchemaRootNode")
+    .withId(base + "jsonSchemaRootNodeId")
+    .withName("JsonSchemaRootNode")
+    .withPropertiesMapping(Seq(propertyMapping))
+
+  def wrap(dialect: Dialect, isArray: Boolean): WrappedDialect = {
+    val originalEncoded = dialect.documents().root().encoded().value()
+    dialect.documents().root().withEncoded(rootNode.id)
+    propertyMapping.withObjectRange(Seq(originalEncoded))
+    if (isArray) propertyMapping.withAllowMultiple(true) else propertyMapping.withAllowMultiple(false)
+    WrappedDialect(dialect.withDeclares(dialect.declares :+ rootNode), originalEncoded, rootNode, dataPropertyTerm)
+  }
+}
+
+case class WrappedDialect(dialect: Dialect, originalRoot: String, rootNode: NodeMapping, dataPropertyTerm: String)

--- a/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/internal/scala/JsonLDSchemaPayloadWrapper.scala
+++ b/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/internal/scala/JsonLDSchemaPayloadWrapper.scala
@@ -1,0 +1,14 @@
+package amf.jsonldschema.internal.scala
+
+object JsonLDSchemaPayloadWrapper {
+
+  def wrap(data: String, dialectName: String): String = {
+    wrapExp.replace(DIALECT_NAME_EXP, dialectName).replace(DATA_EXP, data)
+  }
+
+  private val DIALECT_NAME_EXP = "<jsonld_replacing_name>"
+  private val DATA_EXP         = "<jsonld_replacing_data>"
+
+  private val wrapExp = "\n {\n  \"$dialect\": \"" + DIALECT_NAME_EXP + "\",\n  \"$data\": " + DATA_EXP + "\n}"
+
+}

--- a/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/internal/scala/model/metamodel/JsonLdSchemaEncodesModel.scala
+++ b/amf-jsonld-schema/shared/src/main/scala/amf/jsonldschema/internal/scala/model/metamodel/JsonLdSchemaEncodesModel.scala
@@ -1,0 +1,30 @@
+package amf.jsonldschema.internal.scala.model.metamodel
+
+import amf.core.client.scala.model.domain.AmfObject
+import amf.core.client.scala.vocabulary.Namespace.Document
+import amf.core.client.scala.vocabulary.ValueType
+import amf.core.internal.metamodel.Field
+import amf.core.internal.metamodel.document.{BaseUnitModel, ModuleModel}
+import amf.core.internal.metamodel.domain.{DomainElementModel, ModelDoc, ModelVocabularies}
+import amf.core.internal.metamodel.Type.Array
+import amf.jsonldschema.client.scala.model.JsonLdSchemaDocument
+
+object JsonLdSchemaEncodesModel extends BaseUnitModel with ModuleModel {
+  val base = "http://a.ml/vocabularies/jsondlschema#"
+
+  val Encodes: Field = Field(
+    Array(DomainElementModel),
+    ValueType(base + "encodes"),
+    ModelDoc(
+      ModelVocabularies.AmlDoc,
+      "encodes",
+      "The encodes relationship links a parsing Unit with the DomainElement from a particular domain the unit contains.")
+  )
+
+  override def modelInstance: AmfObject = JsonLdSchemaDocument()
+
+  override def fields: List[Field] = ModuleModel.fields :+ JsonLdSchemaEncodesModel.Encodes
+
+  override val `type`: List[ValueType] = List(ValueType(base + "JsonLdSchemaDocument")) ++ ModuleModel.`type`
+
+}

--- a/amf-jsonld-schema/shared/src/test/resources/configs/array.json
+++ b/amf-jsonld-schema/shared/src/test/resources/configs/array.json
@@ -1,0 +1,22 @@
+[
+  {
+    "itemName": "Default configuration",
+    "itemData":
+    {
+      "message": "#[attributes.headers['id']]",
+      "level": "INFO",
+      "firstSection": true,
+      "secondSection": false
+    }
+  },
+  {
+    "itemName": "newer",
+    "itemData":
+    {
+      "message": "#[attributes.headers['isad']]",
+      "level": "INFO",
+      "firstSection": true,
+      "secondSection": false
+    }
+  }
+]

--- a/amf-jsonld-schema/shared/src/test/resources/golden/array.json
+++ b/amf-jsonld-schema/shared/src/test/resources/golden/array.json
@@ -1,0 +1,20 @@
+[
+  {
+    "itemName": "Default configuration",
+    "itemData": {
+      "message": "#[attributes.headers['id']]",
+      "level": "INFO",
+      "firstSection": true,
+      "secondSection": false
+    }
+  },
+  {
+    "itemName": "newer",
+    "itemData": {
+      "message": "#[attributes.headers['isad']]",
+      "level": "INFO",
+      "firstSection": true,
+      "secondSection": false
+    }
+  }
+]

--- a/amf-jsonld-schema/shared/src/test/resources/policies/array.json
+++ b/amf-jsonld-schema/shared/src/test/resources/policies/array.json
@@ -1,0 +1,75 @@
+{
+  "@context": {
+    "@vocab": "anypoint://vocabulary/policy.yaml#",
+    "security": "anypoint://vocabulary/policy.yaml#",
+    "config": "anypoint://vocabulary/policy.yaml#",
+    "@characteristics": ["config:arrayAsObject"]
+  },
+  "$id": "message-logging.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "minItems": 1,
+  "title": "Message Logging",
+  "description": "Logs custom messages between policies and flow.\nWarning: If the payload is used as part of the logging message or conditional expression while using non repeatable streams, the payload will be consumed by the policy.",
+  "type": "array",
+  "items": {
+    "properties": {
+      "itemName": {
+        "type": "string"
+      },
+      "itemData": {
+        "properties": {
+          "message": {
+            "title": "Message",
+            "description": "Mule Expression for extracting information from the message to log.\ne.g. #[attributes.headers['id']]\n",
+            "@context": {
+              "@characteristics": [
+                "config:dataweaveExpression"
+              ]
+            },
+            "type": "string",
+            "pattern": "^(\\#\\[[\\w\\W]+\\]|\\$\\{[\\w\\W]+\\})$"
+          },
+          "conditional": {
+            "title": "Conditional",
+            "description": "Mule Expression to filter which messages to log.\ne.g. #[attributes.headers['id']==1]\n",
+            "@context": {
+              "@characteristics": [
+                "config:dataweaveExpression"
+              ]
+            },
+            "type": "string",
+            "pattern": "^$|^(\\#\\[[\\w\\W]+\\]|\\$\\{[\\w\\W]+\\})$"
+          },
+          "category": {
+            "title": "Category",
+            "description": "Prefix in the log sentence that usually contains package + class where the log is executed. The category will be\norg.mule.runtime.logging.policy-<policy id> plus this field value if any\n",
+            "type": "string"
+          },
+          "level": {
+            "title": "Level",
+            "description": "INFO, WARN, ERROR or DEBUG\n",
+            "default": "INFO",
+            "type": "string"
+          },
+          "firstSection": {
+            "title": "Before Calling API",
+            "default": true,
+            "type": "boolean"
+          },
+          "secondSection": {
+            "title": "After Calling API",
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message",
+          "level",
+          "firstSection",
+          "secondSection"
+        ]
+      }
+    }
+  }
+}

--- a/amf-jsonld-schema/shared/src/test/scala/amf/jsonldschema/FileAssertionTest.scala
+++ b/amf-jsonld-schema/shared/src/test/scala/amf/jsonldschema/FileAssertionTest.scala
@@ -1,0 +1,36 @@
+package amf.jsonldschema
+
+import amf.core.internal.unsafe.PlatformSecrets
+import org.mulesoft.common.io.{AsyncFile, FileSystem}
+import org.mulesoft.common.test.Tests.{checkDiff, checkLinesDiff}
+import org.scalatest.Assertion
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait FileAssertionTest extends PlatformSecrets {
+
+  private implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  protected val fs: FileSystem = platform.fs
+
+  protected def writeTemporaryFile(golden: String)(content: String): Future[AsyncFile] = {
+    val file   = tmp(s"${golden.replaceAll("/", "-")}.tmp")
+    val actual = fs.asyncFile(file)
+    actual.write(content).map(_ => actual)
+  }
+
+  protected def assertDifferences(actual: AsyncFile, golden: String): Future[Assertion] = {
+    val expected = fs.asyncFile(golden.replace("file://", ""))
+    expected.read().flatMap(_ => checkDiff(actual, expected))
+  }
+
+  protected def assertLinesDifferences(actual: AsyncFile, golden: String): Future[Assertion] = {
+    val expected = fs.asyncFile(golden.replace("file://", ""))
+    expected.read().flatMap(_ => checkLinesDiff(actual, expected))
+  }
+
+  /** Return random temporary file name for testing. */
+  def tmp(name: String = ""): String =
+    (platform.tmpdir() + platform.fs.separatorChar + System.nanoTime() + "-" + name)
+      .replaceAll(s"${platform.fs.separatorChar}${platform.fs.separatorChar}", s"${platform.fs.separatorChar}")
+}

--- a/amf-jsonld-schema/shared/src/test/scala/amf/jsonldschema/ParseAndRederConfigTest.scala
+++ b/amf-jsonld-schema/shared/src/test/scala/amf/jsonldschema/ParseAndRederConfigTest.scala
@@ -1,0 +1,28 @@
+package amf.jsonldschema
+
+import amf.aml.client.scala.AMLConfiguration
+import amf.aml.client.scala.model.document.Dialect
+import amf.core.client.scala.AMFGraphConfiguration
+import amf.jsonldschema.client.scala.JsonLDSchemaConfiguration
+import org.scalatest.funsuite.AsyncFunSuite
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ParseAndRenderConfigTest extends AsyncFunSuite with FileAssertionTest {
+  val basePath: String                   = "file://amf-jsonld-schema/shared/src/test/resources/"
+  override implicit val executionContext = ExecutionContext.global
+  test("Array configuration") {
+    val predefined = JsonLDSchemaConfiguration.predefined().baseUnitClient()
+    for {
+      config <- platform.fetchContent(basePath + "configs/array.json", AMFGraphConfiguration.predefined())(
+        executionContext)
+      converter     <- predefined.parseDialect(basePath + "policies/array.json")
+      dialectS      <- Future(predefined.render(converter.dialect, "application/yaml"))
+      cicledDialect <- AMLConfiguration.predefined().baseUnitClient().parseContent(dialectS)
+      instance      <- predefined.parsePayloadWithDialect(config.toString, cicledDialect.baseUnit.asInstanceOf[Dialect])
+      render        <- Future { predefined.emitPayloadWithDialect(instance, cicledDialect.baseUnit.asInstanceOf[Dialect]) }
+      d             <- writeTemporaryFile(s"$basePath/golden/array.json")(render)
+      r             <- assertDifferences(d, s"$basePath/golden/array.json")
+    } yield r
+  }
+}

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonschema/semanticjsonschema/transform/ShapeTransformation.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonschema/semanticjsonschema/transform/ShapeTransformation.scala
@@ -2,7 +2,7 @@ package amf.shapes.internal.spec.jsonschema.semanticjsonschema.transform
 
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.domain.DomainElement
-import amf.shapes.client.scala.model.domain.{AnyShape, CuriePrefix, NodeShape}
+import amf.shapes.client.scala.model.domain.{AnyShape, ArrayShape, CuriePrefix, NodeShape}
 
 case class ShapeTransformation(s: AnyShape, ctx: ShapeTransformationContext)(implicit errorHandler: AMFErrorHandler) {
 
@@ -13,7 +13,9 @@ case class ShapeTransformation(s: AnyShape, ctx: ShapeTransformationContext)(imp
       updateContext { ctx =>
         shape match {
           case node: NodeShape if node.properties.nonEmpty => NodeShapeTransformer(node, ctx).transform()
-          case any: AnyShape                               => AnyShapeTransformer(any, ctx).transform()
+          case a: ArrayShape if a.items.isInstanceOf[NodeShape] => // hack for root array
+            NodeShapeTransformer(a.items.asInstanceOf[NodeShape], ctx).transform()
+          case any: AnyShape => AnyShapeTransformer(any, ctx).transform()
         }
       }
     }

--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,39 @@ lazy val shapesJS =
     .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin)
 
 
+
+//************************ new semantic json schema module *********************
+
+lazy val semanticJsonSchema = crossProject(JSPlatform, JVMPlatform)
+  .settings(
+    Seq(
+      name := "amf-jsonld-schema"
+    ))
+  .in(file("./amf-jsonld-schema"))
+  .dependsOn(shapes)
+  .settings(commonSettings)
+  .jvmSettings(
+    libraryDependencies += "org.scala-js"                      %% "scalajs-stubs"         % scalaJSVersion % "provided",
+    libraryDependencies += "com.github.everit-org.json-schema" % "org.everit.json.schema" % "1.12.2",
+    libraryDependencies += "org.json"                          % "json"                   % "20211205",
+    Compile / packageDoc / artifactPath := baseDirectory.value / "target" / "artifact" / "amf-jsonld-schema-javadoc.jar"
+  )
+  .jsSettings(
+    scalaJSModuleKind := ModuleKind.CommonJSModule,
+    Compile / fullOptJS / artifactPath := baseDirectory.value / "target" / "artifact" / "amf-jsonld-schema-module.js",
+    scalacOptions += "-P:scalajs:suppressExportDeprecations",
+    npmDependencies += ("ajv", "6.12.6"),
+    npmPackageLoc := "amf-jsonld-schema/js"
+  )
+  .disablePlugins(SonarPlugin)
+
+lazy val semanticJsonSchemaJVM = shapes.jvm.in(file("./amf-jsonld-schema/jvm"))
+
+lazy val semanticJsonSchemaJS = shapes.js.in(file("./amf-jsonld-schema/js")).disablePlugins(SonarPlugin, ScalaJsTypingsPlugin)
+
+
+/*****************************************************************************/
+
 /** **********************************************
   * AMF-Api-contract
   * ********************************************* */


### PR DESCRIPTION
Alternative to wrap transformation and support arrays.
(Probably we should made some changes at dialect to support multiples and constraints at encodes, like con EncodesRootNode structure). For now, just checking the content to advance.