### PR TITLE
W 11905078

### DIFF
--- a/amf-cli/shared/src/test/resources/upanddown/raml10/explicit-implicit-types/input.raml
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/explicit-implicit-types/input.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: MyAPI
+version: 1.0
+baseUri: http://com.foo.bar/api
+types:
+  Person:
+    properties:
+      name: string
+
+  People:
+    type: Person[]
+

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/explicit-implicit-types/output-explicit-types.raml
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/explicit-implicit-types/output-explicit-types.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0
+title: MyAPI
+version: "1.0"
+baseUri: http://com.foo.bar/api
+types:
+  Person:
+    properties:
+      name:
+        type: string
+    type: object
+  People:
+    items: Person
+    type: array

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/explicit-implicit-types/output-implicit-types.raml
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/explicit-implicit-types/output-implicit-types.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+title: MyAPI
+version: "1.0"
+baseUri: http://com.foo.bar/api
+types:
+  Person:
+    properties:
+      name:
+        type: string
+  People:
+    items: Person

--- a/amf-cli/shared/src/test/scala/amf/parser/Raml10ParserTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/parser/Raml10ParserTest.scala
@@ -57,4 +57,24 @@ class Raml10ParserTest extends FunSuiteCycleTests with Matchers {
     )
   }
 
+  test("Render with implicit types") {
+    cycle(
+      "explicit-implicit-types/input.raml",
+      "explicit-implicit-types/output-implicit-types.raml",
+      Raml10YamlHint,
+      Raml10YamlHint,
+      renderOptions = Some(RenderOptions())
+    )
+  }
+
+  test("Render with explicit types") {
+    cycle(
+      "explicit-implicit-types/input.raml",
+      "explicit-implicit-types/output-explicit-types.raml",
+      Raml10YamlHint,
+      Raml10YamlHint,
+      renderOptions = Some(RenderOptions().withoutImplicitRamlTypes)
+    )
+  }
+
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/emitter/RamlArrayShapeEmitter.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/emitter/RamlArrayShapeEmitter.scala
@@ -23,7 +23,8 @@ case class RamlArrayShapeEmitter(array: ArrayShape, ordering: SpecOrdering, refe
 
     fs.entry(ArrayShapeModel.Items)
       .foreach(_ => {
-        typeEmitted = true
+        if (spec.options.implicitRamlTypes)
+          typeEmitted = true
         result += RamlItemsShapeEmitter(array, ordering, references)
       })
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/emitter/RamlNodeShapeEmitter.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/emitter/RamlNodeShapeEmitter.scala
@@ -53,7 +53,8 @@ case class RamlNodeShapeEmitter(node: NodeShape, ordering: SpecOrdering, referen
     fs.entry(NodeShapeModel.DiscriminatorValue).map(f => result += RamlScalarEmitter("discriminatorValue", f))
 
     fs.entry(NodeShapeModel.Properties).map { f =>
-      typeEmitted = true
+      if (spec.options.implicitRamlTypes)
+        typeEmitted = true
       result += RamlPropertiesShapeEmitter(f, ordering, references)
     }
 


### PR DESCRIPTION
- Fix #1626: Support both implicit and explicit type rendering in raml generation
- W-11905078: added test
