### PR TITLE
Issue/1626 Type array is missing in the generated RAML specification

### DIFF
--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/emitter/RamlArrayShapeEmitter.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/emitter/RamlArrayShapeEmitter.scala
@@ -23,7 +23,8 @@ case class RamlArrayShapeEmitter(array: ArrayShape, ordering: SpecOrdering, refe
 
     fs.entry(ArrayShapeModel.Items)
       .foreach(_ => {
-        typeEmitted = true
+        if (spec.options.implicitRamlTypes)
+          typeEmitted = true
         result += RamlItemsShapeEmitter(array, ordering, references)
       })
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/emitter/RamlNodeShapeEmitter.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/emitter/RamlNodeShapeEmitter.scala
@@ -53,7 +53,8 @@ case class RamlNodeShapeEmitter(node: NodeShape, ordering: SpecOrdering, referen
     fs.entry(NodeShapeModel.DiscriminatorValue).map(f => result += RamlScalarEmitter("discriminatorValue", f))
 
     fs.entry(NodeShapeModel.Properties).map { f =>
-      typeEmitted = true
+      if (spec.options.implicitRamlTypes)
+        typeEmitted = true
       result += RamlPropertiesShapeEmitter(f, ordering, references)
     }
 


### PR DESCRIPTION
Fixes #1626
This PR contains both the fix for arrays, but also objects.
If only arrays should be fixed, please comment below.