### PR TITLE
W 11460908

### DIFF
--- a/amf-api-contract/shared/src/test/scala/amf/client/model/domain/DomainModelTests.scala
+++ b/amf-api-contract/shared/src/test/scala/amf/client/model/domain/DomainModelTests.scala
@@ -3,12 +3,7 @@ package amf.client.model.domain
 import amf.apicontract.client.platform.model.domain._
 import amf.apicontract.client.platform.model.domain.api.WebApi
 import amf.apicontract.client.platform.model.domain.bindings.mqtt.MqttServerLastWill
-import amf.apicontract.client.platform.model.domain.bindings.{
-  ChannelBindings,
-  MessageBindings,
-  OperationBindings,
-  ServerBindings
-}
+import amf.apicontract.client.platform.model.domain.bindings.{ChannelBindings, MessageBindings, OperationBindings, ServerBindings}
 import amf.apicontract.client.platform.model.domain.security._
 import amf.apicontract.client.scala.APIConfiguration
 import amf.apicontract.client.scala.model.domain
@@ -16,6 +11,7 @@ import amf.apicontract.internal.convert.ApiClientConverters._
 import amf.core.client.platform.model.domain.ScalarNode
 import amf.shapes.client.platform.model.domain._
 import amf.shapes.client.platform.model.domain.operations._
+import amf.shapes.client.scala.model.domain.federation.Key
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -559,5 +555,10 @@ class DomainModelTests extends AnyFunSuite with Matchers with BeforeAndAfterAll 
     operation.withResponse("201")
     operation.responses.asInternal(0).statusCode.value() shouldBe "200"
     operation.responses.asInternal(1).statusCode.value() shouldBe "201"
+  }
+
+  test("Test Key.isResolvable defaults to true") {
+    val k = Key()
+    k.isResolvable.value() shouldBe true
   }
 }

--- a/amf-cli/shared/src/test/scala/amf/parser/GraphQLDatagraphSetParsingTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/parser/GraphQLDatagraphSetParsingTest.scala
@@ -4,7 +4,8 @@ import amf.core.client.scala.config.RenderOptions
 import amf.core.internal.remote.{AmfJsonHint, GraphQLHint}
 import amf.cycle.GraphQLFunSuiteCycleTests
 
-class GraphQLDatagraphSetParsingTest extends GraphQLFunSuiteCycleTests {
+// make this trait a class to run this tests (do it locally, don't push to CI)
+trait GraphQLDatagraphSetParsingTest extends GraphQLFunSuiteCycleTests {
   override def basePath: String = s"amf-cli/shared/src/test/resources/graphql/datagraph-set/"
 
   // Test valid APIs

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/metamodel/federation/KeyModel.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/metamodel/federation/KeyModel.scala
@@ -21,7 +21,8 @@ object KeyModel extends DomainElementModel {
     Field(
       Bool,
       Federation + "isResolvable",
-      ModelDoc(ModelVocabularies.Federation, "isResolvable", "")
+      ModelDoc(ModelVocabularies.Federation, "isResolvable", ""),
+      defaultValue = Some(true)
     )
 
   override def modelInstance: Key = Key()


### PR DESCRIPTION
- W-11460908: make Key.resolvable default to true
- Skip GraphQL API sets test
Depends on:
- https://github.com/aml-org/amf-core/pull/497
