### PR TITLE
W-11337671

### DIFF
--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.jsonld
@@ -177,7 +177,12 @@
 "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/anyOf/nil/default-nil"
 }
 ],
-"http://www.w3.org/ns/shacl#name": "common"
+"http://www.w3.org/ns/shacl#name": "common",
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/examples/example/default-example"
+}
+]
 },
 {
 "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/any/allOfSchema",
@@ -608,12 +613,7 @@
 "http://a.ml/vocabularies/shapes#deprecated": false,
 "http://a.ml/vocabularies/core#documentation": {
 "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/anyOf/scalar/common/creative-work/https%3A%2F%2Fexample.com"
-},
-"http://a.ml/vocabularies/apiContract#examples": [
-{
-"@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/anyOf/scalar/common/examples/example/default-example"
 }
-]
 },
 {
 "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/anyOf/nil/default-nil",
@@ -623,6 +623,18 @@
 "http://a.ml/vocabularies/shapes#Shape",
 "http://a.ml/vocabularies/document#DomainElement"
 ]
+},
+{
+"@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/examples/example/default-example",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/document#strict": true,
+"http://a.ml/vocabularies/document#structuredValue": {
+"@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/examples/example/default-example/scalar_1"
+},
+"http://a.ml/vocabularies/document#raw": "a"
 },
 {
 "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/any/allOfSchema/and/shape/item0",
@@ -1045,16 +1057,19 @@
 "http://a.ml/vocabularies/core#description": "Find more info here"
 },
 {
-"@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/anyOf/scalar/common/examples/example/default-example",
+"@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/examples/example/default-example/scalar_1",
 "@type": [
-"http://a.ml/vocabularies/apiContract#Example",
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/document#strict": true,
-"http://a.ml/vocabularies/document#structuredValue": {
-"@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/anyOf/scalar/common/examples/example/default-example/scalar_1"
-},
-"http://a.ml/vocabularies/document#raw": "a"
+"http://a.ml/vocabularies/data#value": "a",
+"http://www.w3.org/ns/shacl#datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/core#name": "scalar_1"
 },
 {
 "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/shape/objectSchema/property/property/a/any/a",
@@ -1207,21 +1222,6 @@
 },
 {
 "@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/parameter/header/aHeader/examples/example/default-example/scalar_1",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar",
-"http://a.ml/vocabularies/data#Node",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/data#value": "a",
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/core#name": "scalar_1"
-},
-{
-"@id": "file://amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.yaml#/declares/union/common/anyOf/scalar/common/examples/example/default-example/scalar_1",
 "@type": [
 "http://a.ml/vocabularies/data#Scalar",
 "http://a.ml/vocabularies/data#Node",

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.jsonld.yaml
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.jsonld.yaml
@@ -22,6 +22,9 @@ components:
       not:
         type: string
     common:
+      example:
+        strict: true
+        value: a
       anyOf:
         -
           title: common schema
@@ -30,9 +33,6 @@ components:
             url: https://example.com
             description: Find more info here
           deprecated: false
-          example:
-            strict: true
-            value: a
           type: string
           minLength: 0
           maxLength: 100

--- a/amf-cli/shared/src/test/resources/validations/oas3/nullable-example.yaml
+++ b/amf-cli/shared/src/test/resources/validations/oas3/nullable-example.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: test oas 3.0 api
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string
+                example: a test string
+                nullable: true

--- a/amf-cli/shared/src/test/resources/validations/oas3/nullable-example.yaml
+++ b/amf-cli/shared/src/test/resources/validations/oas3/nullable-example.yaml
@@ -12,5 +12,5 @@ paths:
             application/json:
               schema:
                 type: string
-                example: a test string
+                example: null # should be a valid example
                 nullable: true

--- a/amf-cli/shared/src/test/scala/amf/testing/BaseUnitUtils.scala
+++ b/amf-cli/shared/src/test/scala/amf/testing/BaseUnitUtils.scala
@@ -1,0 +1,35 @@
+package amf.testing
+
+import amf.apicontract.client.scala.model.domain.api.{Api, AsyncApi, WebApi}
+import amf.apicontract.client.scala.model.domain._
+import amf.core.client.scala.model.document.{BaseUnit, Document}
+import amf.core.client.scala.model.domain.Shape
+
+object BaseUnitUtils {
+  def getApi(bu: BaseUnit, isWebApi: Boolean = true): Api =
+    if (isWebApi) bu.asInstanceOf[Document].encodes.asInstanceOf[WebApi]
+    else bu.asInstanceOf[Document].encodes.asInstanceOf[AsyncApi]
+
+  def getEndpoints(bu: BaseUnit, isWebApi: Boolean = true): Seq[EndPoint] = getApi(bu, isWebApi).endPoints
+
+  def getServers(bu: BaseUnit, isWebApi: Boolean = true): Seq[Server] = getApi(bu, isWebApi).servers
+
+  def getFirstEndpoint(bu: BaseUnit, isWebApi: Boolean = true): EndPoint = getApi(bu, isWebApi).endPoints.head
+
+  def getFirstOperation(bu: BaseUnit, isWebApi: Boolean = true): Operation =
+    getFirstEndpoint(bu, isWebApi).operations.head
+
+  def getFirstRequest(bu: BaseUnit, isWebApi: Boolean = true): Request = getFirstOperation(bu, isWebApi).requests.head
+
+  def getFirstResponse(bu: BaseUnit, isWebApi: Boolean = true): Response =
+    getFirstOperation(bu, isWebApi).responses.head
+
+  def getFirstRequestPayload(bu: BaseUnit, isWebApi: Boolean = true): Payload =
+    getFirstRequest(bu, isWebApi).payloads.head
+
+  def getFirstResponsePayload(bu: BaseUnit, isWebApi: Boolean = true): Payload =
+    getFirstResponse(bu, isWebApi).payloads.head
+
+  def getFirstPayloadSchema(bu: BaseUnit, isWebApi: Boolean = true): Shape =
+    getFirstResponsePayload(bu, isWebApi).schema
+}

--- a/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
@@ -12,7 +12,7 @@ import amf.core.client.scala.model.domain.{AmfArray, Annotation, ExternalSourceE
 import amf.core.internal.annotations.{DeclaredElement, Inferred, VirtualElement, VirtualNode}
 import amf.core.internal.parser.domain.Annotations
 import amf.graphql.client.scala.GraphQLConfiguration
-import amf.shapes.client.scala.model.domain.{AnyShape, NodeShape, ScalarShape, SchemaShape}
+import amf.shapes.client.scala.model.domain.{AnyShape, NodeShape, ScalarShape, SchemaShape, UnionShape}
 import amf.shapes.internal.annotations.BaseVirtualNode
 import amf.shapes.internal.domain.metamodel.AnyShapeModel
 import amf.testing.ConfigProvider.configFor
@@ -403,6 +403,16 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
       val serverParamLexical        = virtualServerParam.annotations.lexical()
       val correctServerParamLexical = PositionRange((6, 33), (6, 48))
       serverParamLexical.compareTo(correctServerParamLexical) shouldBe 0
+    }
+  }
+
+  // W-11337671
+  test("CRI OAS Union examples") {
+    val oasApi = s"$basePath/oas3/nullable-example.yaml"
+    modelAssertion(oasApi, PipelineId.Editing) { bu =>
+      val payloadSchema = getFirstResponsePayload(bu).schema.asInstanceOf[UnionShape]
+      payloadSchema.examples.size shouldBe 1
+      payloadSchema.anyOf.head.asInstanceOf[ScalarShape].examples.size shouldBe 0
     }
   }
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
@@ -407,7 +407,7 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   }
 
   // W-11337671
-  test("CRI OAS Union examples") {
+  test("OAS 3 nullable schema should have examples at union level") {
     val oasApi = s"$basePath/oas3/nullable-example.yaml"
     modelAssertion(oasApi, PipelineId.Editing) { bu =>
       val payloadSchema = getFirstResponsePayload(bu).schema.asInstanceOf[UnionShape]

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/ExemplifiedDomainElement.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/ExemplifiedDomainElement.scala
@@ -13,7 +13,7 @@ trait ExemplifiedDomainElement extends DomainElement {
 
   def withExample(name: Option[String]): Example = {
     val example = Example()
-    name.foreach { example.withName(_) }
+    name.foreach { example.withName }
     add(Examples, example)
     example
   }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ExampleDataParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ExampleDataParser.scala
@@ -38,8 +38,9 @@ case class ExampleDataParser(entryLike: YMapEntryLike, example: Example, options
     }
 
     node.toOption[YScalar] match {
-      case Some(_) if node.tagType == YType.Null =>
-        example.setWithoutId(ExampleModel.Raw, AmfScalar("null"), Annotations.synthesized())
+      case Some(value) if node.tagType == YType.Null =>
+        if (isNullLiteral(value))
+          example.setWithoutId(ExampleModel.Raw, AmfScalar("null"), Annotations.synthesized())
       case Some(scalar) =>
         example.setWithoutId(ExampleModel.Raw, AmfScalar(scalar.text), Annotations.synthesized())
       case _ =>
@@ -55,6 +56,8 @@ case class ExampleDataParser(entryLike: YMapEntryLike, example: Example, options
 
     example
   }
+
+  private def isNullLiteral(value: YScalar) = value.text.nonEmpty
 }
 
 case class ExamplesDataParser(seq: YSequence, options: ExampleOptions, parentId: String)(implicit

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ExampleParsers.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ExampleParsers.scala
@@ -188,14 +188,26 @@ case class RamlSingleExampleParser(
           node.tagType match {
             case YType.Map =>
               Option(RamlSingleExampleValueParser(entry, newProducer, options).parse())
+            case YType.Null => checkEmptyExample(newProducer, entry, node)
             case _ => // example can be any type or scalar value, like string int datetime etc. We will handle all like strings in this stage
-              Option(
-                ExampleDataParser(YMapEntryLike(node), newProducer().add(Annotations(entry.value)), options)
-                  .parse()
-              )
+              parseExample(newProducer, entry, node)
           }
       }
     }
+  }
+
+  private def checkEmptyExample(newProducer: () => Example, entry: YMapEntry, node: YNode): Option[Example] = {
+    node.value match {
+      case value: YScalar if value.text.nonEmpty => parseExample(newProducer, entry, node)
+      case _                                     => None
+    }
+  }
+
+  private def parseExample(newProducer: () => Example, entry: YMapEntry, node: YNode): Option[Example] = {
+    Option(
+      ExampleDataParser(YMapEntryLike(node), newProducer().add(Annotations(entry.value)), options)
+        .parse()
+    )
   }
 }
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ExampleParsers.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ExampleParsers.scala
@@ -188,7 +188,6 @@ case class RamlSingleExampleParser(
           node.tagType match {
             case YType.Map =>
               Option(RamlSingleExampleValueParser(entry, newProducer, options).parse())
-            case YType.Null => None
             case _ => // example can be any type or scalar value, like string int datetime etc. We will handle all like strings in this stage
               Option(
                 ExampleDataParser(YMapEntryLike(node), newProducer().add(Annotations(entry.value)), options)

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/oas/parser/InlineOasTypeParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/oas/parser/InlineOasTypeParser.scala
@@ -103,7 +103,7 @@ case class InlineOasTypeParser(
   protected def moveExamplesToUnion(parsed: AnyShape, union: UnionShape): Unit = {
     val AmfArray(values, annotations) = parsed.fields.get(ExamplesField.Examples)
     if (values.nonEmpty) {
-      union.setWithoutId(ExamplesField.Examples, AmfArray(values, annotations), annotations)
+      union.setWithoutId(ExamplesField.Examples, AmfArray(values, annotations), annotations ++= inferred())
       parsed.fields.removeField(ExamplesField.Examples)
     }
   }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/oas/parser/InlineOasTypeParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/oas/parser/InlineOasTypeParser.scala
@@ -101,9 +101,9 @@ case class InlineOasTypeParser(
   protected def isOas3: Boolean = version.isInstanceOf[OAS30SchemaVersion]
 
   protected def moveExamplesToUnion(parsed: AnyShape, union: UnionShape): Unit = {
-    val AmfArray(values, fieldAnnotations) = parsed.fields.get(ExamplesField.Examples)
+    val AmfArray(values, annotations) = parsed.fields.get(ExamplesField.Examples)
     if (values.nonEmpty) {
-      union.setWithoutId(ExamplesField.Examples, AmfArray(values), fieldAnnotations)
+      union.setWithoutId(ExamplesField.Examples, AmfArray(values, annotations), annotations)
       parsed.fields.removeField(ExamplesField.Examples)
     }
   }


### PR DESCRIPTION
- W-11337671: add inferred annotation to union examples field
- W-11337671: avoid parsing empty examples
- W-11337671: stop ignoring null as an example value
- W-11337671: move NilUnion examples to union level
- (refactor): move BaseUnitUtils to its own class
