### PR TITLE
W-10815397: Fix: Parameters with default annotation were not remove from endpoints

### DIFF
--- a/amf-cli/shared/src/test/resources/validations/parameters/param-in-resource-types.raml
+++ b/amf-cli/shared/src/test/resources/validations/parameters/param-in-resource-types.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: storm-storefinder-xp-api
+/logLevel/{loggerName}:
+  type: logLevel
+
+resourceTypes:
+  logLevel:
+    uriParameters:
+      loggerName:
+        description: Name of the logger whose level is to be changed.
+        type: string
+        required: true

--- a/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
@@ -335,4 +335,15 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
       typeWithReference.annotations.lexical().end shouldBe Position(7, 0)
     }
   }
+
+  test("Endpoint parameters with default annotation should be replaced during transformation") {
+    val api = s"$basePath/parameters/param-in-resource-types.raml"
+    modelAssertion(api) { bu =>
+      val components = new BaseUnitComponents
+      val endpoint = components.getFirstEndpoint(bu)
+      val parameters = endpoint.parameters.toList
+      parameters.size shouldBe 1
+      parameters.head.description.value() shouldBe "Name of the logger whose level is to be changed."
+    }
+  }
 }


### PR DESCRIPTION
- During resolution, parameters with this annotation should be removed as they will be replaced by the correct ones. Previously this didn't happen causing duplicates.