### PR TITLE
W 11063850

### DIFF
--- a/adhoc-cli/src/main/scala/amf/adhoc/cli/Main.scala
+++ b/adhoc-cli/src/main/scala/amf/adhoc/cli/Main.scala
@@ -64,6 +64,12 @@ object Main {
     val parsing     = Await.result(parsingFuture, Duration.Inf)
     var baseUnit    = parsing.baseUnit
     val withLexical = args.contains("--with-lexical")
+    val pipeline = if (args.contains("--pipeline")) {
+      val pipelineArgIdx = args.indexOf("--pipeline") + 1
+      args(pipelineArgIdx)
+    } else {
+      PipelineId.Editing
+    }
 
     var transformationConf = APIConfiguration.fromSpec(parsing.sourceSpec)
     parsedExtensions.foreach(e => transformationConf = transformationConf.withExtensions(e))
@@ -71,7 +77,7 @@ object Main {
     val transformation =
       transformationConf
         .baseUnitClient()
-        .transform(parsing.baseUnit, PipelineId.Editing)
+        .transform(parsing.baseUnit, pipeline)
     baseUnit = transformation.baseUnit
 
     val renderOptions = if (withLexical) {

--- a/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLFederationSyntaxParsePlugin.scala
+++ b/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLFederationSyntaxParsePlugin.scala
@@ -1,0 +1,29 @@
+package amf.antlr.internal.plugins.syntax
+
+import amf.antlr.client.scala.parse.document.AntlrParsedDocument
+import amf.core.client.common.{HighPriority, PluginPriority}
+import amf.core.client.scala.parse.AMFSyntaxParsePlugin
+import amf.core.client.scala.parse.document.{ParsedDocument, ParserContext}
+import amf.core.internal.remote.Mimes.`application/graphql`
+import amf.core.internal.remote.Syntax
+import org.mulesoft.antlrast.platform.PlatformGraphQLFederationParser
+
+object GraphQLFederationSyntaxParsePlugin extends AMFSyntaxParsePlugin {
+
+  override def parse(text: CharSequence, mediaType: String, ctx: ParserContext): ParsedDocument = {
+    val input  = text.toString
+    val parser = new PlatformGraphQLFederationParser()
+    val ast    = parser.parse(ctx.rootContextDocument, input)
+    AntlrParsedDocument(ast, None)
+  }
+
+  override def mediaTypes: Seq[String] = Syntax.graphQLMimes.toSeq
+
+  override val id: String = "graphql-federation-parse"
+
+  override def applies(element: CharSequence): Boolean = element.toString.trim.contains("@key(fields:")
+
+  override def priority: PluginPriority = HighPriority
+
+  override def mainMediaType: String = `application/graphql`
+}

--- a/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLFederationSyntaxParsePlugin.scala
+++ b/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLFederationSyntaxParsePlugin.scala
@@ -21,7 +21,7 @@ object GraphQLFederationSyntaxParsePlugin extends AMFSyntaxParsePlugin {
 
   override val id: String = "graphql-federation-parse"
 
-  override def applies(element: CharSequence): Boolean = element.toString.trim.contains("@key(fields:")
+  override def applies(element: CharSequence): Boolean = true
 
   override def priority: PluginPriority = HighPriority
 

--- a/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLFederationSyntaxParsePlugin.scala
+++ b/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLFederationSyntaxParsePlugin.scala
@@ -1,7 +1,7 @@
 package amf.antlr.internal.plugins.syntax
 
 import amf.antlr.client.scala.parse.document.AntlrParsedDocument
-import amf.core.client.common.{HighPriority, PluginPriority}
+import amf.core.client.common.{LowPriority, PluginPriority}
 import amf.core.client.scala.parse.AMFSyntaxParsePlugin
 import amf.core.client.scala.parse.document.{ParsedDocument, ParserContext}
 import amf.core.internal.remote.Mimes.`application/graphql`
@@ -23,7 +23,7 @@ object GraphQLFederationSyntaxParsePlugin extends AMFSyntaxParsePlugin {
 
   override def applies(element: CharSequence): Boolean = true
 
-  override def priority: PluginPriority = HighPriority
+  override def priority: PluginPriority = LowPriority
 
   override def mainMediaType: String = `application/graphql`
 }

--- a/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLSyntaxParsePlugin.scala
+++ b/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLSyntaxParsePlugin.scala
@@ -1,7 +1,7 @@
 package amf.antlr.internal.plugins.syntax
 
 import amf.antlr.client.scala.parse.document.AntlrParsedDocument
-import amf.core.client.common.{HighPriority, PluginPriority}
+import amf.core.client.common.{LowPriority, PluginPriority}
 import amf.core.client.scala.parse.AMFSyntaxParsePlugin
 import amf.core.client.scala.parse.document.{ParsedDocument, ParserContext}
 import amf.core.internal.remote.Mimes.`application/graphql`
@@ -23,7 +23,7 @@ object GraphQLSyntaxParsePlugin extends AMFSyntaxParsePlugin {
 
   override def applies(element: CharSequence): Boolean = true
 
-  override def priority: PluginPriority = HighPriority
+  override def priority: PluginPriority = LowPriority
 
   override def mainMediaType: String = `application/graphql`
 }

--- a/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLSyntaxParsePlugin.scala
+++ b/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLSyntaxParsePlugin.scala
@@ -21,14 +21,7 @@ object GraphQLSyntaxParsePlugin extends AMFSyntaxParsePlugin {
 
   override val id: String = "graphql-parse"
 
-  override def applies(element: CharSequence): Boolean = {
-    val text = element.toString.trim
-
-    text.contains("schema {") ||
-    text.contains("type Query {") ||
-    text.contains("type Mutation {") ||
-    text.contains("type Subscription {")
-  }
+  override def applies(element: CharSequence): Boolean = true
 
   override def priority: PluginPriority = HighPriority
 

--- a/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLSyntaxParsePlugin.scala
+++ b/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GraphQLSyntaxParsePlugin.scala
@@ -1,0 +1,36 @@
+package amf.antlr.internal.plugins.syntax
+
+import amf.antlr.client.scala.parse.document.AntlrParsedDocument
+import amf.core.client.common.{HighPriority, PluginPriority}
+import amf.core.client.scala.parse.AMFSyntaxParsePlugin
+import amf.core.client.scala.parse.document.{ParsedDocument, ParserContext}
+import amf.core.internal.remote.Mimes.`application/graphql`
+import amf.core.internal.remote.Syntax
+import org.mulesoft.antlrast.platform.PlatformGraphQLParser
+
+object GraphQLSyntaxParsePlugin extends AMFSyntaxParsePlugin {
+
+  override def parse(text: CharSequence, mediaType: String, ctx: ParserContext): ParsedDocument = {
+    val input  = text.toString
+    val parser = new PlatformGraphQLParser()
+    val ast    = parser.parse(ctx.rootContextDocument, input)
+    AntlrParsedDocument(ast, None)
+  }
+
+  override def mediaTypes: Seq[String] = Syntax.graphQLMimes.toSeq
+
+  override val id: String = "graphql-parse"
+
+  override def applies(element: CharSequence): Boolean = {
+    val text = element.toString.trim
+
+    text.contains("schema {") ||
+    text.contains("type Query {") ||
+    text.contains("type Mutation {") ||
+    text.contains("type Subscription {")
+  }
+
+  override def priority: PluginPriority = HighPriority
+
+  override def mainMediaType: String = `application/graphql`
+}

--- a/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GrpcSyntaxParsePlugin.scala
+++ b/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GrpcSyntaxParsePlugin.scala
@@ -6,28 +6,22 @@ import amf.core.client.scala.parse.AMFSyntaxParsePlugin
 import amf.core.client.scala.parse.document.{ParsedDocument, ParserContext}
 import amf.core.internal.remote.Mimes.`application/x-protobuf`
 import amf.core.internal.remote.Syntax
-import org.mulesoft.antlrast.platform.{PlatformGraphQLParser, PlatformProtobuf3Parser}
+import org.mulesoft.antlrast.platform.PlatformProtobuf3Parser
 
-object AntlrSyntaxParsePlugin extends AMFSyntaxParsePlugin {
+object GrpcSyntaxParsePlugin extends AMFSyntaxParsePlugin {
 
   override def parse(text: CharSequence, mediaType: String, ctx: ParserContext): ParsedDocument = {
     val input  = text.toString
-    val parser = if (input.contains("proto3")) new PlatformProtobuf3Parser() else new PlatformGraphQLParser()
+    val parser = new PlatformProtobuf3Parser()
     val ast    = parser.parse(ctx.rootContextDocument, input)
     AntlrParsedDocument(ast, None)
   }
 
-  override def mediaTypes: Seq[String] = Syntax.proto3Mimes.toSeq ++ Syntax.graphQLMimes.toSeq
+  override def mediaTypes: Seq[String] = Syntax.proto3Mimes.toSeq
 
-  override val id: String = "antlr-ast-parse"
+  override val id: String = "grpc-parse"
 
-  override def applies(element: CharSequence): Boolean = {
-    val text         = element.toString.trim
-    val isJSONObject = text.startsWith("{") && text.endsWith("}")
-    val isJSONArray  = text.startsWith("[") && text.endsWith("]")
-    val isYamlHash   = text.startsWith("#")
-    !isJSONArray && !isJSONObject && !isYamlHash
-  }
+  override def applies(element: CharSequence): Boolean = element.toString.contains("proto3")
 
   override def priority: PluginPriority = HighPriority
 

--- a/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GrpcSyntaxParsePlugin.scala
+++ b/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GrpcSyntaxParsePlugin.scala
@@ -1,7 +1,7 @@
 package amf.antlr.internal.plugins.syntax
 
 import amf.antlr.client.scala.parse.document.AntlrParsedDocument
-import amf.core.client.common.{HighPriority, PluginPriority}
+import amf.core.client.common.{LowPriority, PluginPriority}
 import amf.core.client.scala.parse.AMFSyntaxParsePlugin
 import amf.core.client.scala.parse.document.{ParsedDocument, ParserContext}
 import amf.core.internal.remote.Mimes.`application/x-protobuf`
@@ -23,7 +23,7 @@ object GrpcSyntaxParsePlugin extends AMFSyntaxParsePlugin {
 
   override def applies(element: CharSequence): Boolean = true
 
-  override def priority: PluginPriority = HighPriority
+  override def priority: PluginPriority = LowPriority
 
   override def mainMediaType: String = `application/x-protobuf`
 }

--- a/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GrpcSyntaxParsePlugin.scala
+++ b/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/GrpcSyntaxParsePlugin.scala
@@ -21,7 +21,7 @@ object GrpcSyntaxParsePlugin extends AMFSyntaxParsePlugin {
 
   override val id: String = "grpc-parse"
 
-  override def applies(element: CharSequence): Boolean = element.toString.contains("proto3")
+  override def applies(element: CharSequence): Boolean = true
 
   override def priority: PluginPriority = HighPriority
 

--- a/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/SyamlForJsonLDSyntaxParsePlugin.scala
+++ b/amf-antlr-syntax/shared/src/main/scala/amf/antlr/internal/plugins/syntax/SyamlForJsonLDSyntaxParsePlugin.scala
@@ -1,0 +1,21 @@
+package amf.antlr.internal.plugins.syntax
+
+import amf.core.internal.plugins.syntax.SyamlSyntaxParsePlugin
+
+object SyamlForJsonLDSyntaxParsePlugin extends SyamlSyntaxParsePlugin {
+
+  /**
+    * Need to override applies method because GraphQL, GraphQL Federation & GRPC syntax plugins return applies true for
+    * ALL strings, same as SYAML. We need some sort of syntax detection otherwise we will not be able to parse GraphQL,
+    * GRPC, etc. and JSON-LD in the same configuration. Doing that syntax detection here
+    * @param element input
+    * @return
+    */
+  override def applies(element: CharSequence): Boolean = {
+    element.toString.trim.charAt(0) match {
+      case '{' => true
+      case '[' => true
+      case _   => false
+    }
+  }
+}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/model/AMFRawValidations.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/model/AMFRawValidations.scala
@@ -1550,6 +1550,11 @@ object AMFRawValidations {
     override def validations(): Seq[AMFValidation] = result
   }
 
+  object GraphQLFederationValidations extends ProfileValidations {
+    private lazy val result                        = Seq()
+    override def validations(): Seq[AMFValidation] = result
+  }
+
   trait GenericValidations {
     def urlValidation(owlClass: ValueType, owlProperty: ValueType): AMFValidation =
       AMFValidation(

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/model/ApiValidationProfiles.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/model/ApiValidationProfiles.scala
@@ -20,6 +20,9 @@ object ApiValidationProfiles {
   val GraphQLValidationProfile: ValidationProfile =
     buildProfileFrom(GraphQLProfile, GraphQLValidations, withStaticValidations = false)
 
+  val GraphQLFederationValidationProfile: ValidationProfile =
+    buildProfileFrom(GraphQLFederationProfile, GraphQLFederationValidations, withStaticValidations = false)
+
   val AmfValidationProfile: ValidationProfile = buildProfileFrom(AmfProfile, AmfValidations)
 
   protected val apiProfiles: Map[ProfileName, ValidationProfile] = Map(
@@ -45,6 +48,7 @@ object ApiEffectiveValidations {
   val Async20EffectiveValidations: EffectiveValidations = EffectiveValidations().someEffective(Async20ValidationProfile)
 
   val GraphQLEffectiveValidations: EffectiveValidations = EffectiveValidations().someEffective(GraphQLValidationProfile)
+  val GraphQLFederationEffectiveValidations: EffectiveValidations = EffectiveValidations().someEffective(GraphQLFederationValidationProfile)
 
   val AmfEffectiveValidations: EffectiveValidations = EffectiveValidations().someEffective(AmfValidationProfile)
 }

--- a/amf-graphql/shared/src/main/scala/amf/graphql/client/platform/GraphQLFederationConfiguration.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/client/platform/GraphQLFederationConfiguration.scala
@@ -1,0 +1,15 @@
+package amf.graphql.client.platform
+
+import amf.apicontract.client.platform.AMFConfiguration
+import amf.graphql.client.scala.{GraphQLFederationConfiguration => InternalGraphQLFederationConfiguration}
+
+import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
+
+@JSExportAll
+@JSExportTopLevel("GraphQLFederationConfiguration")
+object GraphQLFederationConfiguration {
+
+  def GraphQLFederation(): AMFConfiguration = {
+    new AMFConfiguration(InternalGraphQLFederationConfiguration.GraphQLFederation())
+  }
+}

--- a/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLConfiguration.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLConfiguration.scala
@@ -1,11 +1,10 @@
 package amf.graphql.client.scala
 
-import amf.antlr.internal.plugins.syntax.{AntlrSyntaxParsePlugin, AntlrSyntaxRenderPlugin}
+import amf.antlr.internal.plugins.syntax.{AntlrSyntaxRenderPlugin, GraphQLSyntaxParsePlugin}
 import amf.apicontract.client.scala.{AMFConfiguration, APIConfigurationBuilder}
 import amf.apicontract.internal.transformation.{GraphQLCachePipeline, GraphQLEditingPipeline}
 import amf.apicontract.internal.validation.model.ApiEffectiveValidations.GraphQLEffectiveValidations
 import amf.apicontract.internal.validation.model.ApiValidationProfiles.GraphQLValidationProfile
-import amf.apicontract.internal.validation.payload.PayloadValidationPlugin
 import amf.apicontract.internal.validation.shacl.ShaclModelValidationPlugin
 import amf.core.client.common.validation.ProfileNames
 import amf.graphql.plugins.parse.GraphQLParsePlugin
@@ -18,7 +17,7 @@ object GraphQLConfiguration extends APIConfigurationBuilder {
       .withPlugins(
         List(
           GraphQLParsePlugin,
-          AntlrSyntaxParsePlugin,
+          GraphQLSyntaxParsePlugin,
           GraphQLRenderPlugin,
           AntlrSyntaxRenderPlugin,
           ShaclModelValidationPlugin(ProfileNames.GRAPHQL)

--- a/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLConfiguration.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLConfiguration.scala
@@ -1,6 +1,6 @@
 package amf.graphql.client.scala
 
-import amf.antlr.internal.plugins.syntax.{AntlrSyntaxRenderPlugin, GraphQLSyntaxParsePlugin}
+import amf.antlr.internal.plugins.syntax.{AntlrSyntaxRenderPlugin, GraphQLSyntaxParsePlugin, SyamlForJsonLDSyntaxParsePlugin}
 import amf.apicontract.client.scala.{AMFConfiguration, APIConfigurationBuilder}
 import amf.apicontract.internal.transformation.{GraphQLCachePipeline, GraphQLEditingPipeline}
 import amf.apicontract.internal.validation.model.ApiEffectiveValidations.GraphQLEffectiveValidations
@@ -30,5 +30,6 @@ object GraphQLConfiguration extends APIConfigurationBuilder {
         )
       )
       .withValidationProfile(GraphQLValidationProfile, GraphQLEffectiveValidations)
+      .withPlugin(SyamlForJsonLDSyntaxParsePlugin) // override SYAML
   }
 }

--- a/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLFederationConfiguration.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLFederationConfiguration.scala
@@ -1,6 +1,6 @@
 package amf.graphql.client.scala
 
-import amf.antlr.internal.plugins.syntax.AntlrSyntaxRenderPlugin
+import amf.antlr.internal.plugins.syntax.{AntlrSyntaxRenderPlugin, GraphQLFederationSyntaxParsePlugin}
 import amf.apicontract.client.scala.{AMFConfiguration, APIConfigurationBuilder}
 import amf.apicontract.internal.validation.model.ApiEffectiveValidations.GraphQLFederationEffectiveValidations
 import amf.apicontract.internal.validation.model.ApiValidationProfiles.GraphQLFederationValidationProfile
@@ -15,7 +15,7 @@ object GraphQLFederationConfiguration extends APIConfigurationBuilder {
         List(
           // TODO: replace with federation specific plugins
 //          GraphQLParsePlugin,
-//          GraphQLSyntaxParsePlugin,
+          GraphQLFederationSyntaxParsePlugin,
 //          GraphQLRenderPlugin,
           AntlrSyntaxRenderPlugin,
           ShaclModelValidationPlugin(ProfileNames.GRAPHQL_FEDERATION)

--- a/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLFederationConfiguration.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLFederationConfiguration.scala
@@ -1,0 +1,33 @@
+package amf.graphql.client.scala
+
+import amf.antlr.internal.plugins.syntax.AntlrSyntaxRenderPlugin
+import amf.apicontract.client.scala.{AMFConfiguration, APIConfigurationBuilder}
+import amf.apicontract.internal.validation.model.ApiEffectiveValidations.GraphQLFederationEffectiveValidations
+import amf.apicontract.internal.validation.model.ApiValidationProfiles.GraphQLFederationValidationProfile
+import amf.apicontract.internal.validation.shacl.ShaclModelValidationPlugin
+import amf.core.client.common.validation.ProfileNames
+
+object GraphQLFederationConfiguration extends APIConfigurationBuilder {
+
+  def GraphQLFederation(): AMFConfiguration = {
+    common()
+      .withPlugins(
+        List(
+          // TODO: replace with federation specific plugins
+//          GraphQLParsePlugin,
+//          GraphQLSyntaxParsePlugin,
+//          GraphQLRenderPlugin,
+          AntlrSyntaxRenderPlugin,
+          ShaclModelValidationPlugin(ProfileNames.GRAPHQL_FEDERATION)
+        )
+      )
+      .withTransformationPipelines(
+        List(
+          // TODO: replace with federation specific pipelines
+//          GraphQLEditingPipeline(),
+//          GraphQLCachePipeline()
+        )
+      )
+      .withValidationProfile(GraphQLFederationValidationProfile, GraphQLFederationEffectiveValidations)
+  }
+}

--- a/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLFederationConfiguration.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLFederationConfiguration.scala
@@ -1,6 +1,10 @@
 package amf.graphql.client.scala
 
-import amf.antlr.internal.plugins.syntax.{AntlrSyntaxRenderPlugin, GraphQLFederationSyntaxParsePlugin}
+import amf.antlr.internal.plugins.syntax.{
+  AntlrSyntaxRenderPlugin,
+  GraphQLFederationSyntaxParsePlugin,
+  SyamlForJsonLDSyntaxParsePlugin
+}
 import amf.apicontract.client.scala.{AMFConfiguration, APIConfigurationBuilder}
 import amf.apicontract.internal.validation.model.ApiEffectiveValidations.GraphQLFederationEffectiveValidations
 import amf.apicontract.internal.validation.model.ApiValidationProfiles.GraphQLFederationValidationProfile
@@ -29,5 +33,6 @@ object GraphQLFederationConfiguration extends APIConfigurationBuilder {
         )
       )
       .withValidationProfile(GraphQLFederationValidationProfile, GraphQLFederationEffectiveValidations)
+      .withPlugin(SyamlForJsonLDSyntaxParsePlugin) // override SYAML
   }
 }

--- a/amf-grpc/shared/src/main/scala/amf/grpc/client/scala/GRPCConfiguration.scala
+++ b/amf-grpc/shared/src/main/scala/amf/grpc/client/scala/GRPCConfiguration.scala
@@ -1,6 +1,6 @@
 package amf.grpc.client.scala
 
-import amf.antlr.internal.plugins.syntax.{AntlrSyntaxParsePlugin, AntlrSyntaxRenderPlugin}
+import amf.antlr.internal.plugins.syntax.{GrpcSyntaxParsePlugin, AntlrSyntaxRenderPlugin}
 import amf.apicontract.client.scala.{AMFConfiguration, APIConfigurationBuilder}
 import amf.grpc.internal.plugins.parse.GrpcParsePlugin
 import amf.grpc.internal.plugins.render.GrpcRenderPlugin
@@ -8,5 +8,5 @@ import amf.grpc.internal.plugins.render.GrpcRenderPlugin
 object GRPCConfiguration extends APIConfigurationBuilder {
   def GRPC(): AMFConfiguration =
     common()
-      .withPlugins(List(GrpcParsePlugin, AntlrSyntaxParsePlugin, GrpcRenderPlugin, AntlrSyntaxRenderPlugin))
+      .withPlugins(List(GrpcParsePlugin, GrpcSyntaxParsePlugin, GrpcRenderPlugin, AntlrSyntaxRenderPlugin))
 }

--- a/amf-grpc/shared/src/main/scala/amf/grpc/client/scala/GRPCConfiguration.scala
+++ b/amf-grpc/shared/src/main/scala/amf/grpc/client/scala/GRPCConfiguration.scala
@@ -1,6 +1,6 @@
 package amf.grpc.client.scala
 
-import amf.antlr.internal.plugins.syntax.{GrpcSyntaxParsePlugin, AntlrSyntaxRenderPlugin}
+import amf.antlr.internal.plugins.syntax.{AntlrSyntaxRenderPlugin, GrpcSyntaxParsePlugin, SyamlForJsonLDSyntaxParsePlugin}
 import amf.apicontract.client.scala.{AMFConfiguration, APIConfigurationBuilder}
 import amf.grpc.internal.plugins.parse.GrpcParsePlugin
 import amf.grpc.internal.plugins.render.GrpcRenderPlugin
@@ -9,4 +9,5 @@ object GRPCConfiguration extends APIConfigurationBuilder {
   def GRPC(): AMFConfiguration =
     common()
       .withPlugins(List(GrpcParsePlugin, GrpcSyntaxParsePlugin, GrpcRenderPlugin, AntlrSyntaxRenderPlugin))
+      .withPlugin(SyamlForJsonLDSyntaxParsePlugin) // override SYAML
 }


### PR DESCRIPTION
- Split ANTLR syntax parse plugin into individual GraphQL and GRPC syntax plugins
- W-11063850: add GraphQL federation configuration boilerplate
- Added GraphQL Federation syntax parse plugin

Depends on: https://github.com/aml-org/amf-antlr-ast/pull/21
Depends on: https://github.com/aml-org/amf-core/pull/487