### PR TITLE
W-11087059/extend-query-introspection

### DIFF
--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-endpoints.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-endpoints.graphql
@@ -1,0 +1,7 @@
+schema {
+    query: Query
+}
+
+type Query {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-types.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-types.jsonld
@@ -8,10 +8,18 @@
         "doc:RootDomainElement",
         "doc:DomainElement"
       ],
-      "core:name": "introspected-types.graphql"
+      "core:name": "introspected-types.graphql",
+      "apiContract:endpoint": [
+        {
+          "@id": "#2"
+        },
+        {
+          "@id": "#32"
+        }
+      ]
     },
     {
-      "@id": "#2",
+      "@id": "#40",
       "@type": [
         "doc:APIContractProcessingData"
       ],
@@ -20,80 +28,194 @@
       "doc:sourceSpec": "GraphQL"
     },
     {
-      "@id": "",
-      "doc:declares": [
+      "@id": "#2",
+      "@type": [
+        "apiContract:EndPoint",
+        "doc:DomainElement"
+      ],
+      "apiContract:path": "/query/_entities",
+      "core:name": "Query._entities",
+      "apiContract:supportedOperation": [
+        {
+          "@id": "#3"
+        }
+      ]
+    },
+    {
+      "@id": "#32",
+      "@type": [
+        "apiContract:EndPoint",
+        "doc:DomainElement"
+      ],
+      "apiContract:path": "/query/_service",
+      "core:name": "Query._service",
+      "apiContract:supportedOperation": [
+        {
+          "@id": "#33"
+        }
+      ]
+    },
+    {
+      "@id": "#3",
+      "@type": [
+        "apiContract:Operation",
+        "core:Operation",
+        "doc:DomainElement"
+      ],
+      "apiContract:method": "query",
+      "core:name": "Query._entities",
+      "apiContract:expects": [
         {
           "@id": "#4"
-        },
-        {
-          "@id": "#11"
-        },
-        {
-          "@id": "#20"
-        },
-        {
-          "@id": "#29"
-        },
-        {
-          "@id": "#30"
-        },
-        {
-          "@id": "#31"
-        },
-        {
-          "@id": "#34"
-        },
-        {
-          "@id": "#35"
-        },
-        {
-          "@id": "#37"
-        },
-        {
-          "@id": "#42"
-        },
-        {
-          "@id": "#47"
         }
       ],
-      "@type": [
-        "doc:Document",
-        "doc:Fragment",
-        "doc:Module",
-        "doc:Unit"
+      "apiContract:returns": [
+        {
+          "@id": "#8"
+        }
       ],
-      "doc:encodes": {
-        "@id": "#1"
-      },
-      "doc:root": true,
-      "doc:processingData": {
-        "@id": "#2"
-      }
+      "apiContract:operationId": "Query._entities"
+    },
+    {
+      "@id": "#33",
+      "@type": [
+        "apiContract:Operation",
+        "core:Operation",
+        "doc:DomainElement"
+      ],
+      "apiContract:method": "query",
+      "core:name": "Query._service",
+      "apiContract:expects": [
+        {
+          "@id": "#34"
+        }
+      ],
+      "apiContract:returns": [
+        {
+          "@id": "#35"
+        }
+      ],
+      "apiContract:operationId": "Query._service"
     },
     {
       "@id": "#4",
       "@type": [
-        "shacl:NodeShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
+        "apiContract:Request",
+        "core:Request",
+        "apiContract:Message",
         "doc:DomainElement"
       ],
-      "shacl:property": [
+      "apiContract:parameter": [
         {
           "@id": "#5"
-        },
-        {
-          "@id": "#7"
-        },
+        }
+      ]
+    },
+    {
+      "@id": "#8",
+      "@type": [
+        "apiContract:Response",
+        "core:Response",
+        "apiContract:Message",
+        "doc:DomainElement"
+      ],
+      "apiContract:statusCode": "200",
+      "core:name": "default",
+      "apiContract:payload": [
         {
           "@id": "#9"
         }
-      ],
-      "shacl:name": "Romagnoli"
+      ]
     },
     {
-      "@id": "#11",
+      "@id": "#34",
+      "@type": [
+        "apiContract:Request",
+        "core:Request",
+        "apiContract:Message",
+        "doc:DomainElement"
+      ]
+    },
+    {
+      "@id": "#35",
+      "@type": [
+        "apiContract:Response",
+        "core:Response",
+        "apiContract:Message",
+        "doc:DomainElement"
+      ],
+      "apiContract:statusCode": "200",
+      "core:name": "default",
+      "apiContract:payload": [
+        {
+          "@id": "#36"
+        }
+      ]
+    },
+    {
+      "@id": "#5",
+      "@type": [
+        "apiContract:Parameter",
+        "core:Parameter",
+        "doc:DomainElement"
+      ],
+      "core:name": "representations",
+      "apiContract:required": true,
+      "apiContract:binding": "query",
+      "raml-shapes:schema": {
+        "@id": "#6"
+      }
+    },
+    {
+      "@id": "#9",
+      "@type": [
+        "apiContract:Payload",
+        "core:Payload",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:schema": {
+        "@id": "#10"
+      }
+    },
+    {
+      "@id": "#36",
+      "@type": [
+        "apiContract:Payload",
+        "core:Payload",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:schema": {
+        "@id": "#37"
+      }
+    },
+    {
+      "@id": "#6",
+      "@type": [
+        "raml-shapes:ArrayShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:items": {
+        "@id": "#7"
+      }
+    },
+    {
+      "@id": "#10",
+      "@type": [
+        "raml-shapes:ArrayShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:items": {
+        "@id": "#11"
+      }
+    },
+    {
+      "@id": "#37",
       "@type": [
         "shacl:NodeShape",
         "raml-shapes:AnyShape",
@@ -103,45 +225,13 @@
       ],
       "shacl:property": [
         {
-          "@id": "#12"
-        },
-        {
-          "@id": "#14"
+          "@id": "#38"
         }
       ],
-      "federation:keys": [
-        {
-          "@id": "#18"
-        }
-      ],
-      "shacl:name": "Dog"
+      "shacl:name": "_Service"
     },
     {
-      "@id": "#20",
-      "@type": [
-        "shacl:NodeShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "shacl:property": [
-        {
-          "@id": "#21"
-        },
-        {
-          "@id": "#23"
-        }
-      ],
-      "federation:keys": [
-        {
-          "@id": "#27"
-        }
-      ],
-      "shacl:name": "Cat"
-    },
-    {
-      "@id": "#29",
+      "@id": "#7",
       "@type": [
         "raml-shapes:ScalarShape",
         "raml-shapes:AnyShape",
@@ -158,7 +248,378 @@
       "shacl:name": "_Any"
     },
     {
+      "@id": "#11",
+      "@type": [
+        "raml-shapes:UnionShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:anyOf": [
+        {
+          "@id": "#12"
+        },
+        {
+          "@id": "#31"
+        }
+      ]
+    },
+    {
+      "@id": "#38",
+      "@type": [
+        "shacl:PropertyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:range": {
+        "@id": "#39"
+      },
+      "shacl:name": "sdl"
+    },
+    {
+      "@id": "#12",
+      "@type": [
+        "raml-shapes:UnionShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:anyOf": [
+        {
+          "@id": "#13"
+        },
+        {
+          "@id": "#22"
+        }
+      ],
+      "shacl:name": "_Entity"
+    },
+    {
+      "@id": "#31",
+      "@type": [
+        "raml-shapes:NilShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ]
+    },
+    {
+      "@id": "#39",
+      "@type": [
+        "raml-shapes:ScalarShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    },
+    {
+      "@id": "#13",
+      "@type": [
+        "shacl:NodeShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:property": [
+        {
+          "@id": "#14"
+        },
+        {
+          "@id": "#16"
+        }
+      ],
+      "federation:keys": [
+        {
+          "@id": "#20"
+        }
+      ],
+      "shacl:name": "Dog"
+    },
+    {
+      "@id": "#22",
+      "@type": [
+        "shacl:NodeShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:property": [
+        {
+          "@id": "#23"
+        },
+        {
+          "@id": "#25"
+        }
+      ],
+      "federation:keys": [
+        {
+          "@id": "#29"
+        }
+      ],
+      "shacl:name": "Cat"
+    },
+    {
+      "@id": "#14",
+      "@type": [
+        "shacl:PropertyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:range": {
+        "@id": "#15"
+      },
+      "shacl:minCount": 1,
+      "shacl:name": "id"
+    },
+    {
+      "@id": "#16",
+      "@type": [
+        "shacl:PropertyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:range": {
+        "@id": "#17"
+      },
+      "shacl:minCount": 0,
+      "shacl:name": "name"
+    },
+    {
+      "@id": "#20",
+      "@type": [
+        "federation:Key",
+        "doc:DomainElement"
+      ],
+      "federation:keyComponents": [
+        {
+          "@id": "#21"
+        }
+      ]
+    },
+    {
+      "@id": "#23",
+      "@type": [
+        "shacl:PropertyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:range": {
+        "@id": "#24"
+      },
+      "shacl:minCount": 1,
+      "shacl:name": "id"
+    },
+    {
+      "@id": "#25",
+      "@type": [
+        "shacl:PropertyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:range": {
+        "@id": "#26"
+      },
+      "shacl:minCount": 0,
+      "shacl:name": "name"
+    },
+    {
+      "@id": "#29",
+      "@type": [
+        "federation:Key",
+        "doc:DomainElement"
+      ],
+      "federation:keyComponents": [
+        {
+          "@id": "#30"
+        }
+      ]
+    },
+    {
+      "@id": "#15",
+      "@type": [
+        "raml-shapes:ScalarShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "raml-shapes:format": "ID"
+    },
+    {
+      "@id": "#17",
+      "@type": [
+        "raml-shapes:ScalarShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    },
+    {
+      "@id": "#21",
+      "@type": [
+        "raml-shapes:PropertyShapePath",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:path": {
+        "@id": "#21/list"
+      }
+    },
+    {
+      "@id": "#24",
+      "@type": [
+        "raml-shapes:ScalarShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "raml-shapes:format": "ID"
+    },
+    {
+      "@id": "#26",
+      "@type": [
+        "raml-shapes:ScalarShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    },
+    {
       "@id": "#30",
+      "@type": [
+        "raml-shapes:PropertyShapePath",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:path": {
+        "@id": "#30/list"
+      }
+    },
+    {
+      "@id": "#21/list",
+      "@type": "rdfs:Seq",
+      "rdfs:_1": {
+        "@id": "#16"
+      }
+    },
+    {
+      "@id": "#30/list",
+      "@type": "rdfs:Seq",
+      "rdfs:_1": {
+        "@id": "#25"
+      }
+    },
+    {
+      "@id": "",
+      "doc:declares": [
+        {
+          "@id": "#42"
+        },
+        {
+          "@id": "#13"
+        },
+        {
+          "@id": "#22"
+        },
+        {
+          "@id": "#7"
+        },
+        {
+          "@id": "#49"
+        },
+        {
+          "@id": "#37"
+        },
+        {
+          "@id": "#12"
+        },
+        {
+          "@id": "#50"
+        },
+        {
+          "@id": "#52"
+        },
+        {
+          "@id": "#57"
+        },
+        {
+          "@id": "#62"
+        }
+      ],
+      "@type": [
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "doc:encodes": {
+        "@id": "#1"
+      },
+      "doc:root": true,
+      "doc:processingData": {
+        "@id": "#40"
+      }
+    },
+    {
+      "@id": "#42",
+      "@type": [
+        "shacl:NodeShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:property": [
+        {
+          "@id": "#43"
+        },
+        {
+          "@id": "#45"
+        },
+        {
+          "@id": "#47"
+        }
+      ],
+      "shacl:name": "Romagnoli"
+    },
+    {
+      "@id": "#49",
       "@type": [
         "raml-shapes:ScalarShape",
         "raml-shapes:AnyShape",
@@ -175,42 +636,7 @@
       "shacl:name": "_FieldSet"
     },
     {
-      "@id": "#31",
-      "@type": [
-        "shacl:NodeShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "shacl:property": [
-        {
-          "@id": "#32"
-        }
-      ],
-      "shacl:name": "_Service"
-    },
-    {
-      "@id": "#34",
-      "@type": [
-        "raml-shapes:UnionShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "raml-shapes:anyOf": [
-        {
-          "@id": "#11"
-        },
-        {
-          "@id": "#20"
-        }
-      ],
-      "shacl:name": "_Entity"
-    },
-    {
-      "@id": "#35",
+      "@id": "#50",
       "@type": [
         "doc:DomainProperty",
         "rdf:Property",
@@ -222,12 +648,12 @@
         }
       ],
       "raml-shapes:schema": {
-        "@id": "#36"
+        "@id": "#51"
       },
       "core:name": "external"
     },
     {
-      "@id": "#37",
+      "@id": "#52",
       "@type": [
         "doc:DomainProperty",
         "rdf:Property",
@@ -245,12 +671,12 @@
         }
       ],
       "raml-shapes:schema": {
-        "@id": "#38"
+        "@id": "#53"
       },
       "core:name": "requires"
     },
     {
-      "@id": "#42",
+      "@id": "#57",
       "@type": [
         "doc:DomainProperty",
         "rdf:Property",
@@ -268,12 +694,12 @@
         }
       ],
       "raml-shapes:schema": {
-        "@id": "#43"
+        "@id": "#58"
       },
       "core:name": "provides"
     },
     {
-      "@id": "#47",
+      "@id": "#62",
       "@type": [
         "doc:DomainProperty",
         "rdf:Property",
@@ -285,12 +711,12 @@
         }
       ],
       "raml-shapes:schema": {
-        "@id": "#48"
+        "@id": "#63"
       },
       "core:name": "key"
     },
     {
-      "@id": "#5",
+      "@id": "#43",
       "@type": [
         "shacl:PropertyShape",
         "shacl:Shape",
@@ -298,13 +724,13 @@
         "doc:DomainElement"
       ],
       "raml-shapes:range": {
-        "@id": "#6"
+        "@id": "#44"
       },
       "shacl:minCount": 1,
       "shacl:name": "id"
     },
     {
-      "@id": "#7",
+      "@id": "#45",
       "@type": [
         "shacl:PropertyShape",
         "shacl:Shape",
@@ -312,13 +738,13 @@
         "doc:DomainElement"
       ],
       "raml-shapes:range": {
-        "@id": "#8"
+        "@id": "#46"
       },
       "shacl:minCount": 1,
       "shacl:name": "name"
     },
     {
-      "@id": "#9",
+      "@id": "#47",
       "@type": [
         "shacl:PropertyShape",
         "shacl:Shape",
@@ -326,106 +752,13 @@
         "doc:DomainElement"
       ],
       "raml-shapes:range": {
-        "@id": "#10"
+        "@id": "#48"
       },
       "shacl:minCount": 1,
       "shacl:name": "goals"
     },
     {
-      "@id": "#12",
-      "@type": [
-        "shacl:PropertyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "raml-shapes:range": {
-        "@id": "#13"
-      },
-      "shacl:minCount": 1,
-      "shacl:name": "id"
-    },
-    {
-      "@id": "#14",
-      "@type": [
-        "shacl:PropertyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "raml-shapes:range": {
-        "@id": "#15"
-      },
-      "shacl:minCount": 0,
-      "shacl:name": "name"
-    },
-    {
-      "@id": "#18",
-      "@type": [
-        "federation:Key",
-        "doc:DomainElement"
-      ],
-      "federation:keyComponents": [
-        {
-          "@id": "#19"
-        }
-      ]
-    },
-    {
-      "@id": "#21",
-      "@type": [
-        "shacl:PropertyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "raml-shapes:range": {
-        "@id": "#22"
-      },
-      "shacl:minCount": 1,
-      "shacl:name": "id"
-    },
-    {
-      "@id": "#23",
-      "@type": [
-        "shacl:PropertyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "raml-shapes:range": {
-        "@id": "#24"
-      },
-      "shacl:minCount": 0,
-      "shacl:name": "name"
-    },
-    {
-      "@id": "#27",
-      "@type": [
-        "federation:Key",
-        "doc:DomainElement"
-      ],
-      "federation:keyComponents": [
-        {
-          "@id": "#28"
-        }
-      ]
-    },
-    {
-      "@id": "#32",
-      "@type": [
-        "shacl:PropertyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "raml-shapes:range": {
-        "@id": "#33"
-      },
-      "shacl:name": "sdl"
-    },
-    {
-      "@id": "#36",
+      "@id": "#51",
       "@type": [
         "shacl:NodeShape",
         "raml-shapes:AnyShape",
@@ -435,7 +768,7 @@
       ]
     },
     {
-      "@id": "#38",
+      "@id": "#53",
       "@type": [
         "raml-shapes:UnionShape",
         "raml-shapes:AnyShape",
@@ -445,15 +778,15 @@
       ],
       "raml-shapes:anyOf": [
         {
-          "@id": "#39"
+          "@id": "#54"
         },
         {
-          "@id": "#41"
+          "@id": "#56"
         }
       ]
     },
     {
-      "@id": "#43",
+      "@id": "#58",
       "@type": [
         "raml-shapes:UnionShape",
         "raml-shapes:AnyShape",
@@ -463,15 +796,15 @@
       ],
       "raml-shapes:anyOf": [
         {
-          "@id": "#44"
+          "@id": "#59"
         },
         {
-          "@id": "#46"
+          "@id": "#61"
         }
       ]
     },
     {
-      "@id": "#48",
+      "@id": "#63",
       "@type": [
         "raml-shapes:UnionShape",
         "raml-shapes:AnyShape",
@@ -481,15 +814,15 @@
       ],
       "raml-shapes:anyOf": [
         {
-          "@id": "#49"
+          "@id": "#64"
         },
         {
-          "@id": "#51"
+          "@id": "#66"
         }
       ]
     },
     {
-      "@id": "#6",
+      "@id": "#44",
       "@type": [
         "raml-shapes:ScalarShape",
         "raml-shapes:AnyShape",
@@ -505,7 +838,7 @@
       "raml-shapes:format": "ID"
     },
     {
-      "@id": "#8",
+      "@id": "#46",
       "@type": [
         "raml-shapes:ScalarShape",
         "raml-shapes:AnyShape",
@@ -520,7 +853,7 @@
       ]
     },
     {
-      "@id": "#10",
+      "@id": "#48",
       "@type": [
         "raml-shapes:ScalarShape",
         "raml-shapes:AnyShape",
@@ -535,104 +868,7 @@
       ]
     },
     {
-      "@id": "#13",
-      "@type": [
-        "raml-shapes:ScalarShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "shacl:datatype": [
-        {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
-        }
-      ],
-      "raml-shapes:format": "ID"
-    },
-    {
-      "@id": "#15",
-      "@type": [
-        "raml-shapes:ScalarShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "shacl:datatype": [
-        {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
-        }
-      ]
-    },
-    {
-      "@id": "#19",
-      "@type": [
-        "raml-shapes:PropertyShapePath",
-        "doc:DomainElement"
-      ],
-      "raml-shapes:path": {
-        "@id": "#19/list"
-      }
-    },
-    {
-      "@id": "#22",
-      "@type": [
-        "raml-shapes:ScalarShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "shacl:datatype": [
-        {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
-        }
-      ],
-      "raml-shapes:format": "ID"
-    },
-    {
-      "@id": "#24",
-      "@type": [
-        "raml-shapes:ScalarShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "shacl:datatype": [
-        {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
-        }
-      ]
-    },
-    {
-      "@id": "#28",
-      "@type": [
-        "raml-shapes:PropertyShapePath",
-        "doc:DomainElement"
-      ],
-      "raml-shapes:path": {
-        "@id": "#28/list"
-      }
-    },
-    {
-      "@id": "#33",
-      "@type": [
-        "raml-shapes:ScalarShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "shacl:datatype": [
-        {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
-        }
-      ]
-    },
-    {
-      "@id": "#39",
+      "@id": "#54",
       "@type": [
         "shacl:NodeShape",
         "raml-shapes:AnyShape",
@@ -642,12 +878,12 @@
       ],
       "shacl:property": [
         {
-          "@id": "#40"
+          "@id": "#55"
         }
       ]
     },
     {
-      "@id": "#41",
+      "@id": "#56",
       "@type": [
         "raml-shapes:NilShape",
         "shacl:Shape",
@@ -656,7 +892,7 @@
       ]
     },
     {
-      "@id": "#44",
+      "@id": "#59",
       "@type": [
         "shacl:NodeShape",
         "raml-shapes:AnyShape",
@@ -666,12 +902,12 @@
       ],
       "shacl:property": [
         {
-          "@id": "#45"
+          "@id": "#60"
         }
       ]
     },
     {
-      "@id": "#46",
+      "@id": "#61",
       "@type": [
         "raml-shapes:NilShape",
         "shacl:Shape",
@@ -680,7 +916,7 @@
       ]
     },
     {
-      "@id": "#49",
+      "@id": "#64",
       "@type": [
         "shacl:NodeShape",
         "raml-shapes:AnyShape",
@@ -690,12 +926,12 @@
       ],
       "shacl:property": [
         {
-          "@id": "#50"
+          "@id": "#65"
         }
       ]
     },
     {
-      "@id": "#51",
+      "@id": "#66",
       "@type": [
         "raml-shapes:NilShape",
         "shacl:Shape",
@@ -704,21 +940,7 @@
       ]
     },
     {
-      "@id": "#19/list",
-      "@type": "rdfs:Seq",
-      "rdfs:_1": {
-        "@id": "#14"
-      }
-    },
-    {
-      "@id": "#28/list",
-      "@type": "rdfs:Seq",
-      "rdfs:_1": {
-        "@id": "#23"
-      }
-    },
-    {
-      "@id": "#40",
+      "@id": "#55",
       "@type": [
         "shacl:PropertyShape",
         "shacl:Shape",
@@ -726,12 +948,12 @@
         "doc:DomainElement"
       ],
       "raml-shapes:range": {
-        "@id": "#30"
+        "@id": "#49"
       },
       "shacl:name": "fieldSet"
     },
     {
-      "@id": "#45",
+      "@id": "#60",
       "@type": [
         "shacl:PropertyShape",
         "shacl:Shape",
@@ -739,12 +961,12 @@
         "doc:DomainElement"
       ],
       "raml-shapes:range": {
-        "@id": "#30"
+        "@id": "#49"
       },
       "shacl:name": "fieldSet"
     },
     {
-      "@id": "#50",
+      "@id": "#65",
       "@type": [
         "shacl:PropertyShape",
         "shacl:Shape",
@@ -752,15 +974,15 @@
         "doc:DomainElement"
       ],
       "raml-shapes:range": {
-        "@id": "#30"
+        "@id": "#49"
       },
       "shacl:name": "fieldSet"
     }
   ],
   "@context": {
     "@base": "amf://id",
-    "raml-shapes": "http://a.ml/vocabularies/shapes#",
     "shacl": "http://www.w3.org/ns/shacl#",
+    "raml-shapes": "http://a.ml/vocabularies/shapes#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "doc": "http://a.ml/vocabularies/document#",
     "apiContract": "http://a.ml/vocabularies/apiContract#",

--- a/amf-cli/shared/src/test/scala/amf/resolution/GraphQLFederationTransformationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/GraphQLFederationTransformationTest.scala
@@ -1,6 +1,7 @@
 package amf.resolution
 
 import amf.apicontract.client.scala.AMFConfiguration
+import amf.apicontract.client.scala.model.domain.api.Api
 import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.errorhandling.UnhandledErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
@@ -62,6 +63,15 @@ class GraphQLFederationTransformationTest extends GraphQLFederationFunSuiteCycle
       directory = basePath.stripPrefix("file://"),
       renderOptions = Some(RenderOptions().withPrettyPrint.withCompactUris.withCompactedEmission)
     )
+  }
+
+  test("Introspection should add _entities and _service endpoints to existing") {
+    transformed("introspected-endpoints.graphql").map { doc =>
+      val endpoints = doc.encodes.asInstanceOf[Api].endPoints
+      endpoints should have size 3
+      endpoints.find(_.name.value() == "Query._entities") shouldBe a[Some[_]]
+      endpoints.find(_.name.value() == "Query._service") shouldBe a[Some[_]]
+    }
   }
 
   private def findShapeWithName(shapes: Seq[DomainElement], name: String): Option[DomainElement] = {

--- a/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLConfiguration.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/client/scala/GraphQLConfiguration.scala
@@ -11,8 +11,8 @@ import amf.apicontract.internal.validation.model.ApiEffectiveValidations.GraphQL
 import amf.apicontract.internal.validation.model.ApiValidationProfiles.GraphQLValidationProfile
 import amf.apicontract.internal.validation.shacl.APIShaclModelValidationPlugin
 import amf.core.client.common.validation.ProfileNames
-import amf.graphql.plugins.parse.GraphQLParsePlugin
-import amf.graphql.plugins.render.GraphQLRenderPlugin
+import amf.graphql.internal.spec.plugins.parse.GraphQLParsePlugin
+import amf.graphql.internal.spec.plugins.render.GraphQLRenderPlugin
 
 object GraphQLConfiguration extends APIConfigurationBuilder {
 

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/GraphQLRootTypeParser.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/GraphQLRootTypeParser.scala
@@ -75,7 +75,6 @@ case class GraphQLRootTypeParser(ast: Node, queryType: RootTypes.Value)(implicit
 
     val queryParam = Parameter(toAnnotations(argument)).withName(fieldName, annotations).withBinding("query")
     parseDescription(argument, queryParam, queryParam.meta)
-
     unpackNilUnion(parseType(argument)) match {
       case NullableShape(true, shape) =>
         setDefaultValue(argument, queryParam)

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/GraphQLRootTypeParser.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/GraphQLRootTypeParser.scala
@@ -4,6 +4,7 @@ import amf.apicontract.client.scala.model.domain.{EndPoint, Operation, Parameter
 import amf.apicontract.internal.metamodel.domain.EndPointModel
 import amf.graphql.internal.spec.context.GraphQLBaseWebApiContext
 import amf.graphql.internal.spec.context.GraphQLBaseWebApiContext.RootTypes
+import amf.graphql.internal.spec.domain.model.EndpointPath
 import amf.graphql.internal.spec.parser.syntax.TokenTypes.{
   ARGUMENTS_DEFINITION,
   FIELDS_DEFINITION,
@@ -26,18 +27,10 @@ case class GraphQLRootTypeParser(ast: Node, queryType: RootTypes.Value)(implicit
     }
   }
 
-  private def path(fieldName: String): String = {
-    queryType match {
-      case RootTypes.Query        => s"/query/$fieldName"
-      case RootTypes.Mutation     => s"/mutation/$fieldName"
-      case RootTypes.Subscription => s"/subscription/$fieldName"
-    }
-  }
-
   private def parseField(f: Node) = {
     val endPoint: EndPoint       = EndPoint(toAnnotations(f))
     val (fieldName, annotations) = findName(f, "AnonymousField", "Missing name for root type field")
-    val endpointPath             = path(fieldName)
+    val endpointPath             = EndpointPath(fieldName, queryType)
     endPoint.withPath(endpointPath).withName(s"$rootTypeName.$fieldName", annotations)
     parseDescription(f, endPoint, endPoint.meta)
     parseOperation(f, endPoint, fieldName)

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/GraphQLRootTypeParser.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/GraphQLRootTypeParser.scala
@@ -4,7 +4,7 @@ import amf.apicontract.client.scala.model.domain.{EndPoint, Operation, Parameter
 import amf.apicontract.internal.metamodel.domain.EndPointModel
 import amf.graphql.internal.spec.context.GraphQLBaseWebApiContext
 import amf.graphql.internal.spec.context.GraphQLBaseWebApiContext.RootTypes
-import amf.graphql.internal.spec.domain.model.EndpointPath
+import amf.graphql.internal.spec.domain.model.{EndpointPath, OperationMethod}
 import amf.graphql.internal.spec.parser.syntax.TokenTypes.{
   ARGUMENTS_DEFINITION,
   FIELDS_DEFINITION,
@@ -41,11 +41,7 @@ case class GraphQLRootTypeParser(ast: Node, queryType: RootTypes.Value)(implicit
   def parseOperation(f: Node, endPoint: EndPoint, fieldName: String): Unit = {
     val operationId = s"$rootTypeName.$fieldName"
 
-    val method = queryType match {
-      case RootTypes.Query        => "query"
-      case RootTypes.Mutation     => "post"
-      case RootTypes.Subscription => "subscribe"
-    }
+    val method = OperationMethod(queryType)
 
     val op: Operation = endPoint.withOperation(method).withName(operationId).withOperationId(operationId)
     val request       = op.withRequest()

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/model/EndpointPath.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/model/EndpointPath.scala
@@ -1,0 +1,12 @@
+package amf.graphql.internal.spec.domain.model
+
+import amf.graphql.internal.spec.context.GraphQLBaseWebApiContext.RootTypes
+
+object EndpointPath {
+
+  def apply(fieldName: String, operationType: RootTypes.Value): String = operationType match {
+    case RootTypes.Query        => s"/query/$fieldName"
+    case RootTypes.Mutation     => s"/mutation/$fieldName"
+    case RootTypes.Subscription => s"/subscription/$fieldName"
+  }
+}

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/model/FieldBuilder.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/model/FieldBuilder.scala
@@ -1,0 +1,84 @@
+package amf.graphql.internal.spec.domain.model
+
+import amf.apicontract.client.scala.model.domain.{EndPoint, Operation, Parameter}
+import amf.core.client.scala.model.domain.AmfScalar
+import amf.core.internal.metamodel.domain.common.DescriptionField
+import amf.core.internal.parser.domain.Annotations
+import amf.graphql.internal.spec.context.GraphQLBaseWebApiContext.RootTypes
+import amf.graphql.internal.spec.domain.model.FieldBuilderInfo._
+import amf.shapes.client.scala.model.domain.AnyShape
+
+trait FieldBuilderInfo
+object FieldBuilderInfo {
+  sealed trait Empty         extends FieldBuilderInfo
+  sealed trait Name          extends FieldBuilderInfo
+  sealed trait TypeName      extends FieldBuilderInfo
+  sealed trait OperationType extends FieldBuilderInfo
+  sealed trait Schema        extends FieldBuilderInfo
+
+  type Mandatory = Empty with Name with TypeName with OperationType with Schema
+}
+
+object FieldBuilder {
+  def empty(annotations: Annotations): FieldBuilder[Empty] = FieldBuilder[Empty](annotations)
+  def empty(): FieldBuilder[Empty]                         = empty(Annotations.empty)
+}
+
+case class FieldBuilder[I <: FieldBuilderInfo](
+    annotations: Annotations,
+    name: AmfScalar = EmptyScalar,
+    typeName: String = "",
+    description: Option[AmfScalar] = None,
+    operationType: RootTypes.Value = RootTypes.Query,
+    arguments: List[Parameter] = List.empty,
+    schema: AnyShape = AnyShape()
+) {
+
+  def withName(name: AmfScalar): FieldBuilder[I with Name] = {
+    copy(name = name)
+  }
+
+  def withName(name: String): FieldBuilder[I with Name] = {
+    copy(name = AmfScalar(name))
+  }
+
+  def withTypeName(name: String): FieldBuilder[I with TypeName] = {
+    copy(typeName = name)
+  }
+
+  def withOperationType(`type`: RootTypes.Value): FieldBuilder[I with OperationType] = {
+    copy(operationType = `type`)
+  }
+
+  def withDescription(description: AmfScalar): FieldBuilder[I] = {
+    copy(description = Some(description))
+  }
+
+  def withArguments(arguments: List[Parameter]): FieldBuilder[I] = {
+    copy(arguments = arguments)
+  }
+
+  def withSchema(schema: AnyShape): FieldBuilder[I with Schema] = {
+    copy(schema = schema)
+  }
+
+  def build()(implicit ev: I =:= Mandatory): EndPoint = {
+    val endpoint     = EndPoint(annotations)
+    val endpointPath = EndpointPath(name.toString(), operationType)
+    description.foreach(scalar => endpoint.set(DescriptionField.Description, scalar.toString(), scalar.annotations))
+    endpoint.withPath(endpointPath).withName(s"$typeName.$name", name.annotations)
+    endpoint.withOperations(Seq(operation(endpoint)))
+  }
+
+  private def operation(endpoint: EndPoint): Operation = {
+    val operationId = endpoint.name.value()
+    val method      = OperationMethod(operationType)
+    val result      = Operation().withMethod(method).withName(operationId).withOperationId(operationId)
+    val request     = result.withRequest()
+    if (arguments.nonEmpty) request.withQueryParameters(arguments)
+    result.withResponse().withPayload().withSchema(schema)
+    result
+  }
+}
+
+object EmptyScalar extends AmfScalar("", Annotations())

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/model/GraphqlArgument.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/model/GraphqlArgument.scala
@@ -1,0 +1,16 @@
+package amf.graphql.internal.spec.domain.model
+
+import amf.apicontract.client.scala.model.domain.Parameter
+import amf.core.client.scala.model.domain.AmfScalar
+import amf.core.internal.parser.domain.Annotations
+
+object GraphqlArgument {
+
+  def apply(annotations: Annotations, fieldName: AmfScalar) = {
+    Parameter(annotations).withName(fieldName.toString(), fieldName.annotations).withBinding("query")
+  }
+
+  def apply(name: String) = {
+    Parameter().withName(name).withBinding("query")
+  }
+}

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/model/OperationMethod.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/domain/model/OperationMethod.scala
@@ -1,0 +1,12 @@
+package amf.graphql.internal.spec.domain.model
+
+import amf.graphql.internal.spec.context.GraphQLBaseWebApiContext.RootTypes
+
+object OperationMethod {
+
+  def apply(operationType: RootTypes.Value) = operationType match {
+    case RootTypes.Query        => "query"
+    case RootTypes.Mutation     => "post"
+    case RootTypes.Subscription => "subscribe"
+  }
+}

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/emitter/domain/GraphQLEmitter.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/emitter/domain/GraphQLEmitter.scala
@@ -5,7 +5,7 @@ import amf.core.client.scala.model.domain.Shape
 import amf.core.internal.plugins.syntax.StringDocBuilder
 import amf.graphql.internal.spec.parser.syntax.NullableShape
 import amf.graphql.internal.spec.parser.syntax.TokenTypes._
-import amf.graphql.plugins.parse.GraphQLParsePlugin._
+import amf.graphql.internal.spec.plugins.parse.GraphQLParsePlugin._
 import amf.shapes.client.scala.model.domain.{AnyShape, ArrayShape, ScalarShape, UnionShape}
 import org.mulesoft.common.client.lexical.Position
 

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/emitter/domain/GraphQLOperationFieldEmitter.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/emitter/domain/GraphQLOperationFieldEmitter.scala
@@ -5,7 +5,7 @@ import amf.core.internal.plugins.syntax.StringDocBuilder
 import amf.core.internal.render.BaseEmitters.pos
 import amf.graphql.internal.spec.emitter.context.GraphQLEmitterContext
 import amf.graphql.internal.spec.parser.syntax.NullableShape
-import amf.graphql.plugins.parse.GraphQLParsePlugin.unpackNilUnion
+import amf.graphql.internal.spec.plugins.parse.GraphQLParsePlugin.unpackNilUnion
 import amf.shapes.client.scala.model.domain.AnyShape
 import amf.shapes.client.scala.model.domain.operations.{ShapeOperation, ShapeParameter}
 

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/parser/syntax/GraphQLASTParserHelper.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/parser/syntax/GraphQLASTParserHelper.scala
@@ -2,7 +2,7 @@ package amf.graphql.internal.spec.parser.syntax
 
 import amf.antlr.client.scala.parse.syntax.AntlrASTParserHelper
 import amf.core.client.scala.model.DataType
-import amf.core.client.scala.model.domain.{DomainElement, Shape}
+import amf.core.client.scala.model.domain.{AmfScalar, DomainElement, Shape}
 import amf.core.internal.metamodel.domain.common.DescriptionField
 import amf.core.internal.parser.domain.{Annotations, SearchScope}
 import amf.graphql.internal.spec.context.GraphQLBaseWebApiContext
@@ -39,6 +39,10 @@ trait GraphQLASTParserHelper extends AntlrASTParserHelper {
     findDescription(n).foreach { desc =>
       element.set(model.Description, cleanDocumentation(desc.value), toAnnotations(desc))
     }
+  }
+
+  def parseDescription(n: ASTNode): Option[AmfScalar] = {
+    findDescription(n).map { desc => AmfScalar(cleanDocumentation(desc.value), toAnnotations(desc)) }
   }
 
   def findDescription(n: ASTNode): Option[Terminal] = {

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/plugins/parse/GraphQLParsePlugin.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/plugins/parse/GraphQLParsePlugin.scala
@@ -1,4 +1,4 @@
-package amf.graphqlfederation.plugins.parse
+package amf.graphql.internal.spec.plugins.parse
 
 import amf.antlr.client.scala.parse.document.AntlrParsedDocument
 import amf.apicontract.internal.plugins.ApiParsePlugin
@@ -13,12 +13,13 @@ import amf.core.client.scala.parse.document.{
 }
 import amf.core.internal.parser.Root
 import amf.core.internal.remote.{GraphQL, Spec, Syntax}
+import amf.graphql.internal.spec.context.GraphQLWebApiContext
 import amf.graphql.internal.spec.document.GraphQLBaseDocumentParser
 import amf.graphql.internal.spec.parser.syntax.GraphQLASTParserHelper
-import amf.graphql.internal.spec.parser.syntax.TokenTypes.{DEFINITION, TYPE_SYSTEM_DEFINITION}
-import amf.graphqlfederation.internal.spec.context.GraphQLFederationWebApiContext
+import amf.graphql.internal.spec.parser.syntax.TokenTypes.{DEFINITION, DOCUMENT, TYPE_SYSTEM_DEFINITION}
+import org.mulesoft.antlrast.ast.Node
 
-object GraphQLFederationParsePlugin extends ApiParsePlugin with GraphQLASTParserHelper {
+object GraphQLParsePlugin extends ApiParsePlugin with GraphQLASTParserHelper {
   override def spec: Spec = GraphQL
 
   override def parse(document: Root, ctx: ParserContext): BaseUnit = {
@@ -28,8 +29,8 @@ object GraphQLFederationParsePlugin extends ApiParsePlugin with GraphQLASTParser
   override def referenceHandler(eh: AMFErrorHandler): ReferenceHandler =
     (_: ParsedDocument, _: ParserContext) => CompilerReferenceCollector()
 
-  private def context(document: Root, ctx: ParserContext): GraphQLFederationWebApiContext = {
-    new GraphQLFederationWebApiContext(
+  private def context(document: Root, ctx: ParserContext): GraphQLWebApiContext = {
+    new GraphQLWebApiContext(
       ctx.rootContextDocument,
       ctx.refs,
       ctx.parsingOptions,
@@ -51,7 +52,9 @@ object GraphQLFederationParsePlugin extends ApiParsePlugin with GraphQLASTParser
     }
   }
 
-  private def isGraphQL(doc: AntlrParsedDocument): Boolean = collect(doc.ast.root(), Seq(DEFINITION)).nonEmpty
+  private def isGraphQL(doc: AntlrParsedDocument): Boolean = {
+    collect(doc.ast.root(), Seq(DEFINITION, TYPE_SYSTEM_DEFINITION)).exists(e => e.name == TYPE_SYSTEM_DEFINITION)
+  }
 
   override def withIdAdoption: Boolean = true // TODO pending analysis and parsing cleanup
 }

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/plugins/render/GraphQLRenderPlugin.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/plugins/render/GraphQLRenderPlugin.scala
@@ -1,4 +1,4 @@
-package amf.graphql.plugins.render
+package amf.graphql.internal.spec.plugins.render
 
 import amf.core.internal.remote.{GraphQL, Syntax}
 import amf.core.client.common.{NormalPriority, PluginPriority}

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/client/scala/GraphQLFederationConfiguration.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/client/scala/GraphQLFederationConfiguration.scala
@@ -10,8 +10,8 @@ import amf.apicontract.internal.validation.model.ApiEffectiveValidations.GraphQL
 import amf.apicontract.internal.validation.model.ApiValidationProfiles.GraphQLFederationValidationProfile
 import amf.apicontract.internal.validation.shacl.APIShaclModelValidationPlugin
 import amf.core.client.common.validation.ProfileNames
+import amf.graphqlfederation.internal.plugins.GraphQLFederationParsePlugin
 import amf.graphqlfederation.internal.spec.transformation.GraphQLFederationIntrospectionPipeline
-import amf.graphqlfederation.plugins.parse.GraphQLFederationParsePlugin
 
 object GraphQLFederationConfiguration extends APIConfigurationBuilder {
 

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/plugins/GraphQLFederationParsePlugin.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/plugins/GraphQLFederationParsePlugin.scala
@@ -1,4 +1,4 @@
-package amf.graphql.plugins.parse
+package amf.graphqlfederation.internal.plugins
 
 import amf.antlr.client.scala.parse.document.AntlrParsedDocument
 import amf.apicontract.internal.plugins.ApiParsePlugin
@@ -13,13 +13,12 @@ import amf.core.client.scala.parse.document.{
 }
 import amf.core.internal.parser.Root
 import amf.core.internal.remote.{GraphQL, Spec, Syntax}
-import amf.graphql.internal.spec.context.GraphQLWebApiContext
 import amf.graphql.internal.spec.document.GraphQLBaseDocumentParser
 import amf.graphql.internal.spec.parser.syntax.GraphQLASTParserHelper
-import amf.graphql.internal.spec.parser.syntax.TokenTypes.{DEFINITION, DOCUMENT, TYPE_SYSTEM_DEFINITION}
-import org.mulesoft.antlrast.ast.Node
+import amf.graphql.internal.spec.parser.syntax.TokenTypes.DEFINITION
+import amf.graphqlfederation.internal.spec.context.GraphQLFederationWebApiContext
 
-object GraphQLParsePlugin extends ApiParsePlugin with GraphQLASTParserHelper {
+object GraphQLFederationParsePlugin extends ApiParsePlugin with GraphQLASTParserHelper {
   override def spec: Spec = GraphQL
 
   override def parse(document: Root, ctx: ParserContext): BaseUnit = {
@@ -29,8 +28,8 @@ object GraphQLParsePlugin extends ApiParsePlugin with GraphQLASTParserHelper {
   override def referenceHandler(eh: AMFErrorHandler): ReferenceHandler =
     (_: ParsedDocument, _: ParserContext) => CompilerReferenceCollector()
 
-  private def context(document: Root, ctx: ParserContext): GraphQLWebApiContext = {
-    new GraphQLWebApiContext(
+  private def context(document: Root, ctx: ParserContext): GraphQLFederationWebApiContext = {
+    new GraphQLFederationWebApiContext(
       ctx.rootContextDocument,
       ctx.refs,
       ctx.parsingOptions,
@@ -52,9 +51,7 @@ object GraphQLParsePlugin extends ApiParsePlugin with GraphQLASTParserHelper {
     }
   }
 
-  private def isGraphQL(doc: AntlrParsedDocument): Boolean = {
-    collect(doc.ast.root(), Seq(DEFINITION, TYPE_SYSTEM_DEFINITION)).exists(e => e.name == TYPE_SYSTEM_DEFINITION)
-  }
+  private def isGraphQL(doc: AntlrParsedDocument): Boolean = collect(doc.ast.root(), Seq(DEFINITION)).nonEmpty
 
   override def withIdAdoption: Boolean = true // TODO pending analysis and parsing cleanup
 }

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionDirectives.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionDirectives.scala
@@ -1,0 +1,54 @@
+package amf.graphqlfederation.internal.spec.transformation.introspection
+
+import amf.core.client.scala.model.domain.extensions.{CustomDomainProperty, PropertyShape}
+import amf.graphql.internal.spec.parser.syntax.Locations.domainFor
+import TypeBuilders.nullable
+import amf.shapes.client.scala.model.domain.{NodeShape, ScalarShape}
+
+object IntrospectionDirectives {
+
+  private val FIELD_DEFINITION = "FIELD_DEFINITION"
+  private val SCHEMA           = "SCHEMA"
+  private val OBJECT           = "OBJECT"
+  private val INTERFACE        = "INTERFACE"
+
+  def `@external`(): CustomDomainProperty = {
+    CustomDomainProperty()
+      .withName("external")
+      .withSchema(NodeShape())
+      .withDomain(domainFor(SCHEMA))
+  }
+
+  def `@requires`(fieldSet: ScalarShape): CustomDomainProperty = {
+    CustomDomainProperty()
+      .withName("requires")
+      .withSchema(nullable(fieldSetArgument(fieldSet)))
+      .withDomain(domainFor(FIELD_DEFINITION))
+  }
+
+  def `@provides`(fieldSet: ScalarShape): CustomDomainProperty = {
+    CustomDomainProperty()
+      .withName("provides")
+      .withSchema(nullable(fieldSetArgument(fieldSet)))
+      .withDomain(domainFor(FIELD_DEFINITION))
+  }
+
+  def `@key`(fieldSet: ScalarShape): CustomDomainProperty = {
+    // TODO: 'repeatable is not modeled'
+    CustomDomainProperty()
+      .withName("key")
+      .withSchema(nullable(fieldSetArgument(fieldSet)))
+      .withDomain(domainFor(OBJECT, INTERFACE))
+  }
+
+  private def fieldSetArgument(fieldSet: ScalarShape): NodeShape = {
+    NodeShape()
+      .withProperties(
+        List(
+          PropertyShape()
+            .withName("fieldSet")
+            .withRange(fieldSet)
+        )
+      )
+  }
+}

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionTypes.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionTypes.scala
@@ -1,0 +1,82 @@
+package amf.graphqlfederation.internal.spec.transformation.introspection
+
+import amf.apicontract.client.scala.model.domain.EndPoint
+import amf.core.client.platform.model.DataTypes
+import amf.core.client.scala.model.domain.extensions.PropertyShape
+import amf.graphql.internal.spec.context.GraphQLBaseWebApiContext.RootTypes
+import amf.graphql.internal.spec.domain.model.{FieldBuilder, GraphqlArgument}
+import TypeBuilders.{array, nullable}
+import amf.shapes.client.scala.model.domain.{AnyShape, NodeShape, ScalarShape, UnionShape}
+
+object IntrospectionTypes {
+
+  def _Any(): ScalarShape = {
+    ScalarShape()
+      .withName("_Any")
+      .withFormat("_Any")
+      .withDataType(DataTypes.String)
+  }
+
+  def _FieldSet(): ScalarShape = {
+    ScalarShape()
+      .withName("_FieldSet")
+      .withFormat("_FieldSet")
+      .withDataType(DataTypes.String)
+  }
+
+  def _Service(): NodeShape = {
+    NodeShape()
+      .withName("_Service")
+      .withProperties(
+        List(
+          PropertyShape()
+            .withName("sdl")
+            .withRange(
+              ScalarShape()
+                .withDataType(DataTypes.String)
+            )
+        )
+      )
+  }
+
+  def _Entity(types: Seq[NodeShape]): UnionShape = {
+    val typesWithKey = types.filter(_.keys.nonEmpty)
+    UnionShape()
+      .withName("_Entity")
+      .withAnyOf(typesWithKey)
+  }
+
+  def _Query(_any: AnyShape, _entity: AnyShape, _serviceType: AnyShape): List[EndPoint] = {
+    List(
+      _entities(_any, _entity),
+      _service(_serviceType)
+    )
+  }
+
+  private def _service(_serviceType: AnyShape): EndPoint = {
+    queryField("_service")
+      .withSchema(_serviceType)
+      .build()
+  }
+
+  private def _entities(_any: AnyShape, _entity: AnyShape): EndPoint = {
+    queryField("_entities")
+      .withArguments(
+        List(
+          GraphqlArgument("representations")
+            .withSchema(array(_any))
+            .withRequired(true)
+        )
+      )
+      .withSchema(array(nullable(_entity)))
+      .build()
+  }
+
+  private def queryField(name: String) = {
+    FieldBuilder
+      .empty()
+      .withName(name)
+      .withTypeName("Query")
+      .withOperationType(RootTypes.Query)
+  }
+}

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/TypeBuilders.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/TypeBuilders.scala
@@ -1,0 +1,18 @@
+package amf.graphqlfederation.internal.spec.transformation.introspection
+
+import amf.shapes.client.scala.model.domain.{AnyShape, ArrayShape, NilShape, UnionShape}
+
+object TypeBuilders {
+
+  def nullable(shape: AnyShape): UnionShape = {
+    UnionShape()
+      .withAnyOf(
+        List(
+          shape,
+          NilShape()
+        )
+      )
+  }
+
+  def array(shape: AnyShape): ArrayShape = ArrayShape().withItems(shape)
+}


### PR DESCRIPTION
- (refactor): moved graphql plugins inside the 'internal' package
- (refactor): removed useless setter function from root type parser to avoid side effects in parsing
- (refactor): made nil union unpacking more readable, removed simple duplication
- (refactor): extracted endpoint path construction for reuse
- (refactor): extracted operation method construction for reuse
- W-11087059: added type Query extensions for introspected schemas
