### PR TITLE
W-10803434/additional-properties-semschema

### DIFF
--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/additional-properties.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/additional-properties.jsonld
@@ -79,9 +79,12 @@
       "shacl:property": [
         {
           "@id": "/property/property/name"
+        },
+        {
+          "@id": "/property/property/age"
         }
       ],
-      "shacl:closed": false
+      "shacl:closed": true
     },
     {
       "@id": "/property/property/name",
@@ -95,36 +98,29 @@
           "@id": "http://www.w3.org/2001/XMLSchema#string"
         }
       ],
-      "shacl:minCount": 0,
-      "shacl:in": {
-        "@id": "/property/property/name/list"
-      }
+      "shacl:minCount": 1
     },
     {
-      "@id": "/property/property/name/list",
-      "@type": "rdfs:Seq",
-      "rdfs:_1": {
-        "@value": "A",
-        "@type": "xsd:string"
-      },
-      "rdfs:_2": {
-        "@value": "5",
-        "@type": "xsd:integer"
-      },
-      "rdfs:_3": {
-        "@value": "false",
-        "@type": "xsd:boolean"
-      }
+      "@id": "/property/property/age",
+      "@type": [
+        "meta:NodePropertyMapping",
+        "doc:DomainElement"
+      ],
+      "core:name": "age",
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#integer"
+        }
+      ],
+      "shacl:minCount": 1
     }
   ],
   "@context": {
-    "@base": "file://amf-cli/shared/src/test/resources/semantic-jsonschema/json-schemas/enum.json",
+    "@base": "file://amf-cli/shared/src/test/resources/semantic-jsonschema/json-schemas/additional-properties.json",
     "shacl": "http://www.w3.org/ns/shacl#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "doc": "http://a.ml/vocabularies/document#",
     "core": "http://a.ml/vocabularies/core#",
     "owl": "http://www.w3.org/2002/07/owl#",
-    "meta": "http://a.ml/vocabularies/meta#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#"
+    "meta": "http://a.ml/vocabularies/meta#"
   }
 }

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/additional-properties.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/additional-properties.yaml
@@ -6,11 +6,9 @@ nodeMappings:
         range: string
         mandatory: true
       age:
-        range: number
+        range: integer
         mandatory: true
-        minimum: 0.5
-        maximum: 150.2
-    additionalProperties: true
+    additionalProperties: false
 external:
   ns0: http://test.com/vocab#
 dialect: amf-json-schema-generated-dialect

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/allOf.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/allOf.jsonld
@@ -109,7 +109,8 @@
         {
           "@id": "/and/shape/Parent1/property/property/displayName"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "#/declarations/Child",
@@ -132,6 +133,7 @@
           "@id": "/property/property/age"
         }
       ],
