### PR TITLE
W-11757246/fail-fast-json-schema-plugin

### DIFF
--- a/amf-cli/js/src/test/scala/amf/client/validation/JsClientPayloadValidationTest.scala
+++ b/amf-cli/js/src/test/scala/amf/client/validation/JsClientPayloadValidationTest.scala
@@ -1,0 +1,5 @@
+package amf.client.validation
+
+import amf.cli.internal.convert.NativeOpsFromJs
+
+class JsClientPayloadValidationTest extends ClientPayloadValidationTest with NativeOpsFromJs {}

--- a/amf-cli/js/src/test/scala/amf/client/validation/JsPayloadValidationTest.scala
+++ b/amf-cli/js/src/test/scala/amf/client/validation/JsPayloadValidationTest.scala
@@ -2,4 +2,4 @@ package amf.client.validation
 
 import amf.cli.internal.convert.NativeOpsFromJs
 
-class JsPayloadValidationTest extends ClientPayloadValidationTest with NativeOpsFromJs
+class JsPayloadValidationTest extends PayloadValidationTest with NativeOpsFromJs

--- a/amf-cli/jvm/src/test/scala/amf/client/validation/JvmClientPayloadValidationTest.scala
+++ b/amf-cli/jvm/src/test/scala/amf/client/validation/JvmClientPayloadValidationTest.scala
@@ -1,0 +1,5 @@
+package amf.client.validation
+
+import amf.cli.internal.convert.NativeOpsFromJvm
+
+class JvmClientPayloadValidationTest extends ClientPayloadValidationTest with NativeOpsFromJvm

--- a/amf-cli/jvm/src/test/scala/amf/client/validation/JvmPayloadValidationTest.scala
+++ b/amf-cli/jvm/src/test/scala/amf/client/validation/JvmPayloadValidationTest.scala
@@ -1,25 +1,25 @@
 package amf.client.validation
 
 import amf.cli.internal.convert.NativeOpsFromJvm
-import amf.core.client.platform.config.ParsingOptions
 import amf.core.client.platform.model.DataTypes
+import amf.core.client.scala.config.ParsingOptions
 import amf.core.internal.remote.Mimes
 import amf.core.internal.remote.Mimes._
-import amf.shapes.client.platform.ShapesConfiguration
-import amf.shapes.client.platform.model.domain.{ArrayShape, NodeShape, ScalarShape}
+import amf.shapes.client.scala.ShapesConfiguration
+import amf.shapes.client.scala.model.domain.{ArrayShape, NodeShape, ScalarShape}
 
-class JvmPayloadValidationTest extends ClientPayloadValidationTest with NativeOpsFromJvm {
+class JvmPayloadValidationTest extends PayloadValidationTest with NativeOpsFromJvm {
 
   test("Test unexpected type error") {
-    val test   = new ScalarShape().withDataType(DataTypes.String)
+    val test   = ScalarShape().withDataType(DataTypes.String)
     val report = payloadValidator(test, `application/json`).syncValidate("1234")
     report.conforms shouldBe false
-    report.results.asSeq.head.message shouldBe "expected type: String, found: Integer" // APIKit compatibility
+    report.results.head.message shouldBe "expected type: String, found: Integer" // APIKit compatibility
   }
 
   // regex pending analysis (APIMF-3058) jvm cannot process regex, on the other hand it is valid for js
   test("Avoid exception for pattern regex that cannot be parsed") {
-    val shape = new ScalarShape()
+    val shape = ScalarShape()
       .withDataType(DataTypes.String)
       .withPattern(
         "^(([^<>()[\\]\\\\.,;:\\s@\"]+(\\.[^<>()[\\]\\\\.,;:\\s@\"]+)*)|(\".+\"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$"
@@ -27,21 +27,21 @@ class JvmPayloadValidationTest extends ClientPayloadValidationTest with NativeOp
     val validator = payloadValidator(shape, `application/json`)
     val report    = validator.syncValidate(""""irrelevant text"""")
     report.conforms shouldBe false
-    report.results.asSeq.head.message shouldBe "Regex defined in schema could not be processed"
+    report.results.head.message shouldBe "Regex defined in schema could not be processed"
   }
 
   test("Validation against a number with multipleOf 0 should throw violation") {
-    val shape                = new ScalarShape().withDataType(DataTypes.Number).withMultipleOf(0)
+    val shape                = ScalarShape().withDataType(DataTypes.Number).withMultipleOf(0)
     val validator            = payloadValidator(shape, `application/json`)
     val positiveNumberReport = validator.syncValidate("5")
     val zeroReport           = validator.syncValidate("0")
-    positiveNumberReport.results.asSeq.head.message shouldBe "Can't divide by 0"
-    zeroReport.results.asSeq.head.message shouldBe "Can't divide by 0"
+    positiveNumberReport.results.head.message shouldBe "Can't divide by 0"
+    zeroReport.results.head.message shouldBe "Can't divide by 0"
   }
 
   test("Validation order shouldn't affect conformance of each payload") {
-    val itemsShape = new NodeShape()
-    val shape      = new ArrayShape().withItems(itemsShape)
+    val itemsShape = NodeShape()
+    val shape      = ArrayShape().withItems(itemsShape)
     val validator  = payloadValidator(shape, `application/yaml`)
 
     val validPayload = "- {}"
@@ -52,15 +52,15 @@ class JvmPayloadValidationTest extends ClientPayloadValidationTest with NativeOp
     val invalidReport = validator.syncValidate(invalidPayload)
     val validReport2  = validator.syncValidate(validPayload)
 
-    validReport1.results.asSeq.size shouldBe 0
-    invalidReport.results.asSeq.size shouldBe 1
-    validReport2.results.asSeq.size shouldBe 0 // this line should not fail
+    validReport1.results.size shouldBe 0
+    invalidReport.results.size shouldBe 1
+    validReport2.results.size shouldBe 0 // this line should not fail
   }
 
   test("Payload with max depth that exceeds 50 should not conform") {
-    val dummyShape = new NodeShape()
+    val dummyShape = NodeShape()
     val maxDepth   = 50
-    val options    = new ParsingOptions().setMaxJsonYamlDepth(maxDepth)
+    val options    = ParsingOptions().setMaxJsonYamlDepth(maxDepth)
     val config     = ShapesConfiguration.predefined().withParsingOptions(options)
     val validator  = payloadValidator(dummyShape, Mimes.`application/json`, config)
     val payload =
@@ -76,15 +76,15 @@ class JvmPayloadValidationTest extends ClientPayloadValidationTest with NativeOp
 
     val report = validator.syncValidate(payload)
     report.conforms shouldBe false
-    report.results.asSeq.head.message should include(s"Reached maximum nesting value of $maxDepth in JSON")
+    report.results.head.message should include(s"Reached maximum nesting value of $maxDepth in JSON")
   }
 
   test(
     "Big payload with nested depth accumulation of more than 7 but max accumulation of less than 7 should be valid"
   ) {
-    val dummyShape = new NodeShape()
+    val dummyShape = NodeShape()
     val maxDepth   = 7
-    val options    = new ParsingOptions().setMaxJsonYamlDepth(maxDepth)
+    val options    = ParsingOptions().setMaxJsonYamlDepth(maxDepth)
     val config     = ShapesConfiguration.predefined().withParsingOptions(options)
     val validator  = payloadValidator(dummyShape, Mimes.`application/json`, config)
     val payload =

--- a/amf-cli/shared/src/test/scala/amf/client/validation/ClientPayloadValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/client/validation/ClientPayloadValidationTest.scala
@@ -1,245 +1,45 @@
 package amf.client.validation
 
 import amf.cli.internal.convert.NativeOps
-import amf.core.client.common.validation.{ScalarRelaxedValidationMode, StrictValidationMode}
-import amf.core.client.platform.AMFGraphConfiguration
+import amf.core.client.common.validation.StrictValidationMode
 import amf.core.client.platform.model.DataTypes
-import amf.core.client.platform.model.domain.{PropertyShape, RecursiveShape, Shape}
-import amf.core.client.platform.validation.payload.AMFShapePayloadValidator
-import amf.core.client.scala.model.domain.{RecursiveShape => InternalRecursiveShape}
-import amf.core.internal.remote.Mimes._
+import amf.core.internal.remote.Mimes.`application/json`
 import amf.shapes.client.platform.ShapesConfiguration
-import amf.shapes.client.platform.model.domain._
-import amf.shapes.client.scala.model.domain.{ScalarShape => InternalScalarShape}
-import org.scalatest.funsuite.AsyncFunSuite
+import amf.shapes.client.platform.model.domain.ScalarShape
+import org.scalatest.funsuite.{AnyFunSuite, AsyncFunSuite}
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
-trait PayloadValidationUtils {
-  protected def defaultConfig: ShapesConfiguration = ShapesConfiguration.predefined()
+trait ClientPayloadValidationTest extends AsyncFunSuite with NativeOps with Matchers {
 
-  protected def parameterValidator(
-      s: Shape,
-      mediaType: String,
-      config: AMFGraphConfiguration = defaultConfig
-  ): AMFShapePayloadValidator =
-    config.elementClient().payloadValidatorFor(s, mediaType, ScalarRelaxedValidationMode)
+  override implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
-  protected def payloadValidator(
-      s: Shape,
-      mediaType: String,
-      config: AMFGraphConfiguration = defaultConfig
-  ): AMFShapePayloadValidator =
-    config.elementClient().payloadValidatorFor(s, mediaType, StrictValidationMode)
-}
-
-trait ClientPayloadValidationTest extends AsyncFunSuite with NativeOps with Matchers with PayloadValidationUtils {
-
-  import amf.shapes.internal.convert.ShapeClientConverters._
-
-  test("Test parameter validator int payload") {
-    val test = new ScalarShape().withDataType(DataTypes.String).withName("test")
-
-    parameterValidator(test, `application/yaml`)
-      .validate("1234")
-      .asFuture
-      .map(r => assert(r.conforms))
-  }
-
-  test("Test parameter validator boolean payload") {
-    val test = new ScalarShape().withDataType(DataTypes.String).withName("test")
-
-    parameterValidator(test, `application/yaml`)
-      .validate("true")
-      .asFuture
-      .map(r => assert(r.conforms))
-  }
-
-  test("Invalid trailing coma in json object payload") {
-    val s     = new ScalarShape().withDataType(DataTypes.String)
-    val shape = new NodeShape().withName("person")
-    shape.withProperty("someString").withRange(s)
-
-    val payload =
-      """
-          |{
-          |  "someString": "invalid string value",
-          |}
-        """.stripMargin
-
-    payloadValidator(shape, `application/json`)
-      .validate(payload)
-      .asFuture
-      .map(r => assert(!r.conforms))
-  }
-
-  test("Invalid trailing coma in json array payload") {
-
-    val s     = new ScalarShape().withDataType(DataTypes.String)
-    val array = new ArrayShape().withName("person")
-    array.withItems(s)
-
-    val payload =
-      """
-          |["trailing", "comma",]
-        """.stripMargin
-
-    payloadValidator(array, `application/json`)
-      .validate(payload)
-      .asFuture
-      .map(r => assert(!r.conforms))
-  }
-
-  test("Test sync validation") {
-    val test   = new ScalarShape().withDataType(DataTypes.String).withName("test")
-    val report = parameterValidator(test, `application/yaml`).syncValidate("1234")
-    report.conforms shouldBe true
-  }
-
-  test("'null' doesn't conform as string") {
-    val payload   = "null"
-    val shape     = new ScalarShape().withDataType(DataTypes.String)
-    val validator = payloadValidator(shape, `application/yaml`)
-    validator.validate(payload).asFuture.map(r => r.conforms shouldBe false)
-  }
-
-  test("'null' conforms as null") {
-
-    val payload   = "null"
-    val shape     = new ScalarShape().withDataType(DataTypes.Nil)
-    val validator = payloadValidator(shape, `application/yaml`)
-    validator.validate(payload).asFuture.map(r => r.conforms shouldBe true)
-  }
-
-  test("Big number against scalar shape") {
-
-    val payload   = "22337203685477999090"
-    val shape     = new ScalarShape().withDataType(DataTypes.Number)
-    val validator = payloadValidator(shape, `application/json`)
-    validator.validate(payload).asFuture.map(r => r.conforms shouldBe true)
-  }
-
-  test("Very big number against scalar shape") {
-
-    val payload   = "22e20000"
-    val shape     = new ScalarShape().withDataType(DataTypes.Number)
-    val validator = payloadValidator(shape, `application/json`)
-    validator.validate(payload).asFuture.map(r => r.conforms shouldBe true)
-  }
-
-  test("Big number against node shape") {
-
-    val payload =
-      """
-          |{
-          | "in": 22337203685477999090
-          |}
-          |""".stripMargin
-    val properties = new PropertyShape()
-      .withName("in")
-      .withRange(new ScalarShape().withDataType(DataTypes.Number))
-    val shape = new NodeShape()
-      .withProperties(Seq(properties._internal).asClient)
-    val validator = payloadValidator(shape, `application/json`)
-
-    validator.validate(payload).asFuture.map(r => r.conforms shouldBe true)
-  }
-
-  test("Invalid payload for json media type") {
-
-    val payload            = "Hello World"
-    val stringShape: Shape = new ScalarShape().withDataType(DataTypes.String)
-    val shape = new AnyShape()
-      .withId("someId")
-      .withOr(Seq(stringShape._internal).asClient)
-    val validator = payloadValidator(shape, `application/json`)
-    validator.validate(payload).asFuture.map(r => r.conforms shouldBe false)
-  }
-
-  test("Test control characters in the middle of a number") {
-
-    val test = new ScalarShape().withDataType(DataTypes.Integer)
-
-    val report = payloadValidator(test, `application/json`).syncValidate("123\n1234")
-    report.conforms shouldBe false
-
-  }
-
-  test("Test that any payload conforms against an any type") {
-
-    val test = new AnyShape()
-
-    val report = payloadValidator(test, `application/json`).syncValidate("any example")
-    report.conforms shouldBe true
-  }
-
-  test("Test that an invalid object payload is validated against an any type") {
-
-    val test = new AnyShape()
-    val payload = """{
-                    |  "a": "something"
-                    |  "b": "other thing"
-                    |}""".stripMargin
-
-    val report = payloadValidator(test, `application/json`).syncValidate(payload)
+  test("Test unexpected type error") {
+    val test   = new ScalarShape().withDataType(DataTypes.String)
+    val report = payloadValidator(test, `application/json`).syncValidate("1234")
     report.conforms shouldBe false
   }
 
-  test("Test that recursive shape has a payload validator") {
-
-    val innerShape     = InternalScalarShape().withDataType(DataTypes.Number)
-    val recursiveShape = RecursiveShape(InternalRecursiveShape(innerShape))
-    val validator      = payloadValidator(recursiveShape, `application/json`)
-    validator.syncValidate("5").conforms shouldBe true
-    validator.syncValidate("true").conforms shouldBe false
-
+  test("Test unexpected type error async") {
+    val test = new ScalarShape().withDataType(DataTypes.String)
+    for {
+      report <- payloadValidator(test, `application/json`).validate("1234").asFuture
+    } yield {
+      report.conforms shouldBe false
+    }
   }
 
-  test("Long type with int64 format is validated as long") {
-
-    val shape     = new ScalarShape().withDataType(DataTypes.Long).withFormat("int64")
-    val validator = payloadValidator(shape, `application/json`)
-    validator.syncValidate("0.1").conforms shouldBe false
+  test("Test valid scalar async") {
+    val test = new ScalarShape().withDataType(DataTypes.String)
+    for {
+      report <- payloadValidator(test, `application/json`).validate("\"1234\"").asFuture
+    } yield {
+      report.conforms shouldBe true
+    }
   }
 
-  test("Json payload with trailing characters should throw error - Object test") {
-
-    val propertyA = new PropertyShape()
-      .withName("a")
-      .withRange(new ScalarShape().withDataType(DataTypes.String))
-    val propertyB = new PropertyShape()
-      .withName("b")
-      .withRange(new ScalarShape().withDataType(DataTypes.String))
-    val shape     = new NodeShape().withProperties(Seq(propertyA._internal, propertyB._internal).asClient)
-    val validator = payloadValidator(shape, `application/json`)
-    validator
-      .syncValidate("""{"a": "aaaa", "b": "bbb"}asdfgh""")
-      .conforms shouldBe false
+  private def payloadValidator(shape: ScalarShape, mediaType: String) = {
+    ShapesConfiguration.predefined().elementClient().payloadValidatorFor(shape, mediaType, StrictValidationMode)
   }
-
-  test("Json payload with trailing characters should throw error - Array test") {
-
-    val propertyA = new PropertyShape()
-      .withName("a")
-      .withRange(new ScalarShape().withDataType(DataTypes.String))
-    val propertyB = new PropertyShape()
-      .withName("b")
-      .withRange(new ScalarShape().withDataType(DataTypes.String))
-    val shape     = new NodeShape().withProperties(Seq(propertyA._internal, propertyB._internal).asClient)
-    val validator = payloadValidator(shape, `application/json`)
-    validator
-      .syncValidate("""["a", "aaaa", "b", "bbb"]asdfgh""")
-      .conforms shouldBe false
-  }
-
-  test("Date-time can only have 4 digits") {
-
-    val shape     = new ScalarShape().withDataType(DataTypes.DateTimeOnly)
-    val validator = payloadValidator(shape, `application/json`)
-    validator.syncValidate(""""22021-06-05T00:00:00"""").conforms shouldBe false
-    validator.syncValidate(""""2021-06-05T00:00:00"""").conforms shouldBe true
-  }
-
-  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 }

--- a/amf-cli/shared/src/test/scala/amf/client/validation/PayloadValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/client/validation/PayloadValidationTest.scala
@@ -1,7 +1,7 @@
 package amf.client.validation
 
 import amf.cli.internal.convert.NativeOps
-import amf.core.client.common.validation.{ScalarRelaxedValidationMode, StrictValidationMode, ValidationMode}
+import amf.core.client.common.validation.{ScalarRelaxedValidationMode, StrictValidationMode}
 import amf.core.client.platform.model.DataTypes
 import amf.core.client.scala.AMFGraphConfiguration
 import amf.core.client.scala.model.domain.extensions.PropertyShape
@@ -10,7 +10,6 @@ import amf.core.client.scala.validation.payload.{AMFShapePayloadValidationPlugin
 import amf.core.internal.remote.Mimes._
 import amf.shapes.client.scala.ShapesConfiguration
 import amf.shapes.client.scala.model.domain._
-import amf.shapes.client.scala.plugin.FailFastJsonSchemaPayloadValidationPlugin
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -33,9 +32,8 @@ trait PayloadValidationUtils {
   ): AMFShapePayloadValidator =
     config.elementClient().payloadValidatorFor(s, mediaType, StrictValidationMode)
 
-  protected def validator(s: Shape,
-                          mediaType: String,
-                          plugin: AMFShapePayloadValidationPlugin) = defaultConfig.withPlugin(plugin).elementClient().payloadValidatorFor(s, mediaType, StrictValidationMode)
+  protected def validator(s: Shape, mediaType: String, plugin: AMFShapePayloadValidationPlugin) =
+    defaultConfig.withPlugin(plugin).elementClient().payloadValidatorFor(s, mediaType, StrictValidationMode)
 }
 
 trait PayloadValidationTest extends AsyncFunSuite with NativeOps with Matchers with PayloadValidationUtils {
@@ -238,6 +236,6 @@ trait PayloadValidationTest extends AsyncFunSuite with NativeOps with Matchers w
     validator.syncValidate(""""22021-06-05T00:00:00"""").conforms shouldBe false
     validator.syncValidate(""""2021-06-05T00:00:00"""").conforms shouldBe true
   }
-  
+
   override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 }

--- a/amf-cli/shared/src/test/scala/amf/client/validation/PayloadValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/client/validation/PayloadValidationTest.scala
@@ -1,0 +1,243 @@
+package amf.client.validation
+
+import amf.cli.internal.convert.NativeOps
+import amf.core.client.common.validation.{ScalarRelaxedValidationMode, StrictValidationMode, ValidationMode}
+import amf.core.client.platform.model.DataTypes
+import amf.core.client.scala.AMFGraphConfiguration
+import amf.core.client.scala.model.domain.extensions.PropertyShape
+import amf.core.client.scala.model.domain.{RecursiveShape, Shape}
+import amf.core.client.scala.validation.payload.{AMFShapePayloadValidationPlugin, AMFShapePayloadValidator}
+import amf.core.internal.remote.Mimes._
+import amf.shapes.client.scala.ShapesConfiguration
+import amf.shapes.client.scala.model.domain._
+import amf.shapes.client.scala.plugin.FailFastJsonSchemaPayloadValidationPlugin
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.ExecutionContext
+
+trait PayloadValidationUtils {
+  protected def defaultConfig: ShapesConfiguration = ShapesConfiguration.predefined()
+
+  protected def parameterValidator(
+      s: Shape,
+      mediaType: String,
+      config: AMFGraphConfiguration = defaultConfig
+  ): AMFShapePayloadValidator =
+    config.elementClient().payloadValidatorFor(s, mediaType, ScalarRelaxedValidationMode)
+
+  protected def payloadValidator(
+      s: Shape,
+      mediaType: String,
+      config: AMFGraphConfiguration = defaultConfig
+  ): AMFShapePayloadValidator =
+    config.elementClient().payloadValidatorFor(s, mediaType, StrictValidationMode)
+
+  protected def validator(s: Shape,
+                          mediaType: String,
+                          plugin: AMFShapePayloadValidationPlugin) = defaultConfig.withPlugin(plugin).elementClient().payloadValidatorFor(s, mediaType, StrictValidationMode)
+}
+
+trait PayloadValidationTest extends AsyncFunSuite with NativeOps with Matchers with PayloadValidationUtils {
+
+  test("Test parameter validator int payload") {
+    val test = ScalarShape().withDataType(DataTypes.String).withName("test")
+
+    parameterValidator(test, `application/yaml`)
+      .validate("1234")
+      .map(r => assert(r.conforms))
+  }
+
+  test("Test parameter validator boolean payload") {
+    val test = ScalarShape().withDataType(DataTypes.String).withName("test")
+
+    parameterValidator(test, `application/yaml`)
+      .validate("true")
+      .map(r => assert(r.conforms))
+  }
+
+  test("Invalid trailing coma in json object payload") {
+    val s     = ScalarShape().withDataType(DataTypes.String)
+    val shape = NodeShape().withName("person")
+    shape.withProperty("someString").withRange(s)
+
+    val payload =
+      """
+          |{
+          |  "someString": "invalid string value",
+          |}
+        """.stripMargin
+
+    payloadValidator(shape, `application/json`)
+      .validate(payload)
+      .map(r => assert(!r.conforms))
+  }
+
+  test("Invalid trailing coma in json array payload") {
+
+    val s     = ScalarShape().withDataType(DataTypes.String)
+    val array = ArrayShape().withName("person")
+    array.withItems(s)
+
+    val payload =
+      """
+          |["trailing", "comma",]
+        """.stripMargin
+
+    payloadValidator(array, `application/json`)
+      .validate(payload)
+      .map(r => assert(!r.conforms))
+  }
+
+  test("Test sync validation") {
+    val test   = ScalarShape().withDataType(DataTypes.String).withName("test")
+    val report = parameterValidator(test, `application/yaml`).syncValidate("1234")
+    report.conforms shouldBe true
+  }
+
+  test("'null' doesn't conform as string") {
+    val payload   = "null"
+    val shape     = ScalarShape().withDataType(DataTypes.String)
+    val validator = payloadValidator(shape, `application/yaml`)
+    validator.validate(payload).map(r => r.conforms shouldBe false)
+  }
+
+  test("'null' conforms as null") {
+
+    val payload   = "null"
+    val shape     = ScalarShape().withDataType(DataTypes.Nil)
+    val validator = payloadValidator(shape, `application/yaml`)
+    validator.validate(payload).map(r => r.conforms shouldBe true)
+  }
+
+  test("Big number against scalar shape") {
+
+    val payload   = "22337203685477999090"
+    val shape     = ScalarShape().withDataType(DataTypes.Number)
+    val validator = payloadValidator(shape, `application/json`)
+    validator.validate(payload).map(r => r.conforms shouldBe true)
+  }
+
+  test("Very big number against scalar shape") {
+
+    val payload   = "22e20000"
+    val shape     = ScalarShape().withDataType(DataTypes.Number)
+    val validator = payloadValidator(shape, `application/json`)
+    validator.validate(payload).map(r => r.conforms shouldBe true)
+  }
+
+  test("Big number against node shape") {
+
+    val payload =
+      """
+          |{
+          | "in": 22337203685477999090
+          |}
+          |""".stripMargin
+    val properties = PropertyShape()
+      .withName("in")
+      .withRange(ScalarShape().withDataType(DataTypes.Number))
+    val shape = NodeShape()
+      .withProperties(Seq(properties))
+    val validator = payloadValidator(shape, `application/json`)
+
+    validator.validate(payload).map(r => r.conforms shouldBe true)
+  }
+
+  test("Invalid payload for json media type") {
+
+    val payload            = "Hello World"
+    val stringShape: Shape = ScalarShape().withDataType(DataTypes.String)
+    val shape = AnyShape()
+      .withId("someId")
+      .withOr(Seq(stringShape))
+    val validator = payloadValidator(shape, `application/json`)
+    validator.validate(payload).map(r => r.conforms shouldBe false)
+  }
+
+  test("Test control characters in the middle of a number") {
+
+    val test = ScalarShape().withDataType(DataTypes.Integer)
+
+    val report = payloadValidator(test, `application/json`).syncValidate("123\n1234")
+    report.conforms shouldBe false
+
+  }
+
+  test("Test that any payload conforms against an any type") {
+
+    val test = AnyShape()
+
+    val report = payloadValidator(test, `application/json`).syncValidate("any example")
+    report.conforms shouldBe true
+  }
+
+  test("Test that an invalid object payload is validated against an any type") {
+
+    val test = AnyShape()
+    val payload = """{
+                    |  "a": "something"
+                    |  "b": "other thing"
+                    |}""".stripMargin
+
+    val report = payloadValidator(test, `application/json`).syncValidate(payload)
+    report.conforms shouldBe false
+  }
+
+  test("Test that recursive shape has a payload validator") {
+
+    val innerShape     = ScalarShape().withDataType(DataTypes.Number)
+    val recursiveShape = RecursiveShape(innerShape)
+    val validator      = payloadValidator(recursiveShape, `application/json`)
+    validator.syncValidate("5").conforms shouldBe true
+    validator.syncValidate("true").conforms shouldBe false
+
+  }
+
+  test("Long type with int64 format is validated as long") {
+
+    val shape     = ScalarShape().withDataType(DataTypes.Long).withFormat("int64")
+    val validator = payloadValidator(shape, `application/json`)
+    validator.syncValidate("0.1").conforms shouldBe false
+  }
+
+  test("Json payload with trailing characters should throw error - Object test") {
+
+    val propertyA = PropertyShape()
+      .withName("a")
+      .withRange(ScalarShape().withDataType(DataTypes.String))
+    val propertyB = PropertyShape()
+      .withName("b")
+      .withRange(ScalarShape().withDataType(DataTypes.String))
+    val shape     = NodeShape().withProperties(Seq(propertyA, propertyB))
+    val validator = payloadValidator(shape, `application/json`)
+    validator
+      .syncValidate("""{"a": "aaaa", "b": "bbb"}asdfgh""")
+      .conforms shouldBe false
+  }
+
+  test("Json payload with trailing characters should throw error - Array test") {
+
+    val propertyA = PropertyShape()
+      .withName("a")
+      .withRange(ScalarShape().withDataType(DataTypes.String))
+    val propertyB = PropertyShape()
+      .withName("b")
+      .withRange(ScalarShape().withDataType(DataTypes.String))
+    val shape     = NodeShape().withProperties(Seq(propertyA, propertyB))
+    val validator = payloadValidator(shape, `application/json`)
+    validator
+      .syncValidate("""["a", "aaaa", "b", "bbb"]asdfgh""")
+      .conforms shouldBe false
+  }
+
+  test("Date-time can only have 4 digits") {
+
+    val shape     = ScalarShape().withDataType(DataTypes.DateTimeOnly)
+    val validator = payloadValidator(shape, `application/json`)
+    validator.syncValidate(""""22021-06-05T00:00:00"""").conforms shouldBe false
+    validator.syncValidate(""""2021-06-05T00:00:00"""").conforms shouldBe true
+  }
+  
+  override implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+}

--- a/amf-shapes/js/src/main/scala/amf/shapes/internal/document/apicontract/validation/remote/JsShapePayloadValidator.scala
+++ b/amf-shapes/js/src/main/scala/amf/shapes/internal/document/apicontract/validation/remote/JsShapePayloadValidator.scala
@@ -15,8 +15,9 @@ class JsShapePayloadValidator(
     private val shape: Shape,
     private val mediaType: String,
     protected val validationMode: ValidationMode,
-    private val configuration: ShapeValidationConfiguration
-) extends BaseJsonSchemaPayloadValidator(shape, mediaType, configuration) {
+    private val configuration: ShapeValidationConfiguration,
+    private val shouldFailFast: Boolean = false
+) extends BaseJsonSchemaPayloadValidator(shape, mediaType, configuration, shouldFailFast) {
 
   override type LoadedObj    = js.Dynamic
   override type LoadedSchema = Dictionary[js.Dynamic]
@@ -65,8 +66,7 @@ class JsShapePayloadValidator(
       validationProcessor: ValidationProcessor
   ): AMFValidationReport = {
 
-//    val validator = if (fast) LazyAjv.fast else LazyAjv.default
-    val validator = LazyAjv.default
+    val validator = if (shouldFailFast) LazyAjv.fast else LazyAjv.default
     try {
       val correct = validator.validate(schema.asInstanceOf[js.Object], obj)
 

--- a/amf-shapes/js/src/main/scala/amf/shapes/internal/document/apicontract/validation/remote/JsShapePayloadValidator.scala
+++ b/amf-shapes/js/src/main/scala/amf/shapes/internal/document/apicontract/validation/remote/JsShapePayloadValidator.scala
@@ -3,7 +3,7 @@ package amf.shapes.internal.document.apicontract.validation.remote
 import amf.core.client.common.validation.{ProfileName, SeverityLevels, ValidationMode}
 import amf.core.client.scala.model.document.PayloadFragment
 import amf.core.client.scala.model.domain.{DomainElement, Shape}
-import amf.core.client.scala.validation.AMFValidationResult
+import amf.core.client.scala.validation.{AMFValidationReport, AMFValidationResult}
 import amf.core.client.scala.validation.payload.ShapeValidationConfiguration
 import amf.shapes.internal.validation.definitions.ShapePayloadValidations.ExampleValidationErrorSpecification
 import amf.shapes.internal.validation.jsonschema._
@@ -49,7 +49,7 @@ class JsShapePayloadValidator(
       jsonSchema: CharSequence,
       element: DomainElement,
       validationProcessor: ValidationProcessor
-  ): Either[validationProcessor.Return, Option[Dictionary[js.Dynamic]]] = {
+  ): Either[AMFValidationReport, Option[Dictionary[js.Dynamic]]] = {
     var schemaNode = loadJson(jsonSchema.toString).asInstanceOf[Dictionary[js.Dynamic]]
     schemaNode -= "x-amf-fragmentType"
     schemaNode -= "example"
@@ -63,37 +63,38 @@ class JsShapePayloadValidator(
       obj: js.Dynamic,
       fragment: Option[PayloadFragment],
       validationProcessor: ValidationProcessor
-  ): validationProcessor.Return = {
+  ): AMFValidationReport = {
 
-    val fast      = validationProcessor.isInstanceOf[BooleanValidationProcessor.type]
-    val validator = if (fast) LazyAjv.fast else LazyAjv.default
-
+//    val validator = if (fast) LazyAjv.fast else LazyAjv.default
+    val validator = LazyAjv.default
     try {
       val correct = validator.validate(schema.asInstanceOf[js.Object], obj)
 
-      if (fast) correct.asInstanceOf[validationProcessor.Return]
-      else {
-        val results: Seq[AMFValidationResult] = if (!correct) {
+      val results: Seq[AMFValidationResult] =
+        if (correct) Nil
+        else {
           validator.errors.getOrElse(js.Array[ValidationResult]()).map { result =>
-            AMFValidationResult(
-              message = makeValidationMessage(result),
-              level = SeverityLevels.VIOLATION,
-              targetNode = fragment.map(_.encodes.id).getOrElse(""),
-              targetProperty = fragment.map(_.encodes.id),
-              validationId = ExampleValidationErrorSpecification.id,
-              position = fragment.flatMap(_.encodes.position()),
-              location = fragment.flatMap(_.encodes.location()),
-              source = result
-            )
+            asAmfResult(result, fragment)
           }
-        } else Nil
-
-        validationProcessor.processResults(results)
-      }
+        }
+      validationProcessor.processResults(results)
     } catch {
       case e: JavaScriptException =>
         validationProcessor.processException(e, fragment.map(_.encodes))
     }
+  }
+
+  private def asAmfResult(result: ValidationResult, fragment: Option[PayloadFragment]) = {
+    AMFValidationResult(
+      message = makeValidationMessage(result),
+      level = SeverityLevels.VIOLATION,
+      targetNode = fragment.map(_.encodes.id).getOrElse(""),
+      targetProperty = fragment.map(_.encodes.id),
+      validationId = ExampleValidationErrorSpecification.id,
+      position = fragment.flatMap(_.encodes.position()),
+      location = fragment.flatMap(_.encodes.location()),
+      source = result
+    )
   }
 
   private def makeValidationMessage(validationResult: ValidationResult): String = {
@@ -111,7 +112,7 @@ case class JsReportValidationProcessor(
 
   override def keepResults(r: Seq[AMFValidationResult]): Unit = intermediateResults ++= r
 
-  override def processException(r: Throwable, element: Option[DomainElement]): Return = {
+  override def processException(r: Throwable, element: Option[DomainElement]): AMFValidationReport = {
     val results = r match {
       case e: scala.scalajs.js.JavaScriptException =>
         Seq(

--- a/amf-shapes/js/src/main/scala/amf/shapes/internal/domain/apicontract/unsafe/JsonSchemaValidatorBuilder.scala
+++ b/amf-shapes/js/src/main/scala/amf/shapes/internal/domain/apicontract/unsafe/JsonSchemaValidatorBuilder.scala
@@ -16,4 +16,12 @@ object JsonSchemaValidatorBuilder {
       configuration: ShapeValidationConfiguration
   ): BaseJsonSchemaPayloadValidator =
     new JsShapePayloadValidator(shape, mediaType, validationMode, configuration)
+
+  def failFastValidator(
+      shape: Shape,
+      mediaType: String,
+      validationMode: ValidationMode,
+      configuration: ShapeValidationConfiguration
+  ): BaseJsonSchemaPayloadValidator =
+    new JsShapePayloadValidator(shape, mediaType, validationMode, configuration, true)
 }

--- a/amf-shapes/jvm/src/main/scala/amf/shapes/internal/document/apicontract/validation/remote/JvmShapePayloadValidator.scala
+++ b/amf-shapes/jvm/src/main/scala/amf/shapes/internal/document/apicontract/validation/remote/JvmShapePayloadValidator.scala
@@ -31,8 +31,9 @@ class JvmShapePayloadValidator(
     private val shape: Shape,
     private val mediaType: String,
     protected val validationMode: ValidationMode,
-    private val configuration: ShapeValidationConfiguration
-) extends BaseJsonSchemaPayloadValidator(shape, mediaType, configuration) {
+    private val configuration: ShapeValidationConfiguration,
+    private val shouldFailFast: Boolean = false
+) extends BaseJsonSchemaPayloadValidator(shape, mediaType, configuration, shouldFailFast) {
 
   private val DEFAULT_MAX_NESTING_LIMIT: Int = BaseLexer.DEFAULT_MAX_DEPTH
 
@@ -46,11 +47,9 @@ class JvmShapePayloadValidator(
       fragment: Option[PayloadFragment],
       validationProcessor: ValidationProcessor
   ): AMFValidationReport = {
-//    val validator = validationProcessor match {
-//      case BooleanValidationProcessor => Validator.builder().failEarly().build()
-//      case _ => Validator.builder().build()
-//    }
-    val validator = Validator.builder().build()
+
+    val base      = Validator.builder()
+    val validator = if (shouldFailFast) base.failEarly().build() else base.build()
 
     try {
       validator.performValidation(schema, payload)

--- a/amf-shapes/jvm/src/main/scala/amf/shapes/internal/document/apicontract/validation/remote/JvmShapePayloadValidator.scala
+++ b/amf-shapes/jvm/src/main/scala/amf/shapes/internal/document/apicontract/validation/remote/JvmShapePayloadValidator.scala
@@ -3,7 +3,7 @@ package amf.shapes.internal.document.apicontract.validation.remote
 import amf.core.client.common.validation.{ProfileName, SeverityLevels, ValidationMode}
 import amf.core.client.scala.model.document.PayloadFragment
 import amf.core.client.scala.model.domain.{DomainElement, Shape}
-import amf.core.client.scala.validation.AMFValidationResult
+import amf.core.client.scala.validation.{AMFValidationReport, AMFValidationResult}
 import amf.core.client.scala.validation.payload.ShapeValidationConfiguration
 import amf.core.internal.utils.RegexConverter
 import amf.shapes.client.scala.model.domain.ScalarShape
@@ -45,11 +45,12 @@ class JvmShapePayloadValidator(
       payload: LoadedObj,
       fragment: Option[PayloadFragment],
       validationProcessor: ValidationProcessor
-  ): validationProcessor.Return = {
-    val validator = validationProcessor match {
-      case BooleanValidationProcessor => Validator.builder().failEarly().build()
-      case _                          => Validator.builder().build()
-    }
+  ): AMFValidationReport = {
+//    val validator = validationProcessor match {
+//      case BooleanValidationProcessor => Validator.builder().failEarly().build()
+//      case _ => Validator.builder().build()
+//    }
+    val validator = Validator.builder().build()
 
     try {
       validator.performValidation(schema, payload)
@@ -66,7 +67,7 @@ class JvmShapePayloadValidator(
       jsonSchema: CharSequence,
       element: DomainElement,
       validationProcessor: ValidationProcessor
-  ): Either[validationProcessor.Return, Option[LoadedSchema]] = {
+  ): Either[AMFValidationReport, Option[LoadedSchema]] = {
 
     loadJsonSchema(jsonSchema.toString.replace("x-amf-union", "anyOf")) match {
       case schemaNode: JSONObject =>
@@ -158,7 +159,7 @@ case class JvmReportValidationProcessor(
 
   override def keepResults(r: Seq[AMFValidationResult]): Unit = intermediateResults ++= r
 
-  override def processException(r: Throwable, element: Option[DomainElement]): Return = {
+  override def processException(r: Throwable, element: Option[DomainElement]): AMFValidationReport = {
     val results = r match {
 
       case e: MaxNestingValueReached =>

--- a/amf-shapes/jvm/src/main/scala/amf/shapes/internal/domain/apicontract/unsafe/JsonSchemaValidatorBuilder.scala
+++ b/amf-shapes/jvm/src/main/scala/amf/shapes/internal/domain/apicontract/unsafe/JsonSchemaValidatorBuilder.scala
@@ -3,7 +3,6 @@ package amf.shapes.internal.domain.apicontract.unsafe
 import amf.core.client.common.validation.ValidationMode
 import amf.core.client.scala.model.domain.Shape
 import amf.core.client.scala.validation.payload.ShapeValidationConfiguration
-import amf.core.internal.validation.ValidationConfiguration
 import amf.shapes.internal.document.apicontract.validation.remote.JvmShapePayloadValidator
 import amf.shapes.internal.validation.jsonschema.BaseJsonSchemaPayloadValidator
 
@@ -16,4 +15,12 @@ object JsonSchemaValidatorBuilder {
       configuration: ShapeValidationConfiguration
   ): BaseJsonSchemaPayloadValidator =
     new JvmShapePayloadValidator(shape, mediaType, validationMode, configuration)
+
+  def failFastValidator(
+      shape: Shape,
+      mediaType: String,
+      validationMode: ValidationMode,
+      configuration: ShapeValidationConfiguration
+  ): BaseJsonSchemaPayloadValidator =
+    new JvmShapePayloadValidator(shape, mediaType, validationMode, configuration, true)
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/plugin/JsonSchemaShapePayloadValidationPlugin.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/plugin/JsonSchemaShapePayloadValidationPlugin.scala
@@ -12,23 +12,13 @@ import amf.core.internal.remote.Mimes._
 import amf.shapes.client.scala.model.domain.{AnyShape, SchemaShape}
 import amf.shapes.internal.domain.apicontract.unsafe.JsonSchemaValidatorBuilder
 
-object JsonSchemaShapePayloadValidationPlugin extends AMFShapePayloadValidationPlugin {
-
+trait JsonSchemaShapePayloadValidationPlugin extends AMFShapePayloadValidationPlugin {
   override val id: String                   = "AMF Payload Validation"
   private val payloadMediaType: Seq[String] = Seq(`application/json`, `application/yaml`, `text/vnd.yaml`)
 
   override def applies(element: ValidatePayloadRequest): Boolean = {
     val ValidatePayloadRequest(shape, mediaType, _) = element
     isAnyShape(shape) && supportsMediaType(mediaType)
-  }
-
-  override def validator(
-      shape: Shape,
-      mediaType: String,
-      config: ShapeValidationConfiguration,
-      validationMode: ValidationMode
-  ): AMFShapePayloadValidator = {
-    JsonSchemaValidatorBuilder.payloadValidator(shape, mediaType, validationMode, config)
   }
 
   private def isAnyShape(shape: Shape) = shape match {
@@ -38,4 +28,27 @@ object JsonSchemaShapePayloadValidationPlugin extends AMFShapePayloadValidationP
   }
 
   private def supportsMediaType(mediaType: String) = payloadMediaType.contains(mediaType)
+}
+object JsonSchemaShapePayloadValidationPlugin extends JsonSchemaShapePayloadValidationPlugin {
+
+  override def validator(
+      shape: Shape,
+      mediaType: String,
+      config: ShapeValidationConfiguration,
+      validationMode: ValidationMode
+  ): AMFShapePayloadValidator = {
+    JsonSchemaValidatorBuilder.payloadValidator(shape, mediaType, validationMode, config)
+  }
+}
+
+private[amf] object FailFastJsonSchemaPayloadValidationPlugin extends JsonSchemaShapePayloadValidationPlugin {
+
+  override def validator(
+      shape: Shape,
+      mediaType: String,
+      config: ShapeValidationConfiguration,
+      validationMode: ValidationMode
+  ): AMFShapePayloadValidator = {
+    JsonSchemaValidatorBuilder.failFastValidator(shape, mediaType, validationMode, config)
+  }
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/JsonLDSchemaNativeParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/JsonLDSchemaNativeParser.scala
@@ -10,7 +10,12 @@ import amf.shapes.client.scala.model.document.JsonLDInstanceDocument
 import amf.shapes.client.scala.model.domain.AnyShape
 import amf.shapes.client.scala.model.domain.jsonldinstance.{JsonLDArray, JsonLDObject}
 import amf.shapes.internal.spec.jsonldschema.parser.builder.JsonLDElementBuilder
-import amf.shapes.internal.spec.jsonldschema.parser.{JsonLDParserContext, JsonLDSchemaNodeParser, JsonPath}
+import amf.shapes.internal.spec.jsonldschema.parser.{
+  ConfigValidatorFactory,
+  JsonLDParserContext,
+  JsonLDSchemaNodeParser,
+  JsonPath
+}
 import amf.shapes.internal.spec.jsonldschema.validation.JsonLDSchemaValidations.IncompatibleDomainElement
 import org.yaml.model.YNode
 
@@ -40,7 +45,7 @@ class JsonLDSchemaNativeParser(eh: AMFErrorHandler) {
     }
 
     JsonLDSchemaNodeParser(shape, node, "encodes", JsonPath.empty, isRoot = true)(
-      new JsonLDParserContext(eh)
+      new JsonLDParserContext(eh, validatorFactory = ConfigValidatorFactory)
     ).parse()
   }
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/JsonLDBaseElementParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/JsonLDBaseElementParser.scala
@@ -44,11 +44,8 @@ abstract class JsonLDBaseElementParser[T <: JsonLDElementBuilder](node: YValue)(
     if (isValid(shape.ifShape, node)) Option(shape.thenShape) else Option(shape.elseShape)
 
   private def isValid(shape: Shape, node: YValue): Boolean = {
-    // TODO [Native-jsonld]: implement new validator, interface or configuration to invoke with boolean validator processor (fail early)
-    ShapesConfiguration
-      .predefined()
-      .elementClient()
-      .payloadValidatorFor(shape, Mimes.`application/json`, ValidationMode.ScalarRelaxedValidationMode)
+    ctx
+      .validator(shape)
       .syncValidate(ctx.yValueCache.get(node))
       .conforms
   }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/JsonLDParserContext.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/JsonLDParserContext.scala
@@ -1,23 +1,27 @@
 package amf.shapes.internal.spec.jsonldschema.parser
 
 import amf.core.client.scala.errorhandling.AMFErrorHandler
-import amf.core.client.scala.model.domain.AmfObject
+import amf.core.client.scala.model.domain.{AmfObject, Shape}
 import amf.core.client.scala.parse.document.ErrorHandlingContext
 import amf.core.internal.plugins.syntax.SyamlAMFErrorHandler
 import amf.core.internal.validation.core.ValidationSpecification
 import org.mulesoft.common.client.lexical.SourceLocation
-import org.yaml.model.{IllegalTypeHandler, ParseErrorHandler, SyamlException, YError, YValue}
+import org.yaml.model._
 import org.yaml.render.JsonRender
 
 import scala.collection.mutable
 
-class JsonLDParserContext(val eh: AMFErrorHandler, val yValueCache: RenderedYValues = RenderedYValues())
-    extends ErrorHandlingContext
+class JsonLDParserContext(
+    val eh: AMFErrorHandler,
+    val yValueCache: RenderedYValues = RenderedYValues(),
+    val validatorFactory: ValidatorFactory
+) extends ErrorHandlingContext
     with ParseErrorHandler
     with IllegalTypeHandler {
 
   // TODO native-jsonld: unify with shape context (extract to abstract?)
-  def syamleh = new SyamlAMFErrorHandler(eh)
+  def syamleh                 = new SyamlAMFErrorHandler(eh)
+  def validator(shape: Shape) = validatorFactory.failFastValidator(shape)
   override def violation(violationId: ValidationSpecification, node: String, message: String): Unit =
     eh.violation(violationId, node, message)
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/ValidatorFactory.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/jsonldschema/parser/ValidatorFactory.scala
@@ -1,0 +1,36 @@
+package amf.shapes.internal.spec.jsonldschema.parser
+
+import amf.core.client.common.validation.ScalarRelaxedValidationMode
+import amf.core.client.scala.model.domain.Shape
+import amf.core.client.scala.validation.payload.AMFShapePayloadValidator
+import amf.core.internal.remote.Mimes
+import amf.shapes.client.scala.ShapesConfiguration
+import amf.shapes.client.scala.plugin.FailFastJsonSchemaPayloadValidationPlugin
+
+trait ValidatorFactory {
+
+  def fullValidator(shape: Shape): AMFShapePayloadValidator
+  def failFastValidator(shape: Shape): AMFShapePayloadValidator
+}
+
+object ConfigValidatorFactory extends ValidatorFactory {
+
+  private val fullClient = ShapesConfiguration
+    .predefined()
+    .elementClient()
+
+  private val fastClient = ShapesConfiguration
+    .predefined()
+    .withPlugin(FailFastJsonSchemaPayloadValidationPlugin)
+    .elementClient()
+
+  private val mediaType = Mimes.`application/json`
+
+  private val mode: ScalarRelaxedValidationMode.type = ScalarRelaxedValidationMode
+
+  override def fullValidator(shape: Shape): AMFShapePayloadValidator =
+    fullClient.payloadValidatorFor(shape, mediaType, mode)
+
+  override def failFastValidator(shape: Shape): AMFShapePayloadValidator =
+    fastClient.payloadValidatorFor(shape, mediaType, mode)
+}

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/jsonschema/BaseJsonSchemaPayloadValidator.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/jsonschema/BaseJsonSchemaPayloadValidator.scala
@@ -1,6 +1,7 @@
 package amf.shapes.internal.validation.jsonschema
 
 import amf.core.client.common.render.JsonSchemaDraft7
+import amf.core.client.common.validation.ProfileNames.AMF
 import amf.core.client.common.validation._
 import amf.core.client.scala.config.{ParsingOptions, RenderOptions}
 import amf.core.client.scala.errorhandling.{AMFErrorHandler, UnhandledErrorHandler}
@@ -47,27 +48,25 @@ object BaseJsonSchemaPayloadValidator {
 abstract class BaseJsonSchemaPayloadValidator(
     shape: Shape,
     mediaType: String,
-    configuration: ShapeValidationConfiguration
+    configuration: ShapeValidationConfiguration,
+    shouldFailFast: Boolean
 ) extends AMFShapePayloadValidator {
 
   private val defaultSeverity: String = SeverityLevels.VIOLATION
   protected def getReportProcessor(profileName: ProfileName): ValidationProcessor
+  protected def getReportProcessor: ValidationProcessor     = getReportProcessor(AMF)
   protected implicit val executionContext: ExecutionContext = configuration.executionContext
 
   override def validate(payload: String): Future[AMFValidationReport] = {
-    Future.successful(
-      validateForPayload(payload, getReportProcessor(ProfileNames.AMF)).asInstanceOf[AMFValidationReport]
-    )
+    Future.successful(validateForPayload(payload, getReportProcessor))
   }
 
   override def validate(fragment: PayloadFragment): Future[AMFValidationReport] = {
-    Future.successful(
-      validateForFragment(fragment, getReportProcessor(ProfileNames.AMF)).asInstanceOf[AMFValidationReport]
-    )
+    Future.successful(validateForFragment(fragment, getReportProcessor))
   }
 
   override def syncValidate(payload: String): AMFValidationReport = {
-    validateForPayload(payload, getReportProcessor(ProfileNames.AMF)).asInstanceOf[AMFValidationReport]
+    validateForPayload(payload, getReportProcessor)
   }
 
   protected type LoadedObj

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/jsonschema/BaseJsonSchemaPayloadValidator.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/jsonschema/BaseJsonSchemaPayloadValidator.scala
@@ -87,7 +87,7 @@ abstract class BaseJsonSchemaPayloadValidator(
       obj: LoadedObj,
       fragment: Option[PayloadFragment],
       validationProcessor: ValidationProcessor
-  ): validationProcessor.Return
+  ): AMFValidationReport
 
   protected def loadDataNodeString(payload: PayloadFragment): Option[LoadedObj]
 
@@ -99,12 +99,12 @@ abstract class BaseJsonSchemaPayloadValidator(
       jsonSchema: CharSequence,
       element: DomainElement,
       validationProcessor: ValidationProcessor
-  ): Either[validationProcessor.Return, Option[LoadedSchema]]
+  ): Either[AMFValidationReport, Option[LoadedSchema]]
 
   protected def validateForFragment(
       fragment: PayloadFragment,
       validationProcessor: ValidationProcessor
-  ): ValidationProcessor#Return = {
+  ): AMFValidationReport = {
 
     try {
       performValidation(buildCandidate(fragment), validationProcessor)
@@ -119,7 +119,7 @@ abstract class BaseJsonSchemaPayloadValidator(
   protected def validateForPayload(
       payload: String,
       validationProcessor: ValidationProcessor
-  ): validationProcessor.Return = {
+  ): AMFValidationReport = {
     if (!supportedMediaTypes.contains(mediaType)) {
       validationProcessor.processResults(
         Seq(
@@ -151,7 +151,7 @@ abstract class BaseJsonSchemaPayloadValidator(
   private def generateSchema(
       fragmentShape: Shape,
       validationProcessor: ValidationProcessor
-  ): Either[validationProcessor.Return, Option[LoadedSchema]] = {
+  ): Either[AMFValidationReport, Option[LoadedSchema]] = {
 
     val schemaOption: Option[CharSequence] = generateSchemaString(fragmentShape, validationProcessor)
 
@@ -199,7 +199,7 @@ abstract class BaseJsonSchemaPayloadValidator(
   private def getOrCreateSchema(
       s: AnyShape,
       validationProcessor: ValidationProcessor
-  ): Either[validationProcessor.Return, Option[LoadedSchema]] = {
+  ): Either[AMFValidationReport, Option[LoadedSchema]] = {
     schemas.get(s.id) match {
       case Some(json) => Right(Some(json))
       case _ =>
@@ -304,7 +304,7 @@ abstract class BaseJsonSchemaPayloadValidator(
   private def performValidation(
       payload: (Option[LoadedObj], Option[PayloadParsingResult]),
       validationProcessor: ValidationProcessor
-  ): validationProcessor.Return = {
+  ): AMFValidationReport = {
     payload match {
       case (_, Some(result)) if result.hasError => validationProcessor.processResults(result.results)
       case (Some(obj), resultOption) =>

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/jsonschema/ValidationProcessor.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/jsonschema/ValidationProcessor.scala
@@ -6,25 +6,14 @@ import amf.core.client.scala.validation.{AMFValidationReport, AMFValidationResul
 import amf.shapes.internal.validation.definitions.ShapePayloadValidations.ExampleValidationErrorSpecification
 
 trait ValidationProcessor {
-  type Return
-  def processResults(r: Seq[AMFValidationResult]): Return
-  def processException(r: Throwable, element: Option[DomainElement]): Return
+  def processResults(r: Seq[AMFValidationResult]): AMFValidationReport
+  def processException(r: Throwable, element: Option[DomainElement]): AMFValidationReport
   def keepResults(r: Seq[AMFValidationResult]): Unit
-}
-
-object BooleanValidationProcessor extends ValidationProcessor {
-
-  override type Return = Boolean
-  override def processResults(r: Seq[AMFValidationResult]): Return =
-    !r.exists(_.severityLevel == SeverityLevels.VIOLATION)
-  override def processException(r: Throwable, element: Option[DomainElement]): Return = false
-  override def keepResults(r: Seq[AMFValidationResult]): Unit                         = Unit
 }
 
 trait ReportValidationProcessor extends ValidationProcessor {
   val profileName: ProfileName
   protected var intermediateResults: Seq[AMFValidationResult]
-  override type Return = AMFValidationReport
   override def processResults(r: Seq[AMFValidationResult]): AMFValidationReport = {
     val results = r ++ intermediateResults
     AMFValidationReport("http://test.com/payload#validations", profileName, results)


### PR DESCRIPTION
- W-11757246 0/3 (refactor): made payload validation tests use scala interfaces instead of platform
- W-11757246 1/3 (fix): removed dead code involving the BooleanValidationProcessor
- W-11757246 2/3 (feat): added FailFast Json schema validation plugin
- W-11757246 3/3 (feat): adopted fail fast validator in json-ld schema parser
