### PR TITLE
(chore): use lowercase 'introspection' instead of 'Introspection' in GraphQLIntrospectionPipeline. Delegate to ENUM

### DIFF
--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/GraphQLFederationIntrospectionPipeline.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/GraphQLFederationIntrospectionPipeline.scala
@@ -1,11 +1,12 @@
 package amf.graphqlfederation.internal.spec.transformation
 
 import amf.apicontract.internal.transformation.GraphQLEditingPipeline
+import amf.core.client.common.transform.PipelineId
 import amf.core.client.scala.transform.{TransformationPipeline, TransformationStep}
 import amf.core.internal.transform.stages.UrlShortenerStage
 
 object GraphQLFederationIntrospectionPipeline extends TransformationPipeline {
-  override val name: String = "Introspection"
+  override val name: String = PipelineId.Introspection
 
   override def steps: Seq[TransformationStep] =
     GraphQLEditingPipeline().steps.filterNot(_.isInstanceOf[UrlShortenerStage]) ++ List(


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-core/pull/528
