### PR TITLE
W 11542569

### DIFF
--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.flattened.jsonld
@@ -1,0 +1,247 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/web-api",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#WebAPI",
+        "http://a.ml/vocabularies/apiContract#API",
+        "http://a.ml/vocabularies/document#RootDomainElement",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "directive-repeatable.graphql"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#APIContractProcessingData"
+      ],
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.6.0",
+      "http://a.ml/vocabularies/document#sourceSpec": "GraphQL"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql",
+      "http://a.ml/vocabularies/document#declares": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
+        }
+      ],
+      "@type": [
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#encodes": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/web-api"
+      },
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/BaseUnitProcessingData"
+      }
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "Person",
+      "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node"
+        }
+      ],
+      "http://a.ml/vocabularies/document#customDomainProperties": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc",
+      "@type": [
+        "http://a.ml/vocabularies/document#DomainProperty",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#domain": [
+        {
+          "@id": "http://www.w3.org/ns/shacl#NodeShape"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#schema": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node"
+      },
+      "http://a.ml/vocabularies/core#name": "doc",
+      "http://a.ml/vocabularies/core#repeatable": true
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name/scalar/default-scalar"
+      },
+      "http://www.w3.org/ns/shacl#minCount": 0,
+      "http://www.w3.org/ns/shacl#name": "name"
+    },
+    {
+      "http://a.ml/vocabularies/core#extensionName": "doc",
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value"
+      }
+    },
+    {
+      "http://a.ml/vocabularies/core#extensionName": "doc",
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value"
+      }
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#inputOnly": true
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name/scalar/default-scalar",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Doc 1",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "value"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Doc 2",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "value"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union"
+      },
+      "http://www.w3.org/ns/shacl#name": "value"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#UnionShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/shapes#anyOf": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/nil/default-nil"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/scalar/default-scalar"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/nil/default-nil",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#NilShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/scalar/default-scalar",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    }
+  ]
+}

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.jsonld
@@ -99,86 +99,85 @@
             "@value": "Person"
           }
         ],
-        "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": {
-          "http://a.ml/vocabularies/core#extensionName": [
-            {
-              "@value": "doc"
-            }
-          ],
-          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node",
-          "@type": [
-            "http://a.ml/vocabularies/data#Object",
-            "http://a.ml/vocabularies/data#Node",
-            "http://a.ml/vocabularies/document#DomainElement"
-          ],
-          "http://a.ml/vocabularies/data#value": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value",
-              "@type": [
-                "http://a.ml/vocabularies/data#Scalar",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#value": [
-                {
-                  "@value": "Doc 1"
-                }
-              ],
-              "http://www.w3.org/ns/shacl#datatype": [
-                {
-                  "@id": "http://www.w3.org/2001/XMLSchema#string"
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "value"
-                }
-              ]
-            }
-          ]
-        },
-        "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": {
-          "http://a.ml/vocabularies/core#extensionName": [
-            {
-              "@value": "doc"
-            }
-          ],
-          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node",
-          "@type": [
-            "http://a.ml/vocabularies/data#Object",
-            "http://a.ml/vocabularies/data#Node",
-            "http://a.ml/vocabularies/document#DomainElement"
-          ],
-          "http://a.ml/vocabularies/data#value": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value",
-              "@type": [
-                "http://a.ml/vocabularies/data#Scalar",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#value": [
-                {
-                  "@value": "Doc 2"
-                }
-              ],
-              "http://www.w3.org/ns/shacl#datatype": [
-                {
-                  "@id": "http://www.w3.org/2001/XMLSchema#string"
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "value"
-                }
-              ]
-            }
-          ]
-        },
-        "http://a.ml/vocabularies/document#customDomainProperties": [
+        "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": [
           {
-            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
+            "http://a.ml/vocabularies/core#extensionName": [
+              {
+                "@value": "doc"
+              }
+            ],
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node",
+            "@type": [
+              "http://a.ml/vocabularies/data#Object",
+              "http://a.ml/vocabularies/data#Node",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/data#value": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "Doc 1"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "value"
+                  }
+                ]
+              }
+            ]
           },
+          {
+            "http://a.ml/vocabularies/core#extensionName": [
+              {
+                "@value": "doc"
+              }
+            ],
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node",
+            "@type": [
+              "http://a.ml/vocabularies/data#Object",
+              "http://a.ml/vocabularies/data#Node",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/data#value": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "Doc 2"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#customDomainProperties": [
           {
             "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
           }

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.resolved.jsonld
@@ -104,86 +104,85 @@
             "@value": "Person"
           }
         ],
-        "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": {
-          "http://a.ml/vocabularies/core#extensionName": [
-            {
-              "@value": "doc"
-            }
-          ],
-          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node",
-          "@type": [
-            "http://a.ml/vocabularies/data#Object",
-            "http://a.ml/vocabularies/data#Node",
-            "http://a.ml/vocabularies/document#DomainElement"
-          ],
-          "http://a.ml/vocabularies/data#value": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value",
-              "@type": [
-                "http://a.ml/vocabularies/data#Scalar",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#value": [
-                {
-                  "@value": "Doc 1"
-                }
-              ],
-              "http://www.w3.org/ns/shacl#datatype": [
-                {
-                  "@id": "http://www.w3.org/2001/XMLSchema#string"
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "value"
-                }
-              ]
-            }
-          ]
-        },
-        "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": {
-          "http://a.ml/vocabularies/core#extensionName": [
-            {
-              "@value": "doc"
-            }
-          ],
-          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node",
-          "@type": [
-            "http://a.ml/vocabularies/data#Object",
-            "http://a.ml/vocabularies/data#Node",
-            "http://a.ml/vocabularies/document#DomainElement"
-          ],
-          "http://a.ml/vocabularies/data#value": [
-            {
-              "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value",
-              "@type": [
-                "http://a.ml/vocabularies/data#Scalar",
-                "http://a.ml/vocabularies/data#Node",
-                "http://a.ml/vocabularies/document#DomainElement"
-              ],
-              "http://a.ml/vocabularies/data#value": [
-                {
-                  "@value": "Doc 2"
-                }
-              ],
-              "http://www.w3.org/ns/shacl#datatype": [
-                {
-                  "@id": "http://www.w3.org/2001/XMLSchema#string"
-                }
-              ],
-              "http://a.ml/vocabularies/core#name": [
-                {
-                  "@value": "value"
-                }
-              ]
-            }
-          ]
-        },
-        "http://a.ml/vocabularies/document#customDomainProperties": [
+        "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": [
           {
-            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
+            "http://a.ml/vocabularies/core#extensionName": [
+              {
+                "@value": "doc"
+              }
+            ],
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node",
+            "@type": [
+              "http://a.ml/vocabularies/data#Object",
+              "http://a.ml/vocabularies/data#Node",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/data#value": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "Doc 1"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "value"
+                  }
+                ]
+              }
+            ]
           },
