### PR TITLE
Publish 5.1.0-RC.2

### DIFF
--- a/amf-apicontract.versions
+++ b/amf-apicontract.versions
@@ -1,4 +1,4 @@
-amf.apicontract=5.1.0-RC.1
+amf.apicontract=5.1.0-RC.2
 amf.aml=6.1.0-RC.1
 amf.model=3.7.0
 antlr4Version=0.5.17

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-endpoints.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-endpoints.graphql
@@ -5,3 +5,7 @@ schema {
 type Query {
     name: String
 }
+
+type Person @key(fields: "name") {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-types.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-types.jsonld
@@ -241,7 +241,7 @@
       ],
       "shacl:datatype": [
         {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
+          "@id": "http://www.w3.org/2001/XMLSchema#anyType"
         }
       ],
       "raml-shapes:format": "_Any",
@@ -576,10 +576,19 @@
           "@id": "#52"
         },
         {
-          "@id": "#57"
+          "@id": "#55"
         },
         {
-          "@id": "#62"
+          "@id": "#58"
+        },
+        {
+          "@id": "#66"
+        },
+        {
+          "@id": "#68"
+        },
+        {
+          "@id": "#70"
         }
       ],
       "@type": [
@@ -629,7 +638,7 @@
       ],
       "shacl:datatype": [
         {
-          "@id": "http://www.w3.org/2001/XMLSchema#string"
+          "@id": "http://www.w3.org/2001/XMLSchema#anyType"
         }
       ],
       "raml-shapes:format": "_FieldSet",
@@ -644,7 +653,7 @@
       ],
       "rdfs:domain": [
         {
-          "@id": "http://a.ml/vocabularies/graphql#directive/location/SCHEMA"
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/FIELD_DEFINITION"
         }
       ],
       "raml-shapes:schema": {
@@ -670,7 +679,7 @@
       "core:name": "requires"
     },
     {
-      "@id": "#57",
+      "@id": "#55",
       "@type": [
         "doc:DomainProperty",
         "rdf:Property",
@@ -682,12 +691,12 @@
         }
       ],
       "raml-shapes:schema": {
-        "@id": "#58"
+        "@id": "#56"
       },
       "core:name": "provides"
     },
     {
-      "@id": "#62",
+      "@id": "#58",
       "@type": [
         "doc:DomainProperty",
         "rdf:Property",
@@ -702,9 +711,91 @@
         }
       ],
       "raml-shapes:schema": {
-        "@id": "#63"
+        "@id": "#59"
       },
-      "core:name": "key"
+      "core:name": "key",
+      "core:repeatable": true
+    },
+    {
+      "@id": "#66",
+      "@type": [
+        "doc:DomainProperty",
+        "rdf:Property",
+        "doc:DomainElement"
+      ],
+      "rdfs:domain": [
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/OBJECT"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/FIELD_DEFINITION"
+        }
+      ],
+      "raml-shapes:schema": {
+        "@id": "#67"
+      },
+      "core:name": "shareable"
+    },
+    {
+      "@id": "#68",
+      "@type": [
+        "doc:DomainProperty",
+        "rdf:Property",
+        "doc:DomainElement"
+      ],
+      "rdfs:domain": [
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/FIELD_DEFINITION"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/OBJECT"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/INTERFACE"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/UNION"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/ARGUMENT_DEFINITION"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/SCALAR"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/ENUM"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/ENUM_VALUE"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/INPUT_OBJECT"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/INPUT_FIELD_DEFINITION"
+        }
+      ],
+      "raml-shapes:schema": {
+        "@id": "#69"
+      },
+      "core:name": "inaccessible"
+    },
+    {
+      "@id": "#70",
+      "@type": [
+        "doc:DomainProperty",
+        "rdf:Property",
+        "doc:DomainElement"
+      ],
+      "rdfs:domain": [
+        {
+          "@id": "http://a.ml/vocabularies/graphql#directive/location/FIELD_DEFINITION"
+        }
+      ],
+      "raml-shapes:schema": {
+        "@id": "#71"
+      },
+      "core:name": "override"
     },
     {
       "@id": "#43",
@@ -761,33 +852,45 @@
     {
       "@id": "#53",
       "@type": [
-        "raml-shapes:UnionShape",
+        "shacl:NodeShape",
         "raml-shapes:AnyShape",
         "shacl:Shape",
         "raml-shapes:Shape",
         "doc:DomainElement"
       ],
-      "raml-shapes:anyOf": [
+      "shacl:property": [
         {
           "@id": "#54"
-        },
-        {
-          "@id": "#56"
         }
       ]
     },
     {
-      "@id": "#58",
+      "@id": "#56",
       "@type": [
-        "raml-shapes:UnionShape",
+        "shacl:NodeShape",
         "raml-shapes:AnyShape",
         "shacl:Shape",
         "raml-shapes:Shape",
         "doc:DomainElement"
       ],
-      "raml-shapes:anyOf": [
+      "shacl:property": [
         {
-          "@id": "#59"
+          "@id": "#57"
+        }
+      ]
+    },
+    {
+      "@id": "#59",
+      "@type": [
+        "shacl:NodeShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:property": [
+        {
+          "@id": "#60"
         },
         {
           "@id": "#61"
@@ -795,20 +898,37 @@
       ]
     },
     {
-      "@id": "#63",
+      "@id": "#67",
       "@type": [
-        "raml-shapes:UnionShape",
+        "shacl:NodeShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ]
+    },
+    {
+      "@id": "#69",
+      "@type": [
+        "shacl:NodeShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ]
+    },
+    {
+      "@id": "#71",
+      "@type": [
+        "shacl:NodeShape",
         "raml-shapes:AnyShape",
         "shacl:Shape",
         "raml-shapes:Shape",
         "doc:DomainElement"
       ],
-      "raml-shapes:anyOf": [
+      "shacl:property": [
         {
-          "@id": "#64"
-        },
-        {
-          "@id": "#66"
+          "@id": "#72"
         }
       ]
     },
@@ -861,77 +981,18 @@
     {
       "@id": "#54",
       "@type": [
-        "shacl:NodeShape",
-        "raml-shapes:AnyShape",
+        "shacl:PropertyShape",
         "shacl:Shape",
         "raml-shapes:Shape",
         "doc:DomainElement"
       ],
-      "shacl:property": [
-        {
-          "@id": "#55"
-        }
-      ]
+      "raml-shapes:range": {
+        "@id": "#49"
+      },
+      "shacl:name": "fieldSet"
     },
     {
-      "@id": "#56",
-      "@type": [
-        "raml-shapes:NilShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ]
-    },
-    {
-      "@id": "#59",
-      "@type": [
-        "shacl:NodeShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "shacl:property": [
-        {
-          "@id": "#60"
-        }
-      ]
-    },
-    {
-      "@id": "#61",
-      "@type": [
-        "raml-shapes:NilShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ]
-    },
-    {
-      "@id": "#64",
-      "@type": [
-        "shacl:NodeShape",
-        "raml-shapes:AnyShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ],
-      "shacl:property": [
-        {
-          "@id": "#65"
-        }
-      ]
-    },
-    {
-      "@id": "#66",
-      "@type": [
-        "raml-shapes:NilShape",
-        "shacl:Shape",
-        "raml-shapes:Shape",
-        "doc:DomainElement"
-      ]
-    },
-    {
-      "@id": "#55",
+      "@id": "#57",
       "@type": [
         "shacl:PropertyShape",
         "shacl:Shape",
@@ -957,7 +1018,7 @@
       "shacl:name": "fieldSet"
     },
     {
-      "@id": "#65",
+      "@id": "#61",
       "@type": [
         "shacl:PropertyShape",
         "shacl:Shape",
@@ -965,15 +1026,103 @@
         "doc:DomainElement"
       ],
       "raml-shapes:range": {
-        "@id": "#49"
+        "@id": "#63"
       },
-      "shacl:name": "fieldSet"
+      "shacl:name": "resolvable",
+      "shacl:defaultValue": {
+        "@id": "#62"
+      }
+    },
+    {
+      "@id": "#72",
+      "@type": [
+        "shacl:PropertyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:range": {
+        "@id": "#73"
+      },
+      "shacl:name": "from"
+    },
+    {
+      "@id": "#63",
+      "@type": [
+        "raml-shapes:UnionShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "raml-shapes:anyOf": [
+        {
+          "@id": "#64"
+        },
+        {
+          "@id": "#65"
+        }
+      ]
+    },
+    {
+      "@id": "#62",
+      "@type": [
+        "data:Scalar",
+        "data:Node",
+        "doc:DomainElement"
+      ],
+      "data:value": "true",
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+        }
+      ]
+    },
+    {
+      "@id": "#73",
+      "@type": [
+        "raml-shapes:ScalarShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    },
+    {
+      "@id": "#64",
+      "@type": [
+        "raml-shapes:ScalarShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#boolean"
+        }
+      ]
+    },
+    {
+      "@id": "#65",
+      "@type": [
+        "raml-shapes:NilShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ]
     }
   ],
   "@context": {
     "@base": "amf://id",
     "shacl": "http://www.w3.org/ns/shacl#",
     "raml-shapes": "http://a.ml/vocabularies/shapes#",
+    "data": "http://a.ml/vocabularies/data#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "doc": "http://a.ml/vocabularies/document#",
     "apiContract": "http://a.ml/vocabularies/apiContract#",

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-types.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-types.jsonld
@@ -641,8 +641,8 @@
           "@id": "http://www.w3.org/2001/XMLSchema#anyType"
         }
       ],
-      "raml-shapes:format": "_FieldSet",
-      "shacl:name": "_FieldSet"
+      "raml-shapes:format": "FieldSet",
+      "shacl:name": "FieldSet"
     },
     {
       "@id": "#50",

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+scalar MyScalar @myDirective(argA: "valueA", argB: "valueB")
+directive @directiveA on ARGUMENT_DEFINITION
+directive @directiveB on ARGUMENT_DEFINITION
+directive @myDirective(argA: String @directiveA, argB: String = "defaultB") on SCALAR
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.dumped.graphql
@@ -6,15 +6,15 @@ scalar MyScalar @myDirective(argA: "valueA", argB: "valueB")
 directive @directiveA on ARGUMENT_DEFINITION
 directive @directiveB on ARGUMENT_DEFINITION
 directive @myDirective(argA: String @directiveA, argB: String = "defaultB") on SCALAR
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ scalar MyScalar @myDirective(argA: "valueA", argB: "valueB")
 directive @directiveA on ARGUMENT_DEFINITION
 directive @directiveB on ARGUMENT_DEFINITION
 directive @myDirective(argA: String @directiveA, argB: String = "defaultB") on SCALAR
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.dumped.graphql
@@ -8,16 +8,16 @@ extend type Person {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Person
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.dumped.graphql
@@ -15,6 +15,6 @@ type _Service {
 
 union _Entity = Person
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+extend type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Person
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.dumped.graphql
@@ -14,7 +14,10 @@ type _Service {
 }
 
 union _Entity = Person
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.dumped.graphql
@@ -8,16 +8,16 @@ type Person {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Person
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.dumped.graphql
@@ -15,6 +15,6 @@ type _Service {
 
 union _Entity = Person
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Person
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.dumped.graphql
@@ -14,7 +14,10 @@ type _Service {
 }
 
 union _Entity = Person
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ type Person {
   name: String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.dumped.graphql
@@ -6,15 +6,15 @@ type Person {
   name: String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.dumped.graphql
@@ -1,0 +1,39 @@
+type Query {
+  operation(arg: String!): String!
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+  property: String!
+}
+
+interface Interface @Directive {
+  property: String! @Directive
+  operation(arg: String! @Directive): String! @Directive
+}
+
+enum Enum @Directive {
+  Value @Directive
+}
+
+scalar Scalar @Directive
+type Object @Directive {
+  property: String! @Directive
+  operation(arg: String! @Directive): String! @Directive
+}
+
+input InputObject @Directive {
+  property: String! @Directive
+}
+
+union Union @Directive = Object
+directive @Directive on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.dumped.graphql
@@ -1,6 +1,5 @@
 type Query {
   operation(arg: String!): String!
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
   property: String!
 }
@@ -26,13 +25,11 @@ input InputObject @Directive {
 
 union Union @Directive = Object
 directive @Directive on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.dumped.graphql
@@ -25,15 +25,15 @@ input InputObject @Directive {
 
 union Union @Directive = Object
 directive @Directive on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.dumped.graphql
@@ -30,7 +30,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.dumped.graphql
@@ -31,6 +31,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.dumped.graphql
@@ -6,15 +6,15 @@ type Image {
   url(size: Int): String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ type Image {
   url(size: Int): String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Image {
+  url(size: Int): String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -9,13 +8,11 @@ enum Colors {
   BLUE
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.dumped.graphql
@@ -14,6 +14,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.dumped.graphql
@@ -1,0 +1,22 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+enum Colors {
+  RED
+  GREEN
+  BLUE
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.dumped.graphql
@@ -8,15 +8,15 @@ enum Colors {
   BLUE
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.dumped.graphql
@@ -13,7 +13,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -9,13 +8,11 @@ enum Colors {
   BLUE
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.dumped.graphql
@@ -14,6 +14,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.dumped.graphql
@@ -1,0 +1,22 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+enum Colors {
+  RED
+  GREEN
+  BLUE
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.dumped.graphql
@@ -8,15 +8,15 @@ enum Colors {
   BLUE
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.dumped.graphql
@@ -13,7 +13,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.dumped.graphql
@@ -6,15 +6,15 @@ type Person {
   name(arg: String): String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ type Person {
   name(arg: String): String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name(arg: String): String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ type Person {
   name: String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.dumped.graphql
@@ -6,15 +6,15 @@ type Person {
   name: String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+input Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.dumped.graphql
@@ -6,15 +6,15 @@ input Person {
   name: String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ input Person {
   name: String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+input Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.dumped.graphql
@@ -6,15 +6,15 @@ input Person {
   name: String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ input Person {
   name: String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+interface Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.dumped.graphql
@@ -6,15 +6,15 @@ interface Person {
   name: String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ interface Person {
   name: String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ type Person {
   name: String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.dumped.graphql
@@ -6,15 +6,15 @@ type Person {
   name: String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.dumped.graphql
@@ -9,6 +9,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.dumped.graphql
@@ -8,7 +8,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.dumped.graphql
@@ -1,16 +1,13 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
 scalar Name
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.dumped.graphql
@@ -1,0 +1,17 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+scalar Name
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.dumped.graphql
@@ -3,15 +3,15 @@ type Query {
 }
 
 scalar Name
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -12,13 +11,11 @@ type MemberB {
 }
 
 union MyUnion = MemberA | MemberB
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.dumped.graphql
@@ -1,0 +1,25 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type MemberA {
+  propA: String
+}
+
+type MemberB {
+  propB: String
+}
+
+union MyUnion = MemberA | MemberB
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.dumped.graphql
@@ -16,7 +16,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.dumped.graphql
@@ -11,15 +11,15 @@ type MemberB {
 }
 
 union MyUnion = MemberA | MemberB
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.dumped.graphql
@@ -17,6 +17,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.dumped.graphql
@@ -8,16 +8,16 @@ extend interface Person {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Person
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.dumped.graphql
@@ -15,6 +15,6 @@ type _Service {
 
 union _Entity = Person
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+extend interface Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Person
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.dumped.graphql
@@ -14,7 +14,10 @@ type _Service {
 }
 
 union _Entity = Person
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.dumped.graphql
@@ -21,7 +21,10 @@ type _Service {
 }
 
 union _Entity = User
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.dumped.graphql
@@ -22,6 +22,6 @@ type _Service {
 
 union _Entity = User
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.dumped.graphql
@@ -1,0 +1,27 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type RecoveryCode {
+  code: String
+}
+
+extend type User {
+  id: ID!
+  name: String!
+  surname: String!
+  recoveryCode: RecoveryCode
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = User
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.dumped.graphql
@@ -15,16 +15,16 @@ extend type User {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = User
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.dumped.graphql
@@ -8,16 +8,16 @@ extend type Person {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Person
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.dumped.graphql
@@ -15,6 +15,6 @@ type _Service {
 
 union _Entity = Person
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+extend type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Person
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.dumped.graphql
@@ -14,7 +14,10 @@ type _Service {
 }
 
 union _Entity = Person
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.dumped.graphql
@@ -8,16 +8,16 @@ extend type Person {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Person
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.dumped.graphql
@@ -15,6 +15,6 @@ type _Service {
 
 union _Entity = Person
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+extend type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Person
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.dumped.graphql
@@ -14,7 +14,10 @@ type _Service {
 }
 
 union _Entity = Person
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.dumped.graphql
@@ -8,16 +8,16 @@ interface Person {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Person
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.dumped.graphql
@@ -15,6 +15,6 @@ type _Service {
 
 union _Entity = Person
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+interface Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Person
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.dumped.graphql
@@ -14,7 +14,10 @@ type _Service {
 }
 
 union _Entity = Person
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.dumped.graphql
@@ -21,7 +21,10 @@ type _Service {
 }
 
 union _Entity = User
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.dumped.graphql
@@ -22,6 +22,6 @@ type _Service {
 
 union _Entity = User
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.dumped.graphql
@@ -15,16 +15,16 @@ type RecoveryCode {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = User
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.dumped.graphql
@@ -1,0 +1,27 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type User {
+  id: ID!
+  name: String!
+  surname: String!
+  recoveryCode: RecoveryCode
+}
+
+type RecoveryCode {
+  code: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = User
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.dumped.graphql
@@ -10,16 +10,16 @@ type Person {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Person
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.dumped.graphql
@@ -1,0 +1,22 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  nameA: String
+  nameB: String
+  nameC: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Person
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.dumped.graphql
@@ -17,6 +17,6 @@ type _Service {
 
 union _Entity = Person
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.dumped.graphql
@@ -16,7 +16,10 @@ type _Service {
 }
 
 union _Entity = Person
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.dumped.graphql
@@ -8,16 +8,16 @@ type Person {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Person
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.dumped.graphql
@@ -15,6 +15,6 @@ type _Service {
 
 union _Entity = Person
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Person
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.dumped.graphql
@@ -14,7 +14,10 @@ type _Service {
 }
 
 union _Entity = Person
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.dumped.graphql
@@ -8,16 +8,16 @@ type Person {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Person
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.dumped.graphql
@@ -15,6 +15,6 @@ type _Service {
 
 union _Entity = Person
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Person
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.dumped.graphql
@@ -14,7 +14,10 @@ type _Service {
 }
 
 union _Entity = Person
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.dumped.graphql
@@ -1,0 +1,22 @@
+schema @MyDirective {
+  query: Query
+}
+
+type Query {
+  text: String
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+directive @MyDirective on SCHEMA
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.dumped.graphql
@@ -8,15 +8,15 @@ type Query {
 }
 
 directive @MyDirective on SCHEMA
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.dumped.graphql
@@ -4,18 +4,15 @@ schema @MyDirective {
 
 type Query {
   text: String
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
 directive @MyDirective on SCHEMA
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.dumped.graphql
@@ -14,6 +14,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.dumped.graphql
@@ -13,7 +13,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ type Person {
   name: String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.dumped.graphql
@@ -6,15 +6,15 @@ type Person {
   name: String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.dumped.graphql
@@ -20,7 +20,10 @@ type _Service {
 }
 
 union _Entity = Review | Product
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.dumped.graphql
@@ -21,6 +21,6 @@ type _Service {
 
 union _Entity = Review | Product
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.dumped.graphql
@@ -14,16 +14,16 @@ type Product {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Review | Product
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.dumped.graphql
@@ -1,0 +1,26 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Review {
+  id: ID!
+  product: Product
+}
+
+type Product {
+  upc: String
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Review | Product
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.dumped.graphql
@@ -10,16 +10,16 @@ type Person {
 }
 
 scalar _Any
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 union _Entity = Person
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.dumped.graphql
@@ -1,5 +1,5 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.dumped.graphql
@@ -1,0 +1,22 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name: String
+  birthday: Int
+  age: Int
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = Person
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.dumped.graphql
@@ -17,6 +17,6 @@ type _Service {
 
 union _Entity = Person
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.dumped.graphql
@@ -16,7 +16,10 @@ type _Service {
 }
 
 union _Entity = Person
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ type Person {
   name: String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.dumped.graphql
@@ -6,15 +6,15 @@ type Person {
   name: String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.dumped.graphql
@@ -11,7 +11,10 @@ type _Service {
   sdl: String
 }
 
-directive @external on SCHEMA
+directive @external on FIELD_DEFINITION
 directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
 directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.dumped.graphql
@@ -1,5 +1,4 @@
 type Query {
-  _entities(representations: [String!]!): [_Entity]!
   _service: _Service
 }
 
@@ -7,13 +6,11 @@ type Person {
   name: String
 }
 
-scalar _Any
 scalar _FieldSet
 type _Service {
   sdl: String
 }
 
-union _Entity = 
 directive @external on SCHEMA
 directive @requires on FIELD_DEFINITION
 directive @provides on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.dumped.graphql
@@ -12,6 +12,6 @@ type _Service {
 }
 
 directive @external on SCHEMA
-directive @requires on FIELD_DEFINITION
-directive @provides on FIELD_DEFINITION
-directive @key on OBJECT | INTERFACE
+directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.dumped.graphql
@@ -1,0 +1,20 @@
+type Query {
+  _entities(representations: [String!]!): [_Entity]!
+  _service: _Service
+}
+
+type Person {
+  name: String
+}
+
+scalar _Any
+scalar _FieldSet
+type _Service {
+  sdl: String
+}
+
+union _Entity = 
+directive @external on SCHEMA
+directive @requires on FIELD_DEFINITION
+directive @provides on FIELD_DEFINITION
+directive @key on OBJECT | INTERFACE

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.dumped.graphql
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.dumped.graphql
@@ -6,15 +6,15 @@ type Person {
   name: String
 }
 
-scalar _FieldSet
+scalar FieldSet
 type _Service {
   sdl: String
 }
 
 directive @external on FIELD_DEFINITION
-directive @requires(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fieldSet: _FieldSet!) on FIELD_DEFINITION
-directive @key(fieldSet: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @provides(fieldSet: FieldSet!) on FIELD_DEFINITION
+directive @key(fieldSet: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @shareable on OBJECT | FIELD_DEFINITION
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION

--- a/amf-cli/shared/src/test/scala/amf/parser/GraphQLFederationTCKInstrospectionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/parser/GraphQLFederationTCKInstrospectionTest.scala
@@ -1,0 +1,34 @@
+package amf.parser
+
+import amf.apicontract.client.scala.AMFConfiguration
+import amf.core.client.common.transform.PipelineId
+import amf.core.client.scala.model.document.BaseUnit
+import amf.core.internal.remote.GraphQLFederationHint
+import amf.core.internal.remote.Mimes.`application/graphql`
+import amf.graphql.client.scala.GraphQLConfiguration
+
+class GraphQLFederationTCKInstrospectionTest extends GraphQLFederationFunSuiteCycleTests {
+  override def basePath: String = s"amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/"
+
+  // Test valid APIs
+  fs.syncFile(s"$basePath").list.foreach { api =>
+    if (api.endsWith(".graphql") && !api.endsWith(".dumped.graphql")) {
+      test(s"GraphQL Federation TCK > Apis > Valid > $api: introspected GraphQL matches golden") {
+        cycle(api, api.replace(".graphql", ".dumped.graphql"), GraphQLFederationHint, GraphQLFederationHint)
+      }
+    }
+  }
+
+  /** Method to render parsed unit. Override if necessary. */
+  override def render(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): String = {
+    val client = GraphQLConfiguration.GraphQL().baseUnitClient()
+    client.render(unit, `application/graphql`)
+  }
+
+  /** Method for transforming parsed unit. Override if necessary. */
+  override def transform(unit: BaseUnit, config: CycleConfig, amfConfig: AMFConfiguration): BaseUnit = {
+    val client              = amfConfig.baseUnitClient()
+    val introspectionResult = client.transform(unit, PipelineId.Introspection)
+    introspectionResult.baseUnit
+  }
+}

--- a/amf-cli/shared/src/test/scala/amf/resolution/GraphQLFederationTransformationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/GraphQLFederationTransformationTest.scala
@@ -22,11 +22,11 @@ class GraphQLFederationTransformationTest extends GraphQLFederationFunSuiteCycle
 
   val basePath = "file://amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/"
 
-  test("Types _Any, _FieldSet, _Entity and _Service should be in introspected schema") {
+  test("Types _Any, FieldSet, _Entity and _Service should be in introspected schema") {
     transformed("introspected-types.graphql").map { doc: Document =>
       val findInDeclares: String => Option[DomainElement] = findShapeWithName(doc.declares.toList, _)
       findInDeclares("_Any").get shouldBe a[ScalarShape]
-      findInDeclares("_FieldSet").get shouldBe a[ScalarShape]
+      findInDeclares("FieldSet").get shouldBe a[ScalarShape]
       findInDeclares("_Entity").get shouldBe a[UnionShape]
       findInDeclares("_Service").get shouldBe a[NodeShape]
     }

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/emitter/domain/GraphQLDirectiveDeclarationEmitter.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/emitter/domain/GraphQLDirectiveDeclarationEmitter.scala
@@ -54,7 +54,12 @@ case class GraphQLDirectiveDeclarationEmitter(
   }
 
   private def collectArguments(): Seq[GeneratedGraphQLArgument] = {
-    val arguments = directive.schema.asInstanceOf[NodeShape].properties
-    arguments.map { arg => GraphQLDirectiveArgumentGenerator(arg, ctx).generate() }
+    directive.schema match {
+      case n: NodeShape =>
+        val arguments = n.properties
+        arguments.map { arg => GraphQLDirectiveArgumentGenerator(arg, ctx).generate() }
+      case _ => Nil
+    }
+
   }
 }

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/emitter/domain/GraphQLEmitter.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/emitter/domain/GraphQLEmitter.scala
@@ -4,7 +4,7 @@ import amf.apicontract.internal.validation.shacl.graphql.GraphQLDataTypes
 import amf.core.client.scala.model.domain.Shape
 import amf.graphql.internal.spec.parser.syntax.NullableShape
 import amf.graphql.internal.spec.plugins.parse.GraphQLParsePlugin._
-import amf.shapes.client.scala.model.domain.{AnyShape, ArrayShape, ScalarShape, UnionShape}
+import amf.shapes.client.scala.model.domain.{AnyShape, ArrayShape, NodeShape, ScalarShape, UnionShape}
 
 trait GraphQLEmitter {
 
@@ -22,6 +22,7 @@ trait GraphQLEmitter {
               case NullableShape(false, s) => s"${u.name.value()}!"
               case NullableShape(true, s)  => s"${cleanNonNullable(typeTarget(s))}"
             }
+          case n: NodeShape => n.name.value()
           case _ =>
             throw new Exception(s"Type of target $shape not supported yet")
         }

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/IntrospectionElementsAdditionStep.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/IntrospectionElementsAdditionStep.scala
@@ -58,7 +58,7 @@ object IntrospectionElementsAdditionStep extends TransformationStep {
         case _       => List(fieldSet, _service)
       }
     }
-    val directives = List(`@external`(), `@requires`(fieldSet), `@provides`(fieldSet), `@key`(fieldSet))
+    val directives = List(`@external`, `@requires`(fieldSet), `@provides`(fieldSet), `@key`(fieldSet), `@shareable`, `@inaccessible`, `@override`)
     doc.setArrayWithoutId(DocumentModel.Declares, doc.declares ++ types ++ directives)
   }
 

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/IntrospectionElementsAdditionStep.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/IntrospectionElementsAdditionStep.scala
@@ -34,7 +34,13 @@ object IntrospectionElementsAdditionStep extends TransformationStep {
     val fieldSet = _FieldSet()
     val _any     = _Any()
     val _service = _Service()
-    val _entity  = _Entity(assumeNodeShapes(doc))
+    val _entity = {
+      retrieveEntities(doc) match {
+        case entities if entities.nonEmpty => Some(_Entity(entities))
+        case _                             => None
+      }
+
+    }
     addTypesToDocument(doc, fieldSet, _any, _service, _entity)
     addExtensionEndpoints(doc, _any, _service, _entity)
   }
@@ -44,14 +50,24 @@ object IntrospectionElementsAdditionStep extends TransformationStep {
       fieldSet: ScalarShape,
       _any: ScalarShape,
       _service: NodeShape,
-      _entity: UnionShape
+      _entity: Option[UnionShape]
   ) = {
-    val types      = List(_any, fieldSet, _service, _entity)
+    val types = {
+      _entity match {
+        case Some(e) => List(_any, fieldSet, _service, e)
+        case _       => List(fieldSet, _service)
+      }
+    }
     val directives = List(`@external`(), `@requires`(fieldSet), `@provides`(fieldSet), `@key`(fieldSet))
     doc.setArrayWithoutId(DocumentModel.Declares, doc.declares ++ types ++ directives)
   }
 
-  private def addExtensionEndpoints(doc: Document, _any: ScalarShape, _service: NodeShape, _entity: UnionShape) = {
+  private def addExtensionEndpoints(
+      doc: Document,
+      _any: ScalarShape,
+      _service: NodeShape,
+      _entity: Option[UnionShape]
+  ) = {
     val endpoints    = _Query(_any, _entity, _service)
     val apiEndpoints = doc.encodes.asInstanceOf[Api].endPoints
     doc.encodes.asInstanceOf[Api].withEndPoints(apiEndpoints ++ endpoints)
@@ -65,5 +81,7 @@ object IntrospectionElementsAdditionStep extends TransformationStep {
     doc
   }
 
-  private def assumeNodeShapes(doc: Document): Seq[NodeShape] = doc.declares.collect { case n: NodeShape => n }
+  private def retrieveEntities(doc: Document): Seq[NodeShape] = doc.declares.collect {
+    case n: NodeShape if n.keys.nonEmpty => n
+  }
 }

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/IntrospectionElementsAdditionStep.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/IntrospectionElementsAdditionStep.scala
@@ -31,7 +31,7 @@ object IntrospectionElementsAdditionStep extends TransformationStep {
   }
 
   private def addIntrospectionElements(doc: Document): Document = {
-    val fieldSet = _FieldSet()
+    val fieldSet = FieldSet()
     val _any     = _Any()
     val _service = _Service()
     val _entity = {

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionDirectives.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionDirectives.scala
@@ -10,16 +10,65 @@ import amf.shapes.client.scala.model.domain.{NodeShape, ScalarShape}
 
 object IntrospectionDirectives {
 
-  private val FIELD_DEFINITION = "FIELD_DEFINITION"
-  private val SCHEMA           = "SCHEMA"
-  private val OBJECT           = "OBJECT"
-  private val INTERFACE        = "INTERFACE"
+  private val FIELD_DEFINITION       = "FIELD_DEFINITION"
+  private val OBJECT                 = "OBJECT"
+  private val INTERFACE              = "INTERFACE"
+  private val UNION                  = "UNION"
+  private val ARGUMENT_DEFINITION    = "ARGUMENT_DEFINITION"
+  private val SCALAR                 = "SCALAR"
+  private val ENUM                   = "ENUM"
+  private val ENUM_VALUE             = "ENUM_VALUE"
+  private val INPUT_OBJECT           = "INPUT_OBJECT"
+  private val INPUT_FIELD_DEFINITION = "INPUT_FIELD_DEFINITION"
 
-  def `@external`(): CustomDomainProperty = {
+  def `@shareable`: CustomDomainProperty = {
+    CustomDomainProperty()
+      .withName("shareable")
+      .withSchema(NodeShape())
+      .withDomain(toLocationIris(OBJECT, FIELD_DEFINITION))
+  }
+
+  def `@inaccessible`: CustomDomainProperty = {
+    CustomDomainProperty()
+      .withName("inaccessible")
+      .withSchema(NodeShape())
+      .withDomain(
+        toLocationIris(
+          FIELD_DEFINITION,
+          OBJECT,
+          INTERFACE,
+          UNION,
+          ARGUMENT_DEFINITION,
+          SCALAR,
+          ENUM,
+          ENUM_VALUE,
+          INPUT_OBJECT,
+          INPUT_FIELD_DEFINITION
+        )
+      )
+  }
+
+  def `@override`: CustomDomainProperty = {
+    CustomDomainProperty()
+      .withName("override")
+      .withSchema {
+        NodeShape()
+          .withProperties(
+            List(
+              PropertyShape()
+                .withName("from")
+                .withRange(ScalarShape().withDataType(DataTypes.String))
+            )
+          )
+      }
+      .withDomain(toLocationIris(FIELD_DEFINITION))
+  }
+
+  def `@external`: CustomDomainProperty = {
     CustomDomainProperty()
       .withName("external")
       .withSchema(NodeShape())
-      .withDomain(toLocationIris(SCHEMA))
+      .withDomain(toLocationIris(FIELD_DEFINITION))
   }
 
   def `@requires`(fieldSet: ScalarShape): CustomDomainProperty = {

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionDirectives.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionDirectives.scala
@@ -4,6 +4,8 @@ import amf.core.client.scala.model.domain.extensions.{CustomDomainProperty, Prop
 import TypeBuilders.nullable
 import amf.apicontract.internal.validation.shacl.graphql.GraphQLLocationHelper
 import GraphQLLocationHelper.toLocationIris
+import amf.core.client.platform.model.DataTypes
+import amf.core.client.scala.model.domain.ScalarNode
 import amf.shapes.client.scala.model.domain.{NodeShape, ScalarShape}
 
 object IntrospectionDirectives {
@@ -23,22 +25,35 @@ object IntrospectionDirectives {
   def `@requires`(fieldSet: ScalarShape): CustomDomainProperty = {
     CustomDomainProperty()
       .withName("requires")
-      .withSchema(nullable(fieldSetArgument(fieldSet)))
+      .withSchema(fieldSetArgument(fieldSet))
       .withDomain(toLocationIris(FIELD_DEFINITION))
   }
 
   def `@provides`(fieldSet: ScalarShape): CustomDomainProperty = {
     CustomDomainProperty()
       .withName("provides")
-      .withSchema(nullable(fieldSetArgument(fieldSet)))
+      .withSchema(fieldSetArgument(fieldSet))
       .withDomain(toLocationIris(FIELD_DEFINITION))
   }
 
   def `@key`(fieldSet: ScalarShape): CustomDomainProperty = {
-    // TODO: 'repeatable is not modeled'
     CustomDomainProperty()
       .withName("key")
-      .withSchema(nullable(fieldSetArgument(fieldSet)))
+      .withRepeatable(true)
+      .withSchema {
+        NodeShape()
+          .withProperties(
+            List(
+              PropertyShape()
+                .withName("fieldSet")
+                .withRange(fieldSet),
+              PropertyShape()
+                .withName("resolvable")
+                .withDefault(ScalarNode("true", Some(DataTypes.Boolean)))
+                .withRange(nullable(ScalarShape().withDataType(DataTypes.Boolean)))
+            )
+          )
+      }
       .withDomain(toLocationIris(OBJECT, INTERFACE))
   }
 

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionTypes.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionTypes.scala
@@ -22,7 +22,7 @@ object IntrospectionTypes {
     ScalarShape()
       .withName("_FieldSet")
       .withFormat("_FieldSet")
-      .withDataType(DataTypes.String)
+      .withDataType(DataTypes.Any)
   }
 
   def _Service(): NodeShape = {

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionTypes.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionTypes.scala
@@ -15,7 +15,7 @@ object IntrospectionTypes {
     ScalarShape()
       .withName("_Any")
       .withFormat("_Any")
-      .withDataType(DataTypes.String)
+      .withDataType(DataTypes.Any)
   }
 
   def _FieldSet(): ScalarShape = {

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionTypes.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionTypes.scala
@@ -47,11 +47,18 @@ object IntrospectionTypes {
       .withAnyOf(typesWithKey)
   }
 
-  def _Query(_any: AnyShape, _entity: AnyShape, _serviceType: AnyShape): List[EndPoint] = {
-    List(
-      _entities(_any, _entity),
-      _service(_serviceType)
-    )
+  def _Query(_any: AnyShape, _entity: Option[AnyShape], _serviceType: AnyShape): List[EndPoint] = {
+    _entity match {
+      case Some(e) =>
+        List(
+          _entities(_any, e),
+          _service(_serviceType)
+        )
+      case None =>
+        List(
+          _service(_serviceType)
+        )
+    }
   }
 
   private def _service(_serviceType: AnyShape): EndPoint = {

--- a/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionTypes.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphqlfederation/internal/spec/transformation/introspection/IntrospectionTypes.scala
@@ -18,10 +18,10 @@ object IntrospectionTypes {
       .withDataType(DataTypes.Any)
   }
 
-  def _FieldSet(): ScalarShape = {
+  def FieldSet(): ScalarShape = {
     ScalarShape()
-      .withName("_FieldSet")
-      .withFormat("_FieldSet")
+      .withName("FieldSet")
+      .withFormat("FieldSet")
       .withDataType(DataTypes.Any)
   }
 


### PR DESCRIPTION
- W-11778719: fixed exceptions & added tests for rendering introspection
- Skip adding _Entity, _entities & _Any in introspection when no entities are defined
- Fixed fieldSet introspection & fixed @key introspection
- Fixed _Any introspection
- Fixed @external location, added @shareable, @inaccessible & @override to introspection pipeline
- Fix other introspection tests
- Introspection: rename _FieldSet to FieldSet
- Publish 5.1.0-RC.2