+      "shacl:closed": false,
       "doc:extends": [
         {
           "@id": "#/declarations/Child/null"

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/allOf.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/allOf.yaml
@@ -10,12 +10,14 @@ nodeMappings:
         range: number
         mandatory: true
     extends: SchemaNode
+    additionalProperties: true
   SchemaNode:
     mapping:
       displayName:
         range: string
         propertyTerm: foaf.displayName
         mandatory: false
+    additionalProperties: true
 external:
   ns0: http://test.com/vocab#
   xsd: http://www.w3.org/2001/XMLSchema#

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/any-array.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/any-array.jsonld
@@ -109,7 +109,8 @@
         {
           "@id": "/property/property/scopelist"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/scopeheader",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/any-array.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/any-array.yaml
@@ -9,6 +9,7 @@ nodeMappings:
         range: any
         mandatory: true
         allowMultiple: true
+    additionalProperties: true
 external:
   security: anypoint://vocabulary/policy.yaml#
   config: anypoint://vocabulary/policy.yaml#

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/any-property.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/any-property.jsonld
@@ -68,7 +68,8 @@
         {
           "@id": "/property/property/someNonExistingProperty"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/someProperty",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/any-property.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/any-property.yaml
@@ -8,6 +8,7 @@ nodeMappings:
       someNonExistingProperty:
         range: any
         mandatory: true
+    additionalProperties: true
 dialect: amf-json-schema-generated-dialect
 version: "1.0"
 documents:

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/basic-with-characteristics.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/basic-with-characteristics.jsonld
@@ -96,7 +96,8 @@
         {
           "@id": "/property/property/info"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/key",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/basic-with-characteristics.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/basic-with-characteristics.yaml
@@ -10,6 +10,7 @@ nodeMappings:
       info:
         range: integer
         mandatory: true
+    additionalProperties: true
 external:
   security: https://anypoint.mulesoft.com/security#
   ns0: http://test.com/vocab#

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/basic.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/basic.jsonld
@@ -83,7 +83,8 @@
         {
           "@id": "/property/property/info/array/info/shape/items/property/property/note"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "#/declarations/Person",
@@ -103,7 +104,8 @@
         {
           "@id": "/property/property/info"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/info/array/info/shape/items/property/property/note",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/basic.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/basic.yaml
@@ -12,11 +12,13 @@ nodeMappings:
         range: SchemaNode
         mandatory: false
         allowMultiple: true
+    additionalProperties: true
   SchemaNode:
     mapping:
       note:
         range: string
         mandatory: false
+    additionalProperties: true
 external:
   ns0: http://test.com/vocab#
 dialect: amf-json-schema-generated-dialect

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/complex-with-characteristics.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/complex-with-characteristics.jsonld
@@ -112,7 +112,8 @@
         {
           "@id": "/property/property/clientSecretExpression"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/credentialsOriginHasHttpBasicAuthenticationHeader",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/complex-with-characteristics.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/complex-with-characteristics.yaml
@@ -16,6 +16,7 @@ nodeMappings:
         range: string
         mandatory: false
         default: "#[attributes.headers['client_secret']]"
+    additionalProperties: true
 external:
   security: anypoint://vocabulary/policy.yaml#
   config: anypoint://vocabulary/policy.yaml#

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/const.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/const.jsonld
@@ -80,7 +80,8 @@
         {
           "@id": "/property/property/name"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/name",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/const.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/const.yaml
@@ -7,6 +7,7 @@ nodeMappings:
         mandatory: false
         enum:
           - "555"
+    additionalProperties: true
 external:
   ns0: http://test.com/vocab#
 dialect: amf-json-schema-generated-dialect

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/default.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/default.jsonld
@@ -71,7 +71,8 @@
         {
           "@id": "/property/property/favoriteMovie/shape/favoriteMovie/property/property/release"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "#/declarations/Child",
@@ -91,7 +92,8 @@
         {
           "@id": "/property/property/nicknames"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/favoriteMovie/shape/favoriteMovie/property/property/name",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/default.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/default.yaml
@@ -19,6 +19,7 @@ nodeMappings:
         default:
           - Carliños
           - Carl
+    additionalProperties: true
   SchemaNode:
     mapping:
       name:
@@ -27,6 +28,7 @@ nodeMappings:
       release:
         range: integer
         mandatory: true
+    additionalProperties: true
 dialect: amf-json-schema-generated-dialect
 version: "1.0"
 documents:

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/duplicate-semantics.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/duplicate-semantics.jsonld
@@ -128,7 +128,8 @@
         {
           "@id": "/property/property/info_2"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/key_1",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/duplicate-semantics.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/duplicate-semantics.yaml
@@ -20,6 +20,7 @@ nodeMappings:
         range: integer
         propertyTerm: semantics.info_2
         mandatory: false
+    additionalProperties: true
 external:
   somethingElse: https://test.com/somethingElse#
   security: https://test.com/security#

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/enum.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/enum.yaml
@@ -9,6 +9,7 @@ nodeMappings:
           - A
           - "5"
           - "false"
+    additionalProperties: true
 external:
   ns0: http://test.com/vocab#
 dialect: amf-json-schema-generated-dialect

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/intermediate.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/intermediate.jsonld
@@ -114,7 +114,8 @@
         {
           "@id": "/property/property/hey/array/hey/shape/items/property/property/ho"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "#/declarations/Parent",
@@ -134,7 +135,8 @@
         {
           "@id": "/property/property/hey"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/hey/array/hey/shape/items/property/property/ho",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/intermediate.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/intermediate.yaml
@@ -13,6 +13,7 @@ nodeMappings:
         range: SchemaNode
         mandatory: false
         allowMultiple: true
+    additionalProperties: true
   SchemaNode:
     classTerm: foaf.Verse
     mapping:
@@ -20,6 +21,7 @@ nodeMappings:
         range: string
         propertyTerm: foaf.ho
         mandatory: false
+    additionalProperties: true
 external:
   ns0: http://test.com/vocab#
   xsd: http://www.w3.org/2001/XMLSchema#

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/minimum-maximum.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/minimum-maximum.jsonld
@@ -83,7 +83,8 @@
         {
           "@id": "/property/property/age"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/name",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/multiple-characteristics.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/multiple-characteristics.jsonld
@@ -109,7 +109,8 @@
         {
           "@id": "/property/property/info"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/key",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/multiple-characteristics.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/multiple-characteristics.yaml
@@ -10,6 +10,7 @@ nodeMappings:
       info:
         range: integer
         mandatory: true
+    additionalProperties: true
 external:
   security: https://test.com/security#
   ns0: http://test.com/vocab#

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/oneOf.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/oneOf.jsonld
@@ -91,7 +91,8 @@
         {
           "@id": "/exclusiveOr/shape/Parent1/property/property/displayName"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "#/declarations/Child",
@@ -122,7 +123,8 @@
         {
           "@id": "/exclusiveOr/shape/item1/property/property/address"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/exclusiveOr/shape/Parent1/property/property/displayName",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/oneOf.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/oneOf.yaml
@@ -11,6 +11,7 @@ nodeMappings:
         range: string
         propertyTerm: foaf.address
         mandatory: false
+    additionalProperties: true
   SchemaNode:
     classTerm: foaf.Something
     mapping:
@@ -18,6 +19,7 @@ nodeMappings:
         range: string
         propertyTerm: foaf.displayName
         mandatory: false
+    additionalProperties: true
 external:
   foaf: http://xmlns.com/foaf/0.1/
 dialect: amf-json-schema-generated-dialect

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/remote-context.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/remote-context.jsonld
@@ -83,7 +83,8 @@
         {
           "@id": "/property/property/age"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/name",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/remote-context.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/remote-context.yaml
@@ -8,6 +8,7 @@ nodeMappings:
       age:
         range: integer
         mandatory: true
+    additionalProperties: true
 external:
   ns0: http://test.com/my_test_vocabulary#
 dialect: amf-json-schema-generated-dialect

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/without-schema-key.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/without-schema-key.jsonld
@@ -83,7 +83,8 @@
         {
           "@id": "/property/property/info/array/info/shape/items/property/property/note"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "#/declarations/Person",
@@ -103,7 +104,8 @@
         {
           "@id": "/property/property/info"
         }
-      ]
+      ],
+      "shacl:closed": false
     },
     {
       "@id": "/property/property/info/array/info/shape/items/property/property/note",

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/without-schema-key.yaml
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/dialects/without-schema-key.yaml
@@ -12,11 +12,13 @@ nodeMappings:
         range: SchemaNode
         mandatory: false
         allowMultiple: true
+    additionalProperties: true
   SchemaNode:
     mapping:
       note:
         range: string
         mandatory: false
+    additionalProperties: true
 external:
   ns0: http://test.com/vocab#
 dialect: amf-json-schema-generated-dialect

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/instances/basic-with-extra-properties.json
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/instances/basic-with-extra-properties.json
@@ -1,0 +1,6 @@
+{
+  "$dialect": "amf-json-schema-generated-dialect 1.0",
+  "name": "Pepito",
+  "age": 33,
+  "surname": "Pepote"
+}

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/instances/basic-with-extra-properties.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/instances/basic-with-extra-properties.jsonld
@@ -1,0 +1,55 @@
+{
+  "@graph": [
+    {
+      "@id": "/BaseUnitProcessingData",
+      "@type": [
+        "doc:DialectInstanceProcessingData"
+      ],
+      "meta:definedBy": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/semantic-jsonschema/json-schemas/basic-with-extra-properties.json"
+        }
+      ],
+      "doc:transformed": false,
+      "doc:sourceSpec": "amf-json-schema-generated-dialect 1.0"
+    },
+    {
+      "@id": "#/encodes",
+      "@type": [
+        "#/declarations/Person",
+        "meta:DialectDomainElement",
+        "doc:DomainElement"
+      ],
+      "data:name": "Pepito",
+      "data:age": 33
+    },
+    {
+      "@id": "",
+      "@type": [
+        "meta:DialectInstance",
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "meta:definedBy": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/semantic-jsonschema/json-schemas/basic-with-extra-properties.json"
+        }
+      ],
+      "doc:encodes": {
+        "@id": "#/encodes"
+      },
+      "doc:root": true,
+      "doc:processingData": {
+        "@id": "/BaseUnitProcessingData"
+      }
+    }
+  ],
+  "@context": {
+    "@base": "file://amf-cli/shared/src/test/resources/semantic-jsonschema/instances/basic-with-extra-properties.json",
+    "data": "http://a.ml/vocabularies/data#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "meta": "http://a.ml/vocabularies/meta#"
+  }
+}

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/json-schemas/additional-properties.json
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/json-schemas/additional-properties.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "@context": {
+    "@base": "http://test.com/adocument.jsonld",
+    "@vocab": "http://test.com/vocab#"
+  },
+  "title": "Person",
+  "type": "object",
+  "required": [
+    "name",
+    "age"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "age": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false
+}

--- a/amf-cli/shared/src/test/resources/semantic-jsonschema/json-schemas/basic-with-extra-properties.json
+++ b/amf-cli/shared/src/test/resources/semantic-jsonschema/json-schemas/basic-with-extra-properties.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "@context": {
+    "@base": "http://test.com/adocument.jsonld",
+    "@vocab": "http://test.com/vocab#"
+  },
+  "title": "Person",
+  "type": "object",
+  "required": [
+    "name",
+    "age"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "age": {
+      "type": "integer"
+    }
+  }
+}

--- a/amf-cli/shared/src/test/scala/amf/semanticjsonschema/JsonSchemaDialectInstanceTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/semanticjsonschema/JsonSchemaDialectInstanceTest.scala
@@ -27,6 +27,7 @@ class JsonSchemaDialectInstanceTest extends AsyncFunSuite with PlatformSecrets w
   instanceValidation("duplicate-semantics")
   instanceValidation("multiple-characteristics")
   instanceValidation("oneOf")
+  instanceValidation("basic-with-extra-properties")
 
   private def instanceValidation(filename: String): Unit = {
     val label = s"Dialect instance validation with $filename JSON Schema"

--- a/amf-cli/shared/src/test/scala/amf/semanticjsonschema/JsonSchemaToDialectTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/semanticjsonschema/JsonSchemaToDialectTest.scala
@@ -35,6 +35,7 @@ class JsonSchemaToDialectTest extends AsyncFunSuite with PlatformSecrets with Fi
   multiOutputTest("duplicate-semantics")
   multiOutputTest("without-schema-key")
   multiOutputTest("any-array")
+  multiOutputTest("additional-properties")
 
   private def multiOutputTest(filename: String): Unit = {
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/metamodel/NodeShapeModel.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/metamodel/NodeShapeModel.scala
@@ -13,7 +13,7 @@ import amf.shapes.internal.domain.metamodel.operations.ShapeOperationModel
 /**
   * Node shape metaModel.
   */
-trait NodeShapeModel extends AnyShapeModel {
+trait NodeShapeModel extends AnyShapeModel with ClosedModel {
 
   val MinProperties: Field = Field(
     Int,
@@ -24,11 +24,6 @@ trait NodeShapeModel extends AnyShapeModel {
     Int,
     Shapes + "maxProperties",
     ModelDoc(ModelVocabularies.Shapes, "maxProperties", "Maximum number of properties in the input node constraint"))
-
-  val Closed: Field = Field(
-    Bool,
-    Shacl + "closed",
-    ModelDoc(ExternalModelVocabularies.Shacl, "closed", "Additional properties in the input node accepted constraint"))
 
   val AdditionalPropertiesSchema: Field = Field(
     ShapeModel,
@@ -111,7 +106,9 @@ trait NodeShapeModel extends AnyShapeModel {
   val IsAbstract: Field = Field(
     Bool,
     Shapes + "isAbstract",
-    ModelDoc(ModelVocabularies.Shapes, "isAbstract", "Marks this shape as an abstract node shape declared for pure re-use")
+    ModelDoc(ModelVocabularies.Shapes,
+             "isAbstract",
+             "Marks this shape as an abstract node shape declared for pure re-use")
   )
 
   val specificFields = List(

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonschema/semanticjsonschema/transform/NodeShapeTransformer.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonschema/semanticjsonschema/transform/NodeShapeTransformer.scala
@@ -20,10 +20,19 @@ case class NodeShapeTransformer(shape: NodeShape, ctx: ShapeTransformationContex
       PropertyShapeTransformer(property, ctx).transform()
     }
     nodeMapping.withPropertiesMapping(propertyMappings)
+    nodeMapping.withClosed(false)
 
+    checkAdditionalProperties()
     checkInheritance()
     checkSemantics()
     nodeMapping
+  }
+
+  private def checkAdditionalProperties() = {
+    shape.closed.option() match {
+      case Some(value) => nodeMapping.withClosed(value)
+      case None        => nodeMapping.withClosed(false)
+    }
   }
 
   private def checkInheritance(): Unit = {

--- a/documentation/model.md
+++ b/documentation/model.md
@@ -1669,6 +1669,7 @@ Types:
  | uriTemplate | string | URI template that will be used to generate the URI of the parsed nodeds in the graph | http://a.ml/vocabularies/apiContract#uriTemplate |
  | mergePolicy | string | Indication of how to merge this graph node when applying a patch document | http://a.ml/vocabularies/meta#mergePolicy |
  | resolvedExtends | [url] |  | http://a.ml/vocabularies/meta#resolvedExtends |
+ | closed | boolean | Additional properties in the input node accepted constraint | http://www.w3.org/ns/shacl#closed |
  | link-target | url | URI of the linked element | http://a.ml/vocabularies/document#link-target |
  | link-label | string | Label for the type of link | http://a.ml/vocabularies/document#link-label |
  | recursive | boolean | Indication taht this kind of linkable element can support recursive links | http://a.ml/vocabularies/document#recursive |


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-aml/pull/488

- Extraction: extracted Closed field to interface in amf-core
- W-10803434: added additional properties transformation for NodeShapes with a default value in case it is not present
- Documentation: fixed model doc test to take into account new Closed field in AnnotationMappings

**Important**: additionalProperties transformation is only for NodeShapes. We should propagate it to AnyShapes but this means implementing it for UnionShapes also.

How would additionalProperties behave for a UnionShape ?
- Should the UnionShape have the "additionalProperties"? If one of the component also has "additionalProperties", should  the union override it ?
- Should the parsing depend on wether a component of the union has the "additionalProperties" ?