+          {
+            "http://a.ml/vocabularies/core#extensionName": [
+              {
+                "@value": "doc"
+              }
+            ],
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node",
+            "@type": [
+              "http://a.ml/vocabularies/data#Object",
+              "http://a.ml/vocabularies/data#Node",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/data#value": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "Doc 2"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#customDomainProperties": [
           {
             "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
           }

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/repeatable/repeatable.dumped.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/repeatable/repeatable.dumped.expanded.jsonld
@@ -1,0 +1,282 @@
+[
+  {
+    "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql",
+    "@type": [
+      "http://a.ml/vocabularies/document#Document",
+      "http://a.ml/vocabularies/document#Fragment",
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/document#encodes": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/web-api",
+        "@type": [
+          "http://a.ml/vocabularies/apiContract#WebAPI",
+          "http://a.ml/vocabularies/apiContract#API",
+          "http://a.ml/vocabularies/document#RootDomainElement",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "directive-repeatable.graphql"
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document#processingData": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/BaseUnitProcessingData",
+        "@type": [
+          "http://a.ml/vocabularies/document#APIContractProcessingData"
+        ],
+        "http://a.ml/vocabularies/apiContract#modelVersion": [
+          {
+            "@value": "3.6.0"
+          }
+        ],
+        "http://a.ml/vocabularies/document#sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#declares": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": "Person"
+          }
+        ],
+        "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": [
+          {
+            "http://a.ml/vocabularies/core#extensionName": [
+              {
+                "@value": "doc"
+              }
+            ],
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node",
+            "@type": [
+              "http://a.ml/vocabularies/data#Object",
+              "http://a.ml/vocabularies/data#Node",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/data#value": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "Doc 1"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "http://a.ml/vocabularies/core#extensionName": [
+              {
+                "@value": "doc"
+              }
+            ],
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node",
+            "@type": [
+              "http://a.ml/vocabularies/data#Object",
+              "http://a.ml/vocabularies/data#Node",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/data#value": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "Doc 2"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#customDomainProperties": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc",
+        "@type": [
+          "http://a.ml/vocabularies/document#DomainProperty",
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/2000/01/rdf-schema#domain": [
+          {
+            "@id": "http://www.w3.org/ns/shacl#NodeShape"
+          }
+        ],
+        "http://a.ml/vocabularies/shapes#schema": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#UnionShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/shapes#anyOf": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/nil/default-nil",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#NilShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ]
+                      },
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/scalar/default-scalar",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "value"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#inputOnly": [
+              {
+                "@value": true
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "doc"
+          }
+        ],
+        "http://a.ml/vocabularies/core#repeatable": [
+          {
+            "@value": true
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/repeatable/repeatable.dumped.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/repeatable/repeatable.dumped.flattened.jsonld
@@ -1,0 +1,247 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/web-api",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#WebAPI",
+        "http://a.ml/vocabularies/apiContract#API",
+        "http://a.ml/vocabularies/document#RootDomainElement",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "directive-repeatable.graphql"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#APIContractProcessingData"
+      ],
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.6.0",
+      "http://a.ml/vocabularies/document#sourceSpec": "GraphQL"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql",
+      "http://a.ml/vocabularies/document#declares": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
+        }
+      ],
+      "@type": [
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#encodes": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/web-api"
+      },
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/BaseUnitProcessingData"
+      }
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "Person",
+      "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node"
+        }
+      ],
+      "http://a.ml/vocabularies/document#customDomainProperties": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc",
+      "@type": [
+        "http://a.ml/vocabularies/document#DomainProperty",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#domain": [
+        {
+          "@id": "http://www.w3.org/ns/shacl#NodeShape"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#schema": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node"
+      },
+      "http://a.ml/vocabularies/core#name": "doc",
+      "http://a.ml/vocabularies/core#repeatable": true
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name/scalar/default-scalar"
+      },
+      "http://www.w3.org/ns/shacl#minCount": 0,
+      "http://www.w3.org/ns/shacl#name": "name"
+    },
+    {
+      "http://a.ml/vocabularies/core#extensionName": "doc",
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value"
+      }
+    },
+    {
+      "http://a.ml/vocabularies/core#extensionName": "doc",
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value"
+      }
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#inputOnly": true
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name/scalar/default-scalar",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Doc 1",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "value"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Doc 2",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "value"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union"
+      },
+      "http://www.w3.org/ns/shacl#name": "value"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#UnionShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/shapes#anyOf": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/nil/default-nil"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/scalar/default-scalar"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/nil/default-nil",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#NilShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/scalar/default-scalar",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    }
+  ]
+}

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/repeatable/repeatable.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/repeatable/repeatable.expanded.jsonld
@@ -1,0 +1,282 @@
+[
+  {
+    "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql",
+    "@type": [
+      "http://a.ml/vocabularies/document#Document",
+      "http://a.ml/vocabularies/document#Fragment",
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/document#encodes": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/web-api",
+        "@type": [
+          "http://a.ml/vocabularies/apiContract#WebAPI",
+          "http://a.ml/vocabularies/apiContract#API",
+          "http://a.ml/vocabularies/document#RootDomainElement",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "directive-repeatable.graphql"
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document#processingData": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/BaseUnitProcessingData",
+        "@type": [
+          "http://a.ml/vocabularies/document#APIContractProcessingData"
+        ],
+        "http://a.ml/vocabularies/apiContract#modelVersion": [
+          {
+            "@value": "3.6.0"
+          }
+        ],
+        "http://a.ml/vocabularies/document#sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#declares": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person",
+        "@type": [
+          "http://www.w3.org/ns/shacl#NodeShape",
+          "http://a.ml/vocabularies/shapes#AnyShape",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/shapes#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name",
+            "@type": [
+              "http://www.w3.org/ns/shacl#PropertyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/shapes#range": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "http://www.w3.org/ns/shacl#minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "http://www.w3.org/ns/shacl#name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "http://www.w3.org/ns/shacl#name": [
+          {
+            "@value": "Person"
+          }
+        ],
+        "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": [
+          {
+            "http://a.ml/vocabularies/core#extensionName": [
+              {
+                "@value": "doc"
+              }
+            ],
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node",
+            "@type": [
+              "http://a.ml/vocabularies/data#Object",
+              "http://a.ml/vocabularies/data#Node",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/data#value": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "Doc 1"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "http://a.ml/vocabularies/core#extensionName": [
+              {
+                "@value": "doc"
+              }
+            ],
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node",
+            "@type": [
+              "http://a.ml/vocabularies/data#Object",
+              "http://a.ml/vocabularies/data#Node",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/data#value": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value",
+                "@type": [
+                  "http://a.ml/vocabularies/data#Scalar",
+                  "http://a.ml/vocabularies/data#Node",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/data#value": [
+                  {
+                    "@value": "Doc 2"
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#customDomainProperties": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc",
+        "@type": [
+          "http://a.ml/vocabularies/document#DomainProperty",
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/2000/01/rdf-schema#domain": [
+          {
+            "@id": "http://www.w3.org/ns/shacl#NodeShape"
+          }
+        ],
+        "http://a.ml/vocabularies/shapes#schema": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node",
+            "@type": [
+              "http://www.w3.org/ns/shacl#NodeShape",
+              "http://a.ml/vocabularies/shapes#AnyShape",
+              "http://www.w3.org/ns/shacl#Shape",
+              "http://a.ml/vocabularies/shapes#Shape",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://www.w3.org/ns/shacl#property": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#PropertyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/shapes#range": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union",
+                    "@type": [
+                      "http://a.ml/vocabularies/shapes#UnionShape",
+                      "http://a.ml/vocabularies/shapes#AnyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/shapes#anyOf": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/nil/default-nil",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#NilShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ]
+                      },
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/scalar/default-scalar",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "value"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#inputOnly": [
+              {
+                "@value": true
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "doc"
+          }
+        ],
+        "http://a.ml/vocabularies/core#repeatable": [
+          {
+            "@value": true
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/repeatable/repeatable.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/repeatable/repeatable.flattened.jsonld
@@ -1,0 +1,247 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/web-api",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#WebAPI",
+        "http://a.ml/vocabularies/apiContract#API",
+        "http://a.ml/vocabularies/document#RootDomainElement",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "directive-repeatable.graphql"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#APIContractProcessingData"
+      ],
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.6.0",
+      "http://a.ml/vocabularies/document#sourceSpec": "GraphQL"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql",
+      "http://a.ml/vocabularies/document#declares": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
+        }
+      ],
+      "@type": [
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#encodes": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/web-api"
+      },
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/BaseUnitProcessingData"
+      }
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "Person",
+      "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node"
+        }
+      ],
+      "http://a.ml/vocabularies/document#customDomainProperties": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc",
+      "@type": [
+        "http://a.ml/vocabularies/document#DomainProperty",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#domain": [
+        {
+          "@id": "http://www.w3.org/ns/shacl#NodeShape"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#schema": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node"
+      },
+      "http://a.ml/vocabularies/core#name": "doc",
+      "http://a.ml/vocabularies/core#repeatable": true
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name/scalar/default-scalar"
+      },
+      "http://www.w3.org/ns/shacl#minCount": 0,
+      "http://www.w3.org/ns/shacl#name": "name"
+    },
+    {
+      "http://a.ml/vocabularies/core#extensionName": "doc",
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value"
+      }
+    },
+    {
+      "http://a.ml/vocabularies/core#extensionName": "doc",
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node",
+      "@type": [
+        "http://a.ml/vocabularies/data#Object",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value"
+      }
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value"
+        }
+      ],
+      "http://a.ml/vocabularies/shapes#inputOnly": true
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/property/property/name/scalar/default-scalar",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc/data-node/value",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Doc 1",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "value"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/shape/Person/customDomainProperties/doc_1/data-node/value",
+      "@type": [
+        "http://a.ml/vocabularies/data#Scalar",
+        "http://a.ml/vocabularies/data#Node",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/data#value": "Doc 2",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/core#name": "value"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value",
+      "@type": [
+        "http://www.w3.org/ns/shacl#PropertyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/shapes#range": {
+        "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union"
+      },
+      "http://www.w3.org/ns/shacl#name": "value"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#UnionShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/shapes#anyOf": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/nil/default-nil"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/scalar/default-scalar"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/nil/default-nil",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#NilShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ]
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.graphql#/declares/doc/shape/default-node/property/property/value/union/default-union/anyOf/scalar/default-scalar",
+      "@type": [
+        "http://a.ml/vocabularies/shapes#ScalarShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    }
+  ]
+}

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml.jsonld.raml
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml.jsonld.raml
@@ -1,21 +1,23 @@
 #%RAML 1.0
 title: full
+(AnnotationInRoot): hello
 version: "1.0"
 mediaType: application/json
 baseUri: myfalsehost.com/apis
 /customers:
+  (AnnotationInCustomer): hello
   /{customer_id}:
     uriParameters:
       customer_id:
         (AnnotationInParameter): hello
     get:
       description: Returns Customer data
+      (AnnotationInGet): hello
       responses:
         "200":
           body:
             application/json:
               type: any
-      (AnnotationInGet): hello
     delete:
       description: Removes a Customer from the system
     /accounts:
@@ -40,5 +42,3 @@ baseUri: myfalsehost.com/apis
           body:
             application/json:
               type: string
-  (AnnotationInCustomer): hello
-(AnnotationInRoot): hello

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml.jsonld.raml
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml.jsonld.raml
@@ -7,13 +7,13 @@ version:
   (AnnotationInVersion): sjf
 documentation:
   -
+    (AnnotationInDocumentationRoot): sjf
     title:
       value: Documentation title
       (AnnotationInDocumentationTitle): sjf
     content:
       value: Documentation content
       (AnnotationInDocumentationContent): sjf
-    (AnnotationInDocumentationRoot): sjf
 mediaType: application/json
 baseUri: falsedomain.com/apis
 /customers:

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.jsonld.raml
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.jsonld.raml
@@ -1,8 +1,8 @@
 #%RAML 1.0
 title: test api
+(wadus): hello
 (foo):
   a: is
   b:
     - 1
     - 2
-(wadus): hello

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml.jsonld.raml
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml.jsonld.raml
@@ -5,17 +5,17 @@ annotationTypes:
     type: string
 types:
   MyType:
+    (a): stringvalue1
     properties:
       p1:
         (a): stringValue2
-    (a): stringvalue1
 /resource:
+  (a): stringValue3
   get:
+    (a): stringValue4
     body:
       application/json:
+        (a): stringValue5
         properties:
           p2:
             (a): stringValue6
-        (a): stringValue5
-    (a): stringValue4
-  (a): stringValue3

--- a/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.expanded.jsonld
@@ -691,7 +691,7 @@
                             ],
                             "http://a.ml/vocabularies/document-source-maps#value": [
                               {
-                                "@value": "[(39,8)-(39,51)]"
+                                "@value": "[(40,8)-(40,51)]"
                               }
                             ]
                           }
@@ -731,7 +731,7 @@
                             ],
                             "http://a.ml/vocabularies/document-source-maps#value": [
                               {
-                                "@value": "[(40,8)-(40,37)]"
+                                "@value": "[(41,8)-(41,37)]"
                               }
                             ]
                           }
@@ -875,7 +875,7 @@
                       ],
                       "http://a.ml/vocabularies/document-source-maps#value": [
                         {
-                          "@value": "[(41,30)-(41,35)]"
+                          "@value": "[(39,30)-(39,35)]"
                         }
                       ]
                     }

