### PR TITLE
feat/json ld clash array

### DIFF
--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/ShapeSemantics.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/ShapeSemantics.scala
@@ -149,6 +149,10 @@ class SemanticContext(override val fields: Fields, val annotations: Annotations)
     acc
   }
 
+  def getTermFor(property: String) = {
+    mapping.find(m => m.alias.option().contains(property)).flatMap(_.iri.option())
+  }
+
   def normalize(): SemanticContext = {
     val newContext = new SemanticContext(this.fields, this.annotations)
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/jsonldinstance/JsonLDArray.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/jsonldinstance/JsonLDArray.scala
@@ -10,6 +10,14 @@ import amf.shapes.internal.spec.jsonldschema.parser.JsonPath
 
 import scala.collection.mutable
 
+object JsonLDArray {
+  def apply(elements: Seq[JsonLDElement]): JsonLDArray = {
+    val result = new JsonLDArray
+    elements.foreach(elem => result += elem)
+    result
+  }
+}
+
 class JsonLDArray extends AmfArray(Nil) with JsonLDElement {
 
   /** Set of annotations for element. */

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/jsonldinstance/JsonLDObject.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/jsonldinstance/JsonLDObject.scala
@@ -6,6 +6,10 @@ import amf.core.internal.parser.domain.{Annotations, Fields}
 import amf.shapes.internal.domain.metamodel.jsonldschema.JsonLDEntityModel
 import amf.shapes.internal.spec.jsonldschema.parser.JsonPath
 
+object JsonLDObject {
+  def empty(model: JsonLDEntityModel, path: JsonPath): JsonLDObject =
+    new JsonLDObject(Fields(), Annotations(), model, path)
+}
 class JsonLDObject(
     override val fields: Fields,
     override val annotations: Annotations,

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/JsonLDBaseElementParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/JsonLDBaseElementParser.scala
@@ -28,13 +28,6 @@ abstract class JsonLDBaseElementParser[T <: JsonLDElementBuilder](node: YValue)(
 
     val oneOf = if (shape.isXOne) shape.xone.find(isValid(_, node)).map(parse) else None
     (conditional ++ oneOf).toSeq
-
-//    if (anyShape.isXOne) {
-//      anyShape.xone.collectFirst({ case a: AnyShape if isValid(a, map) => a }) match {
-//        case Some(nodeShape: NodeShape) =>
-//        case Some(anyShape: AnyShape) =>
-//      }
-//    }
   }
 
   protected def findClassTerm(ctx: SemanticContext) = ctx.typeMappings.flatMap(_.option()).map(t => ctx.expand(t))

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/JsonLDObjectElementParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/JsonLDObjectElementParser.scala
@@ -49,7 +49,7 @@ case class JsonLDObjectElementParser(
     val terms = super.findClassTerm(ctx)
     if (terms.isEmpty) {
       val fragment = if (path.toString.isEmpty) key else path.toString
-      Seq(computeTerm(ctx, fragment))
+      Seq(computeDefaultTerm(ctx, fragment))
     } else terms
   }
 
@@ -126,9 +126,12 @@ case class JsonLDObjectElementParser(
 
   private def getKeyOrEmpty(e: YMapEntry) = e.key.asScalar.map(_.text).getOrElse("")
 
-  private def computeTerm(ctx: SemanticContext, path: JsonPath): String = computeTerm(ctx, path.toString)
+  private def computeTerm(ctx: SemanticContext, path: JsonPath): String = {
+    propertyName(path).flatMap(ctx.getTermFor).map(ctx.expand).getOrElse(computeDefaultTerm(ctx, path.toString))
+  }
+  private def propertyName(path: JsonPath) = path.lastSegment
 
-  private def computeTerm(ctx: SemanticContext, fragment: String): String = computeBase(ctx) + fragment
+  private def computeDefaultTerm(ctx: SemanticContext, fragment: String): String = computeBase(ctx) + fragment
 
   private def computeBase(ctx: Option[SemanticContext]): String = ctx.map(computeBase).getOrElse(baseIri)
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/JsonLDSchemaNodeParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/JsonLDSchemaNodeParser.scala
@@ -18,6 +18,7 @@ case class JsonPath private (segments: List[String] = Nil) {
   override def toString       = path
   def concat(segment: String) = copy(segments :+ segment)
   def last                    = JsonPath(segments.lastOption.toList)
+  def lastSegment             = segments.lastOption
 }
 case class JsonLDSchemaNodeParser(shape: Shape, node: YNode, key: String, path: JsonPath, isRoot: Boolean = false)(
     implicit ctx: JsonLDParserContext

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/ArrayTypeComputation.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/ArrayTypeComputation.scala
@@ -10,6 +10,12 @@ import scala.collection.SeqLike
 
 object ArrayTypeComputation {
 
+  def computeType(types: List[Type]): Type = types match {
+    case Nil          => Type.Any
+    case head :: Nil  => head
+    case head :: tail => tail.foldLeft(head) { (acc, curr) => computeType(acc, curr) }
+  }
+
   def computeType(prev: Type, next: Type): Type = {
     (prev, next) match {
       case (Type.Array(prev), Type.Array(next)) => Type.Array(computeType(prev, next))

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/JsonLDObjectElementBuilder.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/JsonLDObjectElementBuilder.scala
@@ -6,8 +6,11 @@ import amf.core.internal.metamodel.domain.ModelDoc
 import amf.core.internal.metamodel.{Field, Type}
 import amf.core.internal.parser.domain.{Annotations, Fields}
 import amf.shapes.client.scala.model.domain.SemanticContext
-import amf.shapes.client.scala.model.domain.jsonldinstance.{JsonLDElement, JsonLDObject}
-import amf.shapes.internal.domain.metamodel.jsonldschema.JsonLDEntityModel
+import amf.shapes.client.scala.model.domain.jsonldinstance.{JsonLDArray, JsonLDElement, JsonLDObject}
+import amf.shapes.internal.domain.metamodel.jsonldschema.{JsonLDElementModel, JsonLDEntityModel}
+import amf.shapes.internal.spec.jsonldschema.parser.builder.ArrayTypeComputation.computeType
+import amf.shapes.internal.spec.jsonldschema.parser.builder.JsonLDObjectElementBuilder.{Key, Term, buildObj}
+import amf.shapes.internal.spec.jsonldschema.parser.builder.ObjectPropertyMerge.mergeProperties
 import amf.shapes.internal.spec.jsonldschema.parser.{JsonLDParserContext, JsonPath}
 import amf.shapes.internal.spec.jsonldschema.validation.JsonLDSchemaValidations.IncompatibleNodes
 import org.mulesoft.common.client.lexical.SourceLocation
@@ -18,15 +21,11 @@ import scala.collection.mutable.ListBuffer
 class JsonLDObjectElementBuilder(location: SourceLocation, key: String, base: String, path: JsonPath)
     extends JsonLDElementBuilder(location, path) {
   override type THIS = JsonLDObjectElementBuilder
-  type KEY           = String
-  type TERM          = String
-  val properties: mutable.Map[KEY, JsonLDPropertyBuilder] = mutable.Map()
-  val termIndex: mutable.LinkedHashMap[TERM, KEY]         = mutable.LinkedHashMap()
-  val termExtends: mutable.LinkedHashMap[TERM, TERM]      = mutable.LinkedHashMap()
-  val classTerms: ListBuffer[String]                      = ListBuffer()
+  val properties: mutable.Map[Key, JsonLDPropertyBuilder]                 = mutable.Map()
+  val termIndex: mutable.LinkedHashMap[Term, List[JsonLDPropertyBuilder]] = mutable.LinkedHashMap()
+  val classTerms: ListBuffer[String]                                      = ListBuffer()
 
   def +(property: JsonLDPropertyBuilder): JsonLDObjectElementBuilder = {
-
     addProperty(property)
     addTerm(property)
     this
@@ -37,60 +36,107 @@ class JsonLDObjectElementBuilder(location: SourceLocation, key: String, base: St
   )(implicit ctx: JsonLDParserContext): JsonLDObjectElementBuilder = {
     super.merge(other)
 
-    other.classTerms.foreach { t => if (!classTerms.contains(t)) classTerms.prepend(t) }
-    other.properties.foreach { t =>
-      if (properties.contains(t._2.key)) mergeAndReplaceProperty(properties(t._2.key), t._2)
-      else this + t._2
+    addClassTerms(other)
+    other.properties.foreach { case (_, builder) =>
+      if (!hasBeenParsedWithSameSemantics(builder) && isSubSchemaSemanticDefinition(builder)) {
+        val current = properties(builder.key)
+        val merged  = mergeProperties(current, builder)
+        remove(current)
+        this + builder.copy(element = merged)
+      }
     }
     this
-  }
-
-  def mergeAndReplaceProperty(current: JsonLDPropertyBuilder, other: JsonLDPropertyBuilder)(implicit
-      ctx: JsonLDParserContext
-  ): Any = {
-    val merged: JsonLDElementBuilder = mergeAndReplaceProperty(current.element, other.element)
-    properties.remove(current.key)
-    this + other.copy(element = merged)
-    this
-  }
-
-  private def mergeAndReplaceProperty(current: JsonLDElementBuilder, other: JsonLDElementBuilder)(implicit
-      ctx: JsonLDParserContext
-  ) = {
-    (current, other) match {
-      case (currObj: JsonLDObjectElementBuilder, otherObj: JsonLDObjectElementBuilder) => currObj.merge(otherObj)
-      case (currArr: JsonLDArrayElementBuilder, otherArr: JsonLDArrayElementBuilder)   => currArr.merge(otherArr)
-      case (currScalar: JsonLDScalarElementBuilder, otherScalar: JsonLDScalarElementBuilder) =>
-        currScalar.merge(otherScalar)
-      case (_: JsonLDErrorBuilder, _: JsonLDErrorBuilder) =>
-        ctx.violation(IncompatibleNodes, "", IncompatibleNodes.message, current.location)
-        other
-      case (_: JsonLDErrorBuilder, _) => other
-      case (_, _: JsonLDErrorBuilder) => current
-      case _ =>
-        ctx.violation(IncompatibleNodes, "", IncompatibleNodes.message, current.location)
-        other
-    }
   }
 
   override def build(ctxBuilder: EntityContextBuilder): (JsonLDElement, Type) = {
-    val obj = buildObj(ctxBuilder)
+    val obj = buildObj(termIndex, classTerms.toList, path, ctxBuilder)
     (obj, obj.meta)
   }
 
-  private def buildObj(ctxBuilder: EntityContextBuilder): JsonLDObject = {
-    val fields = termIndex.map { case (term, key) =>
-      val currentBuilder: JsonLDPropertyBuilder = properties(key)
-      val (element, elementType)                = currentBuilder.element.build(ctxBuilder)
-      createField(currentBuilder, elementType, term) -> element
-    }
+  private def isSubSchemaSemanticDefinition(builder: JsonLDPropertyBuilder) = {
+    properties.contains(builder.key) && !builder.hasTermWithDefaultBase
+  }
 
-    val entityModel = new JsonLDEntityModel(classTerms.map(ValueType.apply).toList, fields.keys.toList, path)
+  private def hasBeenParsedWithSameSemantics(property: JsonLDPropertyBuilder) = {
+    termIndex.getOrElse(property.term, List.empty).contains(property)
+  }
+
+  private def addClassTerms(other: JsonLDObjectElementBuilder): Unit = {
+    other.classTerms.foreach { t => if (!classTerms.contains(t)) classTerms.prepend(t) }
+  }
+  override def canEquals(other: Any): Boolean = other.isInstanceOf[JsonLDObjectElementBuilder]
+
+  private def addProperty(property: JsonLDPropertyBuilder) = properties += property.key -> property
+
+  private def addTerm(property: JsonLDPropertyBuilder): Unit = {
+    val existing = termIndex.getOrElse(property.term, List.empty)
+    termIndex += (property.term -> (property :: existing))
+  }
+
+  private def remove(current: JsonLDPropertyBuilder) = {
+    removeTerm(current)
+    removeProperty(current)
+  }
+
+  private def removeProperty(property: JsonLDPropertyBuilder) = {
+    properties -= property.key
+  }
+
+  private def removeTerm(property: JsonLDPropertyBuilder) = {
+    val existing = termIndex.getOrElse(property.term, List.empty)
+    val next     = existing.filter(builder => builder.key != property.key)
+    if (next.isEmpty) termIndex -= property.term
+    else termIndex += (property.term -> next)
+  }
+}
+
+object JsonLDObjectElementBuilder {
+
+  type Key  = String
+  type Term = String
+  def empty(key: String, path: JsonPath) =
+    new JsonLDObjectElementBuilder(SourceLocation.Unknown, key, SemanticContext.baseIri, path)
+
+  protected def buildObj(
+      termIndex: mutable.LinkedHashMap[Term, List[JsonLDPropertyBuilder]],
+      classTerms: List[String],
+      path: JsonPath,
+      ctxBuilder: EntityContextBuilder
+  ): JsonLDObject = {
+    val fields = termIndex.map {
+      case (term, List(builder)) =>
+        val (element, elementType) = builder.element.build(ctxBuilder)
+        createField(builder, elementType, term) -> element
+      case (term, builders) =>
+        val (elements, types) = TupleOps.reduce(builders.map(_.element.build(ctxBuilder)))
+        val element           = JsonLDArray(elements)
+        val arrayType         = computeType(types)
+        Field(
+          Type.Array(arrayType),
+          ValueType(term),
+          ModelDoc(displayName = displayNameForMultipleValuedTerm(builders))
+        ) -> element
+    }
+    createObjectElement(fields, classTerms, path, ctxBuilder)
+  }
+
+  private def createObjectElement(
+      fields: mutable.LinkedHashMap[Field, JsonLDElement],
+      classTerms: List[String],
+      path: JsonPath,
+      ctxBuilder: EntityContextBuilder
+  ) = {
+    val entityModel = new JsonLDEntityModel(asValueTerms(classTerms), fields.keys.toList, path)
     ctxBuilder + entityModel
     val dObject = JsonLDObject.empty(entityModel, path.last)
     fields.foreach { case (field, value) => dObject.set(field, value) }
     dObject
   }
+
+  private def asValueTerms(terms: List[Term]) = terms.map(ValueType.apply)
+
+  private def displayNameForMultipleValuedTerm(builders: List[JsonLDPropertyBuilder]) =
+    builders.map(_.key).mkString("_")
 
   private def createField(builder: JsonLDPropertyBuilder, elementType: Type, term: String): Field = {
     val finalTerm = builder.element.getOverriddenTerm.getOrElse(term)
@@ -98,57 +144,4 @@ class JsonLDObjectElementBuilder(location: SourceLocation, key: String, base: St
     Field(finalType, ValueType(finalTerm), ModelDoc(displayName = builder.key))
   }
 
-  override def canEquals(other: Any): Boolean = other.isInstanceOf[JsonLDObjectElementBuilder]
-
-  private def addProperty(property: JsonLDPropertyBuilder) = properties += property.key -> property
-
-  private def addTerm(property: JsonLDPropertyBuilder): Unit = {
-    val hasToExtend = hasDifferentKeyForTerm(property)
-    if (hasToExtend) {
-      solveTermClash(property)
-    } else addTerm(property.term, property.key)
-  }
-
-  private def hasDifferentKeyForTerm(property: JsonLDPropertyBuilder) = {
-    termIndex.contains(property.term) && !termIndex.get(property.term).contains(property.key)
-  }
-
-  private def solveTermClash(property: JsonLDPropertyBuilder) = {
-    val createdTerms = replaceTermsWithPath(property)
-    createdTerms.foreach { term => addTermExtension(term, property.term) }
-  }
-
-  private def addTerm(term: TERM, key: KEY): Unit = termIndex += term -> key
-
-  private def addTermExtension(term: TERM, key: TERM) = termExtends += term -> key
-
-  private def replaceTermsWithPath(property: JsonLDPropertyBuilder): List[String] = {
-    val anotherTerm = termIndex.get(property.term).map { key =>
-      termIndex.remove(property.term)
-      addTermForProperty(properties(key))
-    }
-    val aTerm = addTermForProperty(property)
-    List(aTerm) ++ anotherTerm.toList
-  }
-
-  private def addTermForProperty(property: JsonLDPropertyBuilder): String = {
-    val nextTerm = computeTerm(property)
-    addTerm(nextTerm, property.key)
-    nextTerm
-  }
-  private def computeTerm(property: JsonLDPropertyBuilder) = base + property.path.toString
 }
-
-object JsonLDObjectElementBuilder {
-  def empty(key: String, path: JsonPath) =
-    new JsonLDObjectElementBuilder(SourceLocation.Unknown, key, SemanticContext.baseIri, path)
-}
-
-case class JsonLDPropertyBuilder(
-    term: String,
-    key: String,
-    father: Option[String],
-    element: JsonLDElementBuilder,
-    path: JsonPath,
-    location: SourceLocation
-)

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/JsonLDObjectElementBuilder.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/JsonLDObjectElementBuilder.scala
@@ -106,7 +106,7 @@ object JsonLDObjectElementBuilder {
     val fields = termIndex.map {
       case (term, List(builder)) =>
         val (element, elementType) = builder.element.build(ctxBuilder)
-        createField(builder, elementType, term) -> element
+        createField(builder, elementType) -> element
       case (term, builders) =>
         val (elements, types) = TupleOps.reduce(builders.map(_.element.build(ctxBuilder)))
         val element           = JsonLDArray(elements)
@@ -138,10 +138,9 @@ object JsonLDObjectElementBuilder {
   private def displayNameForMultipleValuedTerm(builders: List[JsonLDPropertyBuilder]) =
     builders.map(_.key).mkString("_")
 
-  private def createField(builder: JsonLDPropertyBuilder, elementType: Type, term: String): Field = {
-    val finalTerm = builder.element.getOverriddenTerm.getOrElse(term)
+  private def createField(builder: JsonLDPropertyBuilder, elementType: Type): Field = {
     val finalType = builder.element.getOverriddenType.getOrElse(elementType)
-    Field(finalType, ValueType(finalTerm), ModelDoc(displayName = builder.key))
+    Field(finalType, ValueType(builder.term), ModelDoc(displayName = builder.key))
   }
 
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/JsonLDPropertyBuilder.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/JsonLDPropertyBuilder.scala
@@ -1,0 +1,20 @@
+package amf.shapes.internal.spec.jsonldschema.parser.builder
+
+import amf.shapes.client.scala.model.domain.SemanticContext
+import amf.shapes.internal.spec.jsonldschema.parser.JsonPath
+import org.mulesoft.common.client.lexical.SourceLocation
+
+case class JsonLDPropertyBuilder(
+    term: String,
+    key: String,
+    father: Option[String],
+    element: JsonLDElementBuilder,
+    path: JsonPath,
+    location: SourceLocation
+) {
+  def hasTermWithDefaultBase = term.startsWith(SemanticContext.baseIri)
+
+  override def equals(obj: Any): Boolean = obj match {
+    case builder: JsonLDPropertyBuilder => builder.key == key && builder.term == term
+  }
+}

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/JsonLDPropertyBuilder.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/JsonLDPropertyBuilder.scala
@@ -5,7 +5,7 @@ import amf.shapes.internal.spec.jsonldschema.parser.JsonPath
 import org.mulesoft.common.client.lexical.SourceLocation
 
 case class JsonLDPropertyBuilder(
-    term: String,
+    keyTerm: String,
     key: String,
     father: Option[String],
     element: JsonLDElementBuilder,
@@ -13,7 +13,7 @@ case class JsonLDPropertyBuilder(
     location: SourceLocation
 ) {
   def hasTermWithDefaultBase = term.startsWith(SemanticContext.baseIri)
-
+  def term                   = element.getOverriddenTerm.getOrElse(keyTerm)
   override def equals(obj: Any): Boolean = obj match {
     case builder: JsonLDPropertyBuilder => builder.key == key && builder.term == term
   }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/ObjectPropertyMerge.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/ObjectPropertyMerge.scala
@@ -1,0 +1,32 @@
+package amf.shapes.internal.spec.jsonldschema.parser.builder
+
+import amf.shapes.internal.spec.jsonldschema.parser.JsonLDParserContext
+import amf.shapes.internal.spec.jsonldschema.validation.JsonLDSchemaValidations.IncompatibleNodes
+
+object ObjectPropertyMerge {
+
+  def mergeProperties(current: JsonLDPropertyBuilder, other: JsonLDPropertyBuilder)(implicit
+      ctx: JsonLDParserContext
+  ) = {
+    mergeElements(current.element, other.element)
+  }
+
+  private def mergeElements(current: JsonLDElementBuilder, other: JsonLDElementBuilder)(implicit
+      ctx: JsonLDParserContext
+  ) = {
+    (current, other) match {
+      case (currObj: JsonLDObjectElementBuilder, otherObj: JsonLDObjectElementBuilder) => currObj.merge(otherObj)
+      case (currArr: JsonLDArrayElementBuilder, otherArr: JsonLDArrayElementBuilder)   => currArr.merge(otherArr)
+      case (currScalar: JsonLDScalarElementBuilder, otherScalar: JsonLDScalarElementBuilder) =>
+        currScalar.merge(otherScalar)
+      case (_: JsonLDErrorBuilder, _: JsonLDErrorBuilder) =>
+        ctx.violation(IncompatibleNodes, "", IncompatibleNodes.message, current.location)
+        other
+      case (_: JsonLDErrorBuilder, _) => other
+      case (_, _: JsonLDErrorBuilder) => current
+      case _ =>
+        ctx.violation(IncompatibleNodes, "", IncompatibleNodes.message, current.location)
+        other
+    }
+  }
+}

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/TupleOps.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/builder/TupleOps.scala
@@ -1,0 +1,10 @@
+package amf.shapes.internal.spec.jsonldschema.parser.builder
+
+object TupleOps {
+  def reduce[T, R](tuples: List[(T, R)]): (List[T], List[R]) = {
+    val start = (List.empty[T], List.empty[R])
+    tuples.foldLeft(start) { (acc, curr) =>
+      (acc._1 :+ curr._1, acc._2 :+ curr._2)
+    }
+  }
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/clash/clash-with-characteristics-only-props.json.jsonld
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/clash/clash-with-characteristics-only-props.json.jsonld
@@ -1,0 +1,44 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/clash-with-characteristics-only-props.json#/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#BaseUnitProcessingData"
+      ],
+      "http://a.ml/vocabularies/document#transformed": false
+    },
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/clash-with-characteristics-only-props.json#/encodes/",
+      "@type": [
+        "http://a.ml/vocabularies/core#encodes",
+        "http://a.ml/vocabularies/document#JsonLDObject"
+      ],
+      "http://a.ml/vocabularies/aml#b": [
+        "shouldn't have a, should have an array of b",
+        {
+          "@value": "true",
+          "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/clash-with-characteristics-only-props.json",
+      "@type": [
+        "http://a.ml/vocabularies/document#JsonLDInstanceDocument",
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#encodes": [
+        {
+          "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/clash-with-characteristics-only-props.json#/encodes/"
+        }
+      ],
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/clash-with-characteristics-only-props.json#/BaseUnitProcessingData"
+      }
+    }
+  ]
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/clash/clash-with-conditional.json.jsonld
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/clash/clash-with-conditional.json.jsonld
@@ -14,8 +14,13 @@
         "http://a.ml/vocabularies/document#JsonLDObject"
       ],
       "http://a.ml/vocabularies/core#a": true,
-      "http://a.ml/vocabularies/core#c": 5,
-      "http://a.ml/vocabularies/core#b": "something"
+      "http://a.ml/vocabularies/aml#b": [
+        {
+          "@value": "5",
+          "@type": "http://www.w3.org/2001/XMLSchema#integer"
+        },
+        "something"
+      ]
     },
     {
       "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/clash-with-conditional.json",

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/clash/inter-object-properties-clash.json.jsonld
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/clash/inter-object-properties-clash.json.jsonld
@@ -26,8 +26,13 @@
         "http://a.ml/vocabularies/core#a",
         "http://a.ml/vocabularies/document#JsonLDObject"
       ],
-      "http://a.ml/vocabularies/core#a/c": true,
-      "http://a.ml/vocabularies/core#a/d": "true"
+      "http://a.ml/vocabularies/aml#z": [
+        "true",
+        {
+          "@value": "true",
+          "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+        }
+      ]
     },
     {
       "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/inter-object-properties-clash.json#/encodes/b",
@@ -35,8 +40,13 @@
         "http://a.ml/vocabularies/core#b",
         "http://a.ml/vocabularies/document#JsonLDObject"
       ],
-      "http://a.ml/vocabularies/core#b/c": false,
-      "http://a.ml/vocabularies/core#b/d": "false"
+      "http://a.ml/vocabularies/aml#y": [
+        "false",
+        {
+          "@value": "false",
+          "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+        }
+      ]
     },
     {
       "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/inter-object-properties-clash.json",

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/clash/term-with-same-iri-as-prop.json.jsonld
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/clash/term-with-same-iri-as-prop.json.jsonld
@@ -13,8 +13,13 @@
         "http://a.ml/vocabularies/core#encodes",
         "http://a.ml/vocabularies/document#JsonLDObject"
       ],
-      "http://a.ml/vocabularies/core#prop1": true,
-      "http://a.ml/vocabularies/core#prop2": "false"
+      "http://a.ml/vocabularies/core#prop2": [
+        "false",
+        {
+          "@value": "true",
+          "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+        }
+      ]
     },
     {
       "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/term-with-same-iri-as-prop.json",

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/propagation/nested-semantics-redefinition.json.jsonld
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/propagation/nested-semantics-redefinition.json.jsonld
@@ -1,0 +1,61 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json#/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#BaseUnitProcessingData"
+      ],
+      "http://a.ml/vocabularies/document#transformed": false
+    },
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json#/encodes/",
+      "@type": [
+        "http://a.ml/vocabularies/core#encodes",
+        "http://a.ml/vocabularies/document#JsonLDObject"
+      ],
+      "http://a.ml/vocabularies/core#a": true,
+      "http://a.ml/vocabularies/aml#b": "should have redifined semantics",
+      "http://a.ml/vocabularies/aml#c": {
+        "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json#/encodes/c"
+      }
+    },
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json#/encodes/c",
+      "@type": [
+        "http://a.ml/vocabularies/core#c",
+        "http://a.ml/vocabularies/document#JsonLDObject"
+      ],
+      "http://a.ml/vocabularies/core#c/d": "d property",
+      "http://a.ml/vocabularies/aml#e": {
+        "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json#/encodes/c/e"
+      }
+    },
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json#/encodes/c/e",
+      "@type": [
+        "http://a.ml/vocabularies/core#c/e",
+        "http://a.ml/vocabularies/document#JsonLDObject"
+      ],
+      "http://a.ml/vocabularies/aml#f": "f-property"
+    },
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json",
+      "@type": [
+        "http://a.ml/vocabularies/document#JsonLDInstanceDocument",
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#encodes": [
+        {
+          "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json#/encodes/"
+        }
+      ],
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json#/BaseUnitProcessingData"
+      }
+    }
+  ]
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/propagation/simple-nested-semantics-redefinition.json.jsonld
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/propagation/simple-nested-semantics-redefinition.json.jsonld
@@ -1,0 +1,40 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/simple-nested-semantics-redefinition.json#/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#BaseUnitProcessingData"
+      ],
+      "http://a.ml/vocabularies/document#transformed": false
+    },
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/simple-nested-semantics-redefinition.json#/encodes/",
+      "@type": [
+        "http://a.ml/vocabularies/core#encodes",
+        "http://a.ml/vocabularies/document#JsonLDObject"
+      ],
+      "http://a.ml/vocabularies/core#a": true,
+      "http://a.ml/vocabularies/aml#b": "should be aml:b",
+      "http://a.ml/vocabularies/aml#c": "should be aml:c"
+    },
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/simple-nested-semantics-redefinition.json",
+      "@type": [
+        "http://a.ml/vocabularies/document#JsonLDInstanceDocument",
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#encodes": [
+        {
+          "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/simple-nested-semantics-redefinition.json#/encodes/"
+        }
+      ],
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/simple-nested-semantics-redefinition.json#/BaseUnitProcessingData"
+      }
+    }
+  ]
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/propagation/term-is-applied-to-undefined-schema-key.json.jsonld
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/results/semantics/propagation/term-is-applied-to-undefined-schema-key.json.jsonld
@@ -1,0 +1,39 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/term-is-applied-to-undefined-schema-key.json#/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#BaseUnitProcessingData"
+      ],
+      "http://a.ml/vocabularies/document#transformed": false
+    },
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/term-is-applied-to-undefined-schema-key.json#/encodes/",
+      "@type": [
+        "http://a.ml/vocabularies/core#encodes",
+        "http://a.ml/vocabularies/document#JsonLDObject"
+      ],
+      "http://a.ml/vocabularies/core#a": true,
+      "http://a.ml/vocabularies/aml#b": "b wasn't defined in schema"
+    },
+    {
+      "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/term-is-applied-to-undefined-schema-key.json",
+      "@type": [
+        "http://a.ml/vocabularies/document#JsonLDInstanceDocument",
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/document#encodes": [
+        {
+          "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/term-is-applied-to-undefined-schema-key.json#/encodes/"
+        }
+      ],
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/term-is-applied-to-undefined-schema-key.json#/BaseUnitProcessingData"
+      }
+    }
+  ]
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/clash-with-characteristics-only-props.json
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/clash/clash-with-characteristics-only-props.json
@@ -1,0 +1,4 @@
+{
+  "a": true,
+  "b": "shouldn't have a, should have an array of b"
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/nested-semantics-redefinition.json
@@ -1,0 +1,10 @@
+{
+  "a": true,
+  "b": "should have redifined semantics",
+  "c": {
+    "d": "d property",
+    "e": {
+      "f": "f-property"
+    }
+  }
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/simple-nested-semantics-redefinition.json
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/simple-nested-semantics-redefinition.json
@@ -1,0 +1,5 @@
+{
+  "a": true,
+  "b": "should be aml:b",
+  "c": "should be aml:c"
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/term-is-applied-to-undefined-schema-key.json
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/instances/semantics/propagation/term-is-applied-to-undefined-schema-key.json
@@ -1,0 +1,4 @@
+{
+  "a": true,
+  "b": "b wasn't defined in schema"
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/schemas/semantics/clash/clash-with-characteristics-only-props.json
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/schemas/semantics/clash/clash-with-characteristics-only-props.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "@context": {
+    "aml": "http://a.ml/vocabularies/aml#",
+    "b": "aml:b"
+  },
+  "properties": {
+    "a": {
+      "@context": {
+        "@characteristics": [
+          "http://a.ml/vocabularies/aml#b"
+        ]
+      },
+      "type": "boolean"
+    },
+    "b": {
+      "type": "string"
+    }
+  }
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/schemas/semantics/propagation/nested-semantics-redefinition.json
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/schemas/semantics/propagation/nested-semantics-redefinition.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "@context": {
+    "aml": "http://a.ml/vocabularies/aml#",
+    "b": "aml:b"
+  },
+  "properties": {
+    "a": {
+      "type": "boolean"
+    },
+    "b": {
+      "type": "string"
+    },
+    "c": {
+      "@context": {
+        "e": "aml:e"
+      },
+      "properties": {
+        "d": {
+          "type": "string"
+        },
+        "e": {
+          "@context": {
+            "f": "aml:f"
+          },
+          "properties": {
+            "f": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    }
+  },
+  "if": {
+    "a": true
+  },
+  "then": {
+    "@context": {
+      "c": "aml:c"
+    },
+    "properties": {
+      "c": {
+        "type": "object",
+        "properties": {
+          "d": {
+            "type": "string"
+          },
+          "e": {
+            "@context": {
+              "redefine": "http://a.ml/vocabularies/aml-redefined#",
+              "e": "redefine:e"
+            },
+            "properties": {
+              "f": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/schemas/semantics/propagation/simple-nested-semantics-redefinition.json
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/schemas/semantics/propagation/simple-nested-semantics-redefinition.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "@context": {
+    "aml": "http://a.ml/vocabularies/aml#",
+    "b": "aml:b"
+  },
+  "properties": {
+    "a": {
+      "type": "boolean"
+    },
+    "b": {
+      "type": "string"
+    }
+  },
+  "if": {
+    "a": true
+  },
+  "then": {
+    "@context": {
+      "c": "aml:c"
+    },
+    "properties": {
+      "c": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/amf-shapes/shared/src/test/resources/jsonld-schema/schemas/semantics/propagation/term-is-applied-to-undefined-schema-key.json
+++ b/amf-shapes/shared/src/test/resources/jsonld-schema/schemas/semantics/propagation/term-is-applied-to-undefined-schema-key.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "@context": {
+    "aml": "http://a.ml/vocabularies/aml#",
+    "b": "aml:b"
+  },
+  "properties": {
+    "a": {
+      "type": "boolean"
+    }
+  }
+}


### PR DESCRIPTION
- (refactor): cleaned up parsers
- fix: fixed usage of ctx aliases for properties not defined in schema but present in instance
- feat: changed semantic clash mechanism to form an array of values instead of term inheritance
- fix: overriden term shouldn't be set at the end at Field creation, it should be taken into account when clashing also. Test change is side-effect. Needs proper test