--- a/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.flattened.jsonld
@@ -738,7 +738,7 @@
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(41,30)-(41,35)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(39,30)-(39,35)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/customDomainProperties/scopes-extension/scalar_1/source-map/orphan-oas-extension/element_0",
@@ -748,12 +748,12 @@
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/flows/implicit/scope/write%3Apets/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/flows/implicit/scope/write%3Apets",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(39,8)-(39,51)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(40,8)-(40,51)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/flows/implicit/scope/read%3Apets/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json#/declares/scheme/petstore_auth/settings/oauth2/flows/implicit/scope/read%3Apets",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(40,8)-(40,37)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(41,8)-(41,37)]"
     }
   ]
 }

--- a/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json
+++ b/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.json
@@ -36,9 +36,9 @@
       "authorizationUrl": "http://swagger.io/api/oauth/dialog",
       "flow": "implicit",
       "scopes": {
+        "x-scopes-extension": "hey",
         "write:pets": "modify pets in your account",
-        "read:pets": "read your pets",
-        "x-scopes-extension": "hey"
+        "read:pets": "read your pets"
       }
     }
   }

--- a/amf-cli/shared/src/test/scala/amf/cycle/GraphQLCycleTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/cycle/GraphQLCycleTest.scala
@@ -124,4 +124,24 @@ class GraphQLCycleTest extends GraphQLFunSuiteCycleTests {
       renderOptions = Some(RenderOptions().withoutFlattenedJsonLd.withPrettyPrint.withSourceMaps)
     )
   }
+
+  test("Can parse API wit repeatable directive from Embedded JSON-LD"){
+    cycle(
+      "repeatable/repeatable.expanded.jsonld",
+      "repeatable/repeatable.dumped.expanded.jsonld",
+      AmfJsonHint,
+      AmfJsonHint,
+      renderOptions = Some(RenderOptions().withoutFlattenedJsonLd.withPrettyPrint.withSourceMaps)
+    )
+  }
+
+  test("Can parse API wit repeatable directive from Flattened JSON-LD"){
+    cycle(
+      "repeatable/repeatable.flattened.jsonld",
+      "repeatable/repeatable.dumped.flattened.jsonld",
+      AmfJsonHint,
+      AmfJsonHint,
+      renderOptions = Some(RenderOptions().withFlattenedJsonLd.withPrettyPrint.withSourceMaps)
+    )
+  }
 }

--- a/amf-cli/shared/src/test/scala/amf/parser/GraphQLTCKParsingTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/parser/GraphQLTCKParsingTest.scala
@@ -30,5 +30,9 @@ class GraphQLTCKParsingTest extends GraphQLFunSuiteCycleTests {
     cycle(api, api.replace(".graphql", ".dumped.graphql"), GraphQLHint, GraphQLHint)
   }
 
+  test("GraphQL TCK > Apis > Valid > directive-repeatable.graphql: dumped Flattened JSON matches golden") {
+    cycle("directive-repeatable.graphql", "directive-repeatable.flattened.jsonld", GraphQLHint, AmfJsonHint, renderOptions = Some(RenderOptions().withFlattenedJsonLd.withPrettyPrint))
+  }
+
   override def renderOptions(): RenderOptions = RenderOptions().withoutFlattenedJsonLd.withPrettyPrint
 }


### PR DESCRIPTION
Depends on: https://github.com/aml-org/amf-core/pull/520

- W-11542569: add repeatable GraphQL directive applications JSON-LD rendering tests
- W-11542569: add repeatable GraphQL directive applications JSON-LD parsing tests
- Fix tests from repeatable extension parsing, just some ordering changes
