### PR TITLE
W-12438860: syntax recovery

### DIFF
--- a/amf-antlr-syntax/js/package-lock.json
+++ b/amf-antlr-syntax/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aml-org/amf-antlr-parsers": "0.6.21",
+        "@aml-org/amf-antlr-parsers": "0.6.22",
         "ajv": "6.12.6"
       }
     },
     "node_modules/@aml-org/amf-antlr-parsers": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.21.tgz",
-      "integrity": "sha512-QhVGMCeaLG0LqgTodJXflMl6gjr2ls0FeRBmUR5RQQWeT0YZWPE+kTRNGk810UbgvE1pnWKj7ERHyGxoMy/HXg=="
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
+      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@aml-org/amf-antlr-parsers": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.21.tgz",
-      "integrity": "sha512-QhVGMCeaLG0LqgTodJXflMl6gjr2ls0FeRBmUR5RQQWeT0YZWPE+kTRNGk810UbgvE1pnWKj7ERHyGxoMy/HXg=="
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
+      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/amf-antlr-syntax/js/package.json
+++ b/amf-antlr-syntax/js/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/aml-org/amf"
   },
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.21",
+    "@aml-org/amf-antlr-parsers": "0.6.22",
     "ajv": "6.12.6"
   }
 }

--- a/amf-api-contract/js/package-lock.json
+++ b/amf-api-contract/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aml-org/amf-antlr-parsers": "0.6.21",
+        "@aml-org/amf-antlr-parsers": "0.6.22",
         "ajv": "6.12.6"
       }
     },
     "node_modules/@aml-org/amf-antlr-parsers": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.21.tgz",
-      "integrity": "sha512-QhVGMCeaLG0LqgTodJXflMl6gjr2ls0FeRBmUR5RQQWeT0YZWPE+kTRNGk810UbgvE1pnWKj7ERHyGxoMy/HXg=="
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
+      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@aml-org/amf-antlr-parsers": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.21.tgz",
-      "integrity": "sha512-QhVGMCeaLG0LqgTodJXflMl6gjr2ls0FeRBmUR5RQQWeT0YZWPE+kTRNGk810UbgvE1pnWKj7ERHyGxoMy/HXg=="
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
+      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/amf-api-contract/js/package.json
+++ b/amf-api-contract/js/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/aml-org/amf"
   },
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.21",
+    "@aml-org/amf-antlr-parsers": "0.6.22",
     "ajv": "6.12.6"
   }
 }

--- a/amf-apicontract.versions
+++ b/amf-apicontract.versions
@@ -1,6 +1,6 @@
 amf.apicontract=5.3.0-SNAPSHOT
 amf.aml=6.3.0-SNAPSHOT
 amf.model=3.8.1
-antlr4Version=0.6.21
+antlr4Version=0.6.22
 amf.validation.profile.dialect=1.4.0-SNAPSHOT
 amf.validation.report.dialect=1.2.0-SNAPSHOT

--- a/amf-cli/js/package.json
+++ b/amf-cli/js/package.json
@@ -16,7 +16,7 @@
   "types": "./typings/amf-client-js.d.ts",
   "typings": "./typings/amf-client-js.d.ts",
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.21",
+    "@aml-org/amf-antlr-parsers": "0.6.22",
     "ajv": "6.12.6"
   }
 }

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-!-token.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-!-token.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name!: String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-!-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-!-token.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "extraneous-!-token.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-!-token.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-!-token.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-!-token.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-!-token.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '!'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,8)-(2,9)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-"-token.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-"-token.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name": String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-"-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-"-token.jsonld
@@ -1,0 +1,57 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "extraneous-%22-token.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-%22-token.graphql",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-"-token.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-"-token.report
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-"-token.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '": String\n}\n\ntype Person {\n    name: String\n}'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: 
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error: Unexpected end of file
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(7,1)-(7,1)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-&-token.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-&-token.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name&: String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-&-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-&-token.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "extraneous-&-token.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-&-token.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-&-token.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-&-token.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-&-token.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '&'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,8)-(2,9)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-*-token.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-*-token.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name*: String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-*-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-*-token.jsonld
@@ -1,0 +1,237 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "extraneous-*-token.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-*-token.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-*-token.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-*-token.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-*-token.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '*'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: 
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous---token.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous---token.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name-: String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous---token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous---token.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "extraneous---token.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous---token.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous---token.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous---token.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous---token.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '-:'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: 
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-:-token.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-:-token.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name:: String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-:-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-:-token.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "extraneous-:-token.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-:-token.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-:-token.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-:-token.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-:-token.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ':'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,9)-(2,10)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-;-token.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-;-token.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name;: String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-;-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-;-token.jsonld
@@ -1,0 +1,237 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "extraneous-;-token.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-;-token.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-;-token.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-;-token.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-;-token.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ';'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: 
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-@-token.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-@-token.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name@: String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-@-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-@-token.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "extraneous-@-token.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-@-token.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-@-token.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-@-token.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-@-token.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ':'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,9)-(2,10)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-tokens.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-tokens.graphql
@@ -1,0 +1,7 @@
+type Query {
+    !@$%^&*
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-tokens.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-tokens.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "extraneous-tokens.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-tokens.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-tokens.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-tokens.report
@@ -1,0 +1,38 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-tokens.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 4
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '%'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: 
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '*'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: 
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '^'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: 
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '!'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,4)-(2,5)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-|-token.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-|-token.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name|: String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-|-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-|-token.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "extraneous-%7C-token.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-%7C-token.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-|-token.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-|-token.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-|-token.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '|'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,8)-(2,9)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-colon.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-colon.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-colon.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-colon.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-colon.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-colon.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-colon.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-colon.report
@@ -1,0 +1,4 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-colon.graphql
+Profile: GraphQL
+Conforms: true
+Number of results: 0

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name:
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.jsonld
@@ -21,7 +21,103 @@
             "@value": "missing-field-type-0.graphql"
           }
         ],
-        "apiContract:endpoint": []
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/any/default-any",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ],
     "doc:root": [
@@ -47,8 +143,65 @@
         ]
       }
     ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
     "@context": {
       "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
       "doc": "http://a.ml/vocabularies/document#",
       "apiContract": "http://a.ml/vocabularies/apiContract#",
       "core": "http://a.ml/vocabularies/core#"

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.jsonld
@@ -1,0 +1,57 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-field-type-0.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.graphql",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.report
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '}'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(3,0)-(3,1)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error: Unexpected end of file
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(7,1)-(7,1)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.report
@@ -1,22 +1,14 @@
 ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.graphql
 Profile: GraphQL
 Conforms: false
-Number of results: 2
+Number of results: 1
 
 Level: Violation
 
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: '}'
+  Message: Field 'name' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(3,0)-(3,1)]
-  Location: 
-
-- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error: Unexpected end of file
-  Severity: Violation
-  Target: 
-  Property: 
-  Range: [(7,1)-(7,1)]
+  Range: [(2,4)-(2,8)]
   Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.graphql
@@ -1,0 +1,7 @@
+type Query {
+    name: *
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.jsonld
@@ -1,0 +1,57 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-field-type-1.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.graphql",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.jsonld
@@ -21,7 +21,103 @@
             "@value": "missing-field-type-1.graphql"
           }
         ],
-        "apiContract:endpoint": []
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/any/default-any",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ],
     "doc:root": [
@@ -47,8 +143,65 @@
         ]
       }
     ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
     "@context": {
       "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
       "doc": "http://a.ml/vocabularies/document#",
       "apiContract": "http://a.ml/vocabularies/apiContract#",
       "core": "http://a.ml/vocabularies/core#"

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.report
@@ -1,0 +1,30 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 3
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '*'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: 
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '}'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(3,0)-(3,1)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error: Unexpected end of file
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(7,1)-(7,1)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.report
@@ -1,7 +1,7 @@
 ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.graphql
 Profile: GraphQL
 Conforms: false
-Number of results: 3
+Number of results: 2
 
 Level: Violation
 
@@ -14,17 +14,9 @@ Level: Violation
   Location: 
 
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: '}'
+  Message: Field 'name' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(3,0)-(3,1)]
-  Location: 
-
-- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error: Unexpected end of file
-  Severity: Violation
-  Target: 
-  Property: 
-  Range: [(7,1)-(7,1)]
+  Range: [(2,4)-(2,8)]
   Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.graphql
@@ -1,0 +1,8 @@
+type Query {
+    name:
+    another: String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.jsonld
@@ -21,7 +21,225 @@
             "@value": "missing-field-type-2.graphql"
           }
         ],
-        "apiContract:endpoint": []
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/any/default-any",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fanother",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/another"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.another"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fanother/supportedOperation/query/Query.another",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.another"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fanother/supportedOperation/query/Query.another/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fanother/supportedOperation/query/Query.another/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fanother/supportedOperation/query/Query.another/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fanother/supportedOperation/query/Query.another/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fanother/supportedOperation/query/Query.another/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fanother/supportedOperation/query/Query.another/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.another"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ],
     "doc:root": [
@@ -104,8 +322,8 @@
     ],
     "@context": {
       "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.graphql",
-      "raml-shapes": "http://a.ml/vocabularies/shapes#",
       "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
       "doc": "http://a.ml/vocabularies/document#",
       "apiContract": "http://a.ml/vocabularies/apiContract#",
       "core": "http://a.ml/vocabularies/core#"

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-field-type-2.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.report
@@ -6,9 +6,9 @@ Number of results: 1
 Level: Violation
 
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: ':'
+  Message: Field 'name' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(3,11)-(3,12)]
+  Range: [(2,4)-(2,8)]
   Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ':'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(3,11)-(3,12)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.graphql
@@ -1,0 +1,8 @@
+type Query {
+    name: String
+}
+
+type Person {
+    name:
+    another: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.jsonld
@@ -180,6 +180,74 @@
           "raml-shapes:Shape",
           "doc:DomainElement"
         ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/any/default-any",
+                "@type": [
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          },
+          {
+            "@id": "#/declares/shape/Person/property/property/another",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/another/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "another"
+              }
+            ]
+          }
+        ],
         "shacl:name": [
           {
             "@value": "Person"

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.jsonld
@@ -1,0 +1,199 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-field-type-3.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.report
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#empty-definition
+  Message: Type definitions must have at least one field
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.graphql#/declares/shape/Person
+  Property: http://www.w3.org/ns/shacl#property
+  Range: [(5,0)-(5,11)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ':'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(7,11)-(7,12)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.report
@@ -1,22 +1,14 @@
 ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.graphql
 Profile: GraphQL
 Conforms: false
-Number of results: 2
+Number of results: 1
 
 Level: Violation
 
-- Constraint: http://a.ml/vocabularies/amf/parser#empty-definition
-  Message: Type definitions must have at least one field
-  Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.graphql#/declares/shape/Person
-  Property: http://www.w3.org/ns/shacl#property
-  Range: [(5,0)-(5,11)]
-  Location: 
-
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: ':'
+  Message: Field 'name' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(7,11)-(7,12)]
+  Range: [(6,4)-(6,8)]
   Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.graphql
@@ -1,0 +1,8 @@
+type Query {
+    name: String
+}
+
+type Person {
+    type:
+    another: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.jsonld
@@ -1,0 +1,199 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-field-type-4.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.jsonld
@@ -180,6 +180,74 @@
           "raml-shapes:Shape",
           "doc:DomainElement"
         ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/type",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/type/any/default-any",
+                "@type": [
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "type"
+              }
+            ]
+          },
+          {
+            "@id": "#/declares/shape/Person/property/property/another",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/another/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "another"
+              }
+            ]
+          }
+        ],
         "shacl:name": [
           {
             "@value": "Person"

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.report
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#empty-definition
+  Message: Type definitions must have at least one field
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.graphql#/declares/shape/Person
+  Property: http://www.w3.org/ns/shacl#property
+  Range: [(5,0)-(5,11)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ':'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(7,11)-(7,12)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.report
@@ -1,22 +1,14 @@
 ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.graphql
 Profile: GraphQL
 Conforms: false
-Number of results: 2
+Number of results: 1
 
 Level: Violation
 
-- Constraint: http://a.ml/vocabularies/amf/parser#empty-definition
-  Message: Type definitions must have at least one field
-  Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.graphql#/declares/shape/Person
-  Property: http://www.w3.org/ns/shacl#property
-  Range: [(5,0)-(5,11)]
-  Location: 
-
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: ':'
+  Message: Field 'type' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(7,11)-(7,12)]
+  Range: [(6,4)-(6,8)]
   Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.graphql
@@ -1,0 +1,8 @@
+type Query {
+    name: String
+}
+
+type Person {
+    type(param: String):
+    another: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.jsonld
@@ -1,0 +1,360 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-field-type-5.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/String",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/String/any/default-any",
+                "@type": [
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "String"
+              }
+            ]
+          }
+        ],
+        "raml-shapes:supportedOperation": [
+          {
+            "@id": "#/declares/shape/Person/supportedOperation/type",
+            "@type": [
+              "raml-shapes:Operation",
+              "core:Operation",
+              "doc:DomainElement"
+            ],
+            "core:name": [
+              {
+                "@value": "type"
+              }
+            ],
+            "raml-shapes:expects": [
+              {
+                "@id": "#/declares/shape/Person/supportedOperation/type/expects/request",
+                "@type": [
+                  "raml-shapes:Request",
+                  "core:Request",
+                  "doc:DomainElement"
+                ],
+                "raml-shapes:parameter": [
+                  {
+                    "@id": "#/declares/shape/Person/supportedOperation/type/expects/request/parameter/parameter/param",
+                    "@type": [
+                      "raml-shapes:Parameter",
+                      "core:Parameter",
+                      "doc:DomainElement"
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "param"
+                      }
+                    ],
+                    "raml-shapes:binding": [
+                      {
+                        "@value": "query"
+                      }
+                    ],
+                    "raml-shapes:required": [
+                      {
+                        "@value": false
+                      }
+                    ],
+                    "raml-shapes:schema": [
+                      {
+                        "@id": "#/declares/shape/Person/supportedOperation/type/expects/request/parameter/parameter/param/scalar/default-scalar",
+                        "@type": [
+                          "raml-shapes:ScalarShape",
+                          "raml-shapes:AnyShape",
+                          "shacl:Shape",
+                          "raml-shapes:Shape",
+                          "doc:DomainElement"
+                        ],
+                        "shacl:datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "raml-shapes:returns": [
+              {
+                "@id": "#/declares/shape/Person/supportedOperation/type/returns/response",
+                "@type": [
+                  "raml-shapes:Response",
+                  "core:Response",
+                  "doc:DomainElement"
+                ],
+                "core:name": [
+                  {
+                    "@value": "default"
+                  }
+                ],
+                "raml-shapes:payload": [
+                  {
+                    "@id": "#/declares/shape/Person/supportedOperation/type/returns/response/default",
+                    "@type": [
+                      "raml-shapes:Payload",
+                      "core:Payload",
+                      "doc:DomainElement"
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "raml-shapes:schema": [
+                      {
+                        "@id": "#/declares/shape/Person/supportedOperation/type/returns/response/default/union/default-union",
+                        "@type": [
+                          "raml-shapes:UnionShape",
+                          "raml-shapes:AnyShape",
+                          "shacl:Shape",
+                          "raml-shapes:Shape",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:anyOf": [
+                          {
+                            "@id": "#/declares/shape/Person/supportedOperation/type/returns/response/default/union/default-union/anyOf/nil/default-nil",
+                            "@type": [
+                              "raml-shapes:NilShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ]
+                          },
+                          {
+                            "@id": "#/declares/shape/Person/supportedOperation/type/returns/response/default/union/default-union/anyOf/unresolved",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.jsonld
@@ -182,7 +182,7 @@
         ],
         "shacl:property": [
           {
-            "@id": "#/declares/shape/Person/property/property/String",
+            "@id": "#/declares/shape/Person/property/property/another",
             "@type": [
               "shacl:PropertyShape",
               "shacl:Shape",
@@ -191,23 +191,29 @@
             ],
             "raml-shapes:range": [
               {
-                "@id": "#/declares/shape/Person/property/property/String/any/default-any",
+                "@id": "#/declares/shape/Person/property/property/another/scalar/default-scalar",
                 "@type": [
+                  "raml-shapes:ScalarShape",
                   "raml-shapes:AnyShape",
                   "shacl:Shape",
                   "raml-shapes:Shape",
                   "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
                 ]
               }
             ],
             "shacl:minCount": [
               {
-                "@value": 1
+                "@value": 0
               }
             ],
             "shacl:name": [
               {
-                "@value": "String"
+                "@value": "another"
               }
             ]
           }
@@ -305,33 +311,12 @@
                     ],
                     "raml-shapes:schema": [
                       {
-                        "@id": "#/declares/shape/Person/supportedOperation/type/returns/response/default/union/default-union",
+                        "@id": "#/declares/shape/Person/supportedOperation/type/returns/response/default/any/default-any",
                         "@type": [
-                          "raml-shapes:UnionShape",
                           "raml-shapes:AnyShape",
                           "shacl:Shape",
                           "raml-shapes:Shape",
                           "doc:DomainElement"
-                        ],
-                        "raml-shapes:anyOf": [
-                          {
-                            "@id": "#/declares/shape/Person/supportedOperation/type/returns/response/default/union/default-union/anyOf/nil/default-nil",
-                            "@type": [
-                              "raml-shapes:NilShape",
-                              "shacl:Shape",
-                              "raml-shapes:Shape",
-                              "doc:DomainElement"
-                            ]
-                          },
-                          {
-                            "@id": "#/declares/shape/Person/supportedOperation/type/returns/response/default/union/default-union/anyOf/unresolved",
-                            "@type": [
-                              "raml-shapes:AnyShape",
-                              "shacl:Shape",
-                              "raml-shapes:Shape",
-                              "doc:DomainElement"
-                            ]
-                          }
                         ]
                       }
                     ]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.report
@@ -1,0 +1,30 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 3
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/core#unresolved-reference
+  Message: Unresolved reference 'another'
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.graphql#/declares/shape/Person/supportedOperation/type/returns/response/default/union/default-union/anyOf/unresolved
+  Property: 
+  Range: [(7,4)-(7,11)]
+  Location: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.graphql
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ':'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(7,11)-(7,12)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '}'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(8,0)-(8,1)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.report
@@ -1,30 +1,14 @@
 ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.graphql
 Profile: GraphQL
 Conforms: false
-Number of results: 3
+Number of results: 1
 
 Level: Violation
 
-- Constraint: http://a.ml/vocabularies/amf/core#unresolved-reference
-  Message: Unresolved reference 'another'
-  Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.graphql#/declares/shape/Person/supportedOperation/type/returns/response/default/union/default-union/anyOf/unresolved
-  Property: 
-  Range: [(7,4)-(7,11)]
-  Location: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.graphql
-
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: ':'
+  Message: Field 'type' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(7,11)-(7,12)]
-  Location: 
-
-- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: '}'
-  Severity: Violation
-  Target: 
-  Property: 
-  Range: [(8,0)-(8,1)]
+  Range: [(6,4)-(6,8)]
   Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.graphql
@@ -1,0 +1,8 @@
+type Query {
+    type(param: String):
+    name: String
+}
+
+type Person {
+    another: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.jsonld
@@ -138,33 +138,12 @@
                         ],
                         "raml-shapes:schema": [
                           {
-                            "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default/payload/default/union/default-union",
+                            "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default/payload/default/any/default-any",
                             "@type": [
-                              "raml-shapes:UnionShape",
                               "raml-shapes:AnyShape",
                               "shacl:Shape",
                               "raml-shapes:Shape",
                               "doc:DomainElement"
-                            ],
-                            "raml-shapes:anyOf": [
-                              {
-                                "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
-                                "@type": [
-                                  "raml-shapes:NilShape",
-                                  "shacl:Shape",
-                                  "raml-shapes:Shape",
-                                  "doc:DomainElement"
-                                ]
-                              },
-                              {
-                                "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default/payload/default/union/default-union/anyOf/unresolved",
-                                "@type": [
-                                  "raml-shapes:AnyShape",
-                                  "shacl:Shape",
-                                  "raml-shapes:Shape",
-                                  "doc:DomainElement"
-                                ]
-                              }
                             ]
                           }
                         ]
@@ -181,24 +160,24 @@
             ]
           },
           {
-            "@id": "#/web-api/endpoint/%2Fquery%2FString",
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
             "@type": [
               "apiContract:EndPoint",
               "doc:DomainElement"
             ],
             "apiContract:path": [
               {
-                "@value": "/query/String"
+                "@value": "/query/name"
               }
             ],
             "core:name": [
               {
-                "@value": "Query.String"
+                "@value": "Query.name"
               }
             ],
             "apiContract:supportedOperation": [
               {
-                "@id": "#/web-api/endpoint/%2Fquery%2FString/supportedOperation/query/Query.String",
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
                 "@type": [
                   "apiContract:Operation",
                   "core:Operation",
@@ -211,12 +190,12 @@
                 ],
                 "core:name": [
                   {
-                    "@value": "Query.String"
+                    "@value": "Query.name"
                   }
                 ],
                 "apiContract:expects": [
                   {
-                    "@id": "#/web-api/endpoint/%2Fquery%2FString/supportedOperation/query/Query.String/expects/request",
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
                     "@type": [
                       "apiContract:Request",
                       "core:Request",
@@ -227,7 +206,7 @@
                 ],
                 "apiContract:returns": [
                   {
-                    "@id": "#/web-api/endpoint/%2Fquery%2FString/supportedOperation/query/Query.String/returns/resp/default",
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
                     "@type": [
                       "apiContract:Response",
                       "core:Response",
@@ -246,7 +225,7 @@
                     ],
                     "apiContract:payload": [
                       {
-                        "@id": "#/web-api/endpoint/%2Fquery%2FString/supportedOperation/query/Query.String/returns/resp/default/payload/default",
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
                         "@type": [
                           "apiContract:Payload",
                           "core:Payload",
@@ -254,12 +233,39 @@
                         ],
                         "raml-shapes:schema": [
                           {
-                            "@id": "#/web-api/endpoint/%2Fquery%2FString/supportedOperation/query/Query.String/returns/resp/default/payload/default/any/default-any",
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union",
                             "@type": [
+                              "raml-shapes:UnionShape",
                               "raml-shapes:AnyShape",
                               "shacl:Shape",
                               "raml-shapes:Shape",
                               "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
                             ]
                           }
                         ]
@@ -269,7 +275,7 @@
                 ],
                 "apiContract:operationId": [
                   {
-                    "@value": "Query.String"
+                    "@value": "Query.name"
                   }
                 ]
               }

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.jsonld
@@ -1,0 +1,368 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-field-type-6.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Ftype",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/type"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.type"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.type"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:parameter": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/expects/request/parameter/parameter/query/param",
+                        "@type": [
+                          "apiContract:Parameter",
+                          "core:Parameter",
+                          "doc:DomainElement"
+                        ],
+                        "core:name": [
+                          {
+                            "@value": "param"
+                          }
+                        ],
+                        "apiContract:required": [
+                          {
+                            "@value": false
+                          }
+                        ],
+                        "apiContract:binding": [
+                          {
+                            "@value": "query"
+                          }
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/expects/request/parameter/parameter/query/param/scalar/default-scalar",
+                            "@type": [
+                              "raml-shapes:ScalarShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "shacl:datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#string"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default/payload/default/union/default-union/anyOf/unresolved",
+                                "@type": [
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.type"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2FString",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/String"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.String"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2FString/supportedOperation/query/Query.String",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.String"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2FString/supportedOperation/query/Query.String/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2FString/supportedOperation/query/Query.String/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2FString/supportedOperation/query/Query.String/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2FString/supportedOperation/query/Query.String/returns/resp/default/payload/default/any/default-any",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.String"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/another",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/another/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "another"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.report
@@ -1,30 +1,14 @@
 ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.graphql
 Profile: GraphQL
 Conforms: false
-Number of results: 3
+Number of results: 1
 
 Level: Violation
 
-- Constraint: http://a.ml/vocabularies/amf/core#unresolved-reference
-  Message: Unresolved reference 'name'
-  Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.graphql#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default/payload/default/union/default-union/anyOf/unresolved
-  Property: 
-  Range: [(3,4)-(3,8)]
-  Location: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.graphql
-
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: ':'
+  Message: Field 'type' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(3,8)-(3,9)]
-  Location: 
-
-- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: '}'
-  Severity: Violation
-  Target: 
-  Property: 
-  Range: [(4,0)-(4,1)]
+  Range: [(2,4)-(2,8)]
   Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.report
@@ -1,0 +1,30 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 3
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/core#unresolved-reference
+  Message: Unresolved reference 'name'
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.graphql#/web-api/endpoint/%2Fquery%2Ftype/supportedOperation/query/Query.type/returns/resp/default/payload/default/union/default-union/anyOf/unresolved
+  Property: 
+  Range: [(3,4)-(3,8)]
+  Location: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.graphql
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ':'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(3,8)-(3,9)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '}'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(4,0)-(4,1)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.graphql
@@ -1,0 +1,9 @@
+type Query {
+    name1:
+    name2:
+    name3:
+}
+
+type Person {
+    another: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.jsonld
@@ -21,7 +21,293 @@
             "@value": "missing-field-type-7.graphql"
           }
         ],
-        "apiContract:endpoint": []
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname1",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name1"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name1"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname1/supportedOperation/query/Query.name1",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name1"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname1/supportedOperation/query/Query.name1/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname1/supportedOperation/query/Query.name1/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname1/supportedOperation/query/Query.name1/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname1/supportedOperation/query/Query.name1/returns/resp/default/payload/default/any/default-any",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name1"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname2",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name2"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name2"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname2/supportedOperation/query/Query.name2",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name2"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname2/supportedOperation/query/Query.name2/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname2/supportedOperation/query/Query.name2/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname2/supportedOperation/query/Query.name2/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname2/supportedOperation/query/Query.name2/returns/resp/default/payload/default/any/default-any",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name2"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname3",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name3"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name3"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname3/supportedOperation/query/Query.name3",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name3"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname3/supportedOperation/query/Query.name3/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname3/supportedOperation/query/Query.name3/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname3/supportedOperation/query/Query.name3/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname3/supportedOperation/query/Query.name3/returns/resp/default/payload/default/any/default-any",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name3"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ],
     "doc:root": [
@@ -47,8 +333,65 @@
         ]
       }
     ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/another",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/another/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "another"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
     "@context": {
       "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
       "doc": "http://a.ml/vocabularies/document#",
       "apiContract": "http://a.ml/vocabularies/apiContract#",
       "core": "http://a.ml/vocabularies/core#"

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.jsonld
@@ -1,0 +1,57 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-field-type-7.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.graphql",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.report
@@ -1,0 +1,30 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 3
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ':'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(3,9)-(3,10)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '}'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(5,0)-(5,1)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error: Unexpected end of file
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(9,1)-(9,1)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.report
@@ -6,25 +6,25 @@ Number of results: 3
 Level: Violation
 
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: ':'
+  Message: Field 'name1' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(3,9)-(3,10)]
+  Range: [(2,4)-(2,9)]
   Location: 
 
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: '}'
+  Message: Field 'name2' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(5,0)-(5,1)]
+  Range: [(3,4)-(3,9)]
   Location: 
 
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error: Unexpected end of file
+  Message: Field 'name3' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(9,1)-(9,1)]
+  Range: [(4,4)-(4,9)]
   Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.graphql
@@ -1,0 +1,9 @@
+type Query {
+    name: String
+}
+
+type Person {
+    name1:
+    name2:
+    name3:
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.jsonld
@@ -180,6 +180,98 @@
           "raml-shapes:Shape",
           "doc:DomainElement"
         ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name1",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name1/any/default-any",
+                "@type": [
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name1"
+              }
+            ]
+          },
+          {
+            "@id": "#/declares/shape/Person/property/property/name2",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name2/any/default-any",
+                "@type": [
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name2"
+              }
+            ]
+          },
+          {
+            "@id": "#/declares/shape/Person/property/property/name3",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name3/any/default-any",
+                "@type": [
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name3"
+              }
+            ]
+          }
+        ],
         "shacl:name": [
           {
             "@value": "Person"

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.jsonld
@@ -1,0 +1,199 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-field-type-8.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.report
@@ -1,0 +1,30 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 3
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#empty-definition
+  Message: Type definitions must have at least one field
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.graphql#/declares/shape/Person
+  Property: http://www.w3.org/ns/shacl#property
+  Range: [(5,0)-(5,11)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ':'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(7,9)-(7,10)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '}'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(9,0)-(9,1)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.report
@@ -5,26 +5,26 @@ Number of results: 3
 
 Level: Violation
 
-- Constraint: http://a.ml/vocabularies/amf/parser#empty-definition
-  Message: Type definitions must have at least one field
-  Severity: Violation
-  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.graphql#/declares/shape/Person
-  Property: http://www.w3.org/ns/shacl#property
-  Range: [(5,0)-(5,11)]
-  Location: 
-
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: ':'
+  Message: Field 'name1' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(7,9)-(7,10)]
+  Range: [(6,4)-(6,9)]
   Location: 
 
 - Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
-  Message: Syntax error in the following text: '}'
+  Message: Field 'name2' missing field type
   Severity: Violation
   Target: 
   Property: 
-  Range: [(9,0)-(9,1)]
+  Range: [(7,4)-(7,9)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Field 'name3' missing field type
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(8,4)-(8,9)]
   Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket-and-lparen.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket-and-lparen.graphql
@@ -1,0 +1,7 @@
+type Query
+    namea: String): String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket-and-lparen.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket-and-lparen.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-lbracket-and-lparen.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket-and-lparen.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket-and-lparen.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket-and-lparen.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket-and-lparen.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: 'namea'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,4)-(2,9)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket.graphql
@@ -1,0 +1,7 @@
+type Query
+    name: String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-lbracket.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: 'name'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,4)-(2,8)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket-and-rparen.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket-and-rparen.graphql
@@ -1,0 +1,6 @@
+type Query {
+    name(a: String: String
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket-and-rparen.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket-and-rparen.jsonld
@@ -1,0 +1,57 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-rbracket-and-rparen.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket-and-rparen.graphql",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket-and-rparen.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket-and-rparen.report
@@ -1,0 +1,38 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket-and-rparen.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 4
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ':'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,18)-(2,19)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: 'type'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(4,0)-(4,4)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '{'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(4,12)-(4,13)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error: Unexpected end of file
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(6,1)-(6,1)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket.graphql
@@ -1,0 +1,6 @@
+type Query {
+    name: String
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket.jsonld
@@ -1,0 +1,57 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-rbracket.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket.graphql",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error: Unexpected end of file
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(6,1)-(6,1)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rparen.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rparen.graphql
@@ -1,0 +1,7 @@
+type Query {
+    namea: String): String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rparen.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rparen.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-rparen.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rparen.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rparen.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rparen.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rparen.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ')'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,17)-(2,18)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-slbracket.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-slbracket.graphql
@@ -1,0 +1,7 @@
+type Query {
+    names: String]
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-slbracket.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-slbracket.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-slbracket.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-slbracket.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-slbracket.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-slbracket.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-slbracket.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: ']'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(2,17)-(2,18)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-srbracket.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-srbracket.graphql
@@ -1,0 +1,7 @@
+type Query {
+    names: [String
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-srbracket.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-srbracket.jsonld
@@ -1,0 +1,270 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-srbracket.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fnames",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/names"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.names"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fnames/supportedOperation/query/Query.names",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.names"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fnames/supportedOperation/query/Query.names/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fnames/supportedOperation/query/Query.names/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fnames/supportedOperation/query/Query.names/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fnames/supportedOperation/query/Query.names/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fnames/supportedOperation/query/Query.names/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fnames/supportedOperation/query/Query.names/returns/resp/default/payload/default/union/default-union/anyOf/array/default-array",
+                                "@type": [
+                                  "raml-shapes:ArrayShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "raml-shapes:items": [
+                                  {
+                                    "@id": "#/web-api/endpoint/%2Fquery%2Fnames/supportedOperation/query/Query.names/returns/resp/default/payload/default/union/default-union/anyOf/array/default-array/union/default-union",
+                                    "@type": [
+                                      "raml-shapes:UnionShape",
+                                      "raml-shapes:AnyShape",
+                                      "shacl:Shape",
+                                      "raml-shapes:Shape",
+                                      "doc:DomainElement"
+                                    ],
+                                    "raml-shapes:anyOf": [
+                                      {
+                                        "@id": "#/web-api/endpoint/%2Fquery%2Fnames/supportedOperation/query/Query.names/returns/resp/default/payload/default/union/default-union/anyOf/array/default-array/union/default-union/anyOf/nil/default-nil",
+                                        "@type": [
+                                          "raml-shapes:NilShape",
+                                          "shacl:Shape",
+                                          "raml-shapes:Shape",
+                                          "doc:DomainElement"
+                                        ]
+                                      },
+                                      {
+                                        "@id": "#/web-api/endpoint/%2Fquery%2Fnames/supportedOperation/query/Query.names/returns/resp/default/payload/default/union/default-union/anyOf/array/default-array/union/default-union/anyOf/scalar/default-scalar",
+                                        "@type": [
+                                          "raml-shapes:ScalarShape",
+                                          "raml-shapes:AnyShape",
+                                          "shacl:Shape",
+                                          "raml-shapes:Shape",
+                                          "doc:DomainElement"
+                                        ],
+                                        "shacl:datatype": [
+                                          {
+                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.names"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-srbracket.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-srbracket.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-srbracket.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-srbracket.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '}'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(3,0)-(3,1)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.graphql
@@ -1,0 +1,21 @@
+type Query {
+    name: String
+}
+
+union UnionType = AType | BType |
+
+type AType {
+    a: String
+}
+
+type BType {
+    b: String
+}
+
+type CType {
+    c: String
+}
+
+type DType {
+    D: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.jsonld
@@ -1,0 +1,394 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-union-member-remixed.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/BType",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/BType/property/property/b",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/BType/property/property/b/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "b"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "BType"
+          }
+        ]
+      },
+      {
+        "@id": "#/declares/shape/CType",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/CType/property/property/c",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/CType/property/property/c/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "c"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "CType"
+          }
+        ]
+      },
+      {
+        "@id": "#/declares/shape/DType",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/DType/property/property/D",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/DType/property/property/D/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "D"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "DType"
+          }
+        ]
+      },
+      {
+        "@id": "#/declares/union/UnionType",
+        "@type": [
+          "raml-shapes:UnionShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "raml-shapes:anyOf": [
+          {
+            "@id": "#/declares/union/UnionType/anyOf/unresolved",
+            "@type": [
+              "raml-shapes:AnyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ]
+          },
+          {
+            "@id": "#/declares/union/UnionType/anyOf/shape/BType",
+            "@type": [
+              "shacl:NodeShape",
+              "raml-shapes:AnyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "doc:link-target": [
+              {
+                "@id": "#/declares/shape/BType"
+              }
+            ],
+            "doc:link-label": [
+              {
+                "@value": "BType"
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "BType"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "UnionType"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.report
@@ -1,0 +1,30 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 3
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/core#unresolved-reference
+  Message: Unresolved reference 'AType'
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.graphql#/declares/union/UnionType/anyOf/unresolved
+  Property: 
+  Range: [(5,18)-(5,23)]
+  Location: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.graphql
+
+- Constraint: http://a.ml/vocabularies/amf/parser#invalid-ast
+  Message: Missing union member
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(7,0)-(7,4)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: 'AType'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(7,5)-(7,10)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member.graphql
@@ -1,0 +1,21 @@
+type Query {
+    name: String
+}
+
+type AType {
+    a: String
+}
+
+type BType {
+    b: String
+}
+
+type CType {
+    c: String
+}
+
+union UnionType = AType | BType |
+
+type DType {
+    D: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member.jsonld
@@ -1,0 +1,410 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "missing-union-member.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/AType",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/AType/property/property/a",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/AType/property/property/a/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "a"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "AType"
+          }
+        ]
+      },
+      {
+        "@id": "#/declares/shape/BType",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/BType/property/property/b",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/BType/property/property/b/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "b"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "BType"
+          }
+        ]
+      },
+      {
+        "@id": "#/declares/shape/CType",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/CType/property/property/c",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/CType/property/property/c/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "c"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "CType"
+          }
+        ]
+      },
+      {
+        "@id": "#/declares/union/UnionType",
+        "@type": [
+          "raml-shapes:UnionShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "raml-shapes:anyOf": [
+          {
+            "@id": "#/declares/union/UnionType/anyOf/shape/AType",
+            "@type": [
+              "shacl:NodeShape",
+              "raml-shapes:AnyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "doc:link-target": [
+              {
+                "@id": "#/declares/shape/AType"
+              }
+            ],
+            "doc:link-label": [
+              {
+                "@value": "AType"
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "AType"
+              }
+            ]
+          },
+          {
+            "@id": "#/declares/union/UnionType/anyOf/shape/BType",
+            "@type": [
+              "shacl:NodeShape",
+              "raml-shapes:AnyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "doc:link-target": [
+              {
+                "@id": "#/declares/shape/BType"
+              }
+            ],
+            "doc:link-label": [
+              {
+                "@value": "BType"
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "BType"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "UnionType"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member.report
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#invalid-ast
+  Message: Missing union member
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(19,0)-(19,4)]
+  Location: 
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: 'DType'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(19,5)-(19,10)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/misspelling-type.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/misspelling-type.graphql
@@ -1,0 +1,11 @@
+type Query {
+    name: String
+}
+
+typee Person {
+    name: String
+}
+
+type Dog {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/misspelling-type.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/misspelling-type.jsonld
@@ -1,0 +1,237 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "misspelling-type.graphql"
+          }
+        ],
+        "apiContract:endpoint": [
+          {
+            "@id": "#/web-api/endpoint/%2Fquery%2Fname",
+            "@type": [
+              "apiContract:EndPoint",
+              "doc:DomainElement"
+            ],
+            "apiContract:path": [
+              {
+                "@value": "/query/name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "Query.name"
+              }
+            ],
+            "apiContract:supportedOperation": [
+              {
+                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name",
+                "@type": [
+                  "apiContract:Operation",
+                  "core:Operation",
+                  "doc:DomainElement"
+                ],
+                "apiContract:method": [
+                  {
+                    "@value": "query"
+                  }
+                ],
+                "core:name": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ],
+                "apiContract:expects": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/expects/request",
+                    "@type": [
+                      "apiContract:Request",
+                      "core:Request",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ]
+                  }
+                ],
+                "apiContract:returns": [
+                  {
+                    "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default",
+                    "@type": [
+                      "apiContract:Response",
+                      "core:Response",
+                      "apiContract:Message",
+                      "doc:DomainElement"
+                    ],
+                    "apiContract:statusCode": [
+                      {
+                        "@value": "200"
+                      }
+                    ],
+                    "core:name": [
+                      {
+                        "@value": "default"
+                      }
+                    ],
+                    "apiContract:payload": [
+                      {
+                        "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default",
+                        "@type": [
+                          "apiContract:Payload",
+                          "core:Payload",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:schema": [
+                          {
+                            "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union",
+                            "@type": [
+                              "raml-shapes:UnionShape",
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "raml-shapes:anyOf": [
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/nil/default-nil",
+                                "@type": [
+                                  "raml-shapes:NilShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ]
+                              },
+                              {
+                                "@id": "#/web-api/endpoint/%2Fquery%2Fname/supportedOperation/query/Query.name/returns/resp/default/payload/default/union/default-union/anyOf/scalar/default-scalar",
+                                "@type": [
+                                  "raml-shapes:ScalarShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "apiContract:operationId": [
+                  {
+                    "@value": "Query.name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Dog",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Dog/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Dog/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Dog"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/misspelling-type.graphql",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/misspelling-type.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/misspelling-type.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/misspelling-type.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: 'typee'
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(5,0)-(5,5)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/replace-{-with-[.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/replace-{-with-[.graphql
@@ -1,0 +1,7 @@
+type Query [
+    name: String
+]
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/replace-{-with-[.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/replace-{-with-[.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "replace-%7B-with-%5B.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/replace-%7B-with-%5B.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/replace-{-with-[.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/replace-{-with-[.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/replace-{-with-[.graphql
+Profile: GraphQL
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#antlr-error
+  Message: Syntax error in the following text: '['
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(1,11)-(1,12)]
+  Location: 

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/scalar-inside-type.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/scalar-inside-type.graphql
@@ -1,0 +1,8 @@
+type Query {
+    name: String
+    scalar Another
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/scalar-inside-type.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/scalar-inside-type.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "scalar-inside-type.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/scalar-inside-type.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/scalar-inside-type.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/scalar-inside-type.report
@@ -1,0 +1,4 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/scalar-inside-type.graphql
+Profile: GraphQL
+Conforms: true
+Number of results: 0

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/type-inside-type.graphql
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/type-inside-type.graphql
@@ -1,0 +1,10 @@
+type Query {
+    name: String
+    type Another {
+        name: String
+    }
+}
+
+type Person {
+    name: String
+}

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/type-inside-type.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/type-inside-type.jsonld
@@ -1,0 +1,114 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#/web-api",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "type-inside-type.graphql"
+          }
+        ],
+        "apiContract:endpoint": []
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.1"
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "GraphQL"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declares/shape/Person",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declares/shape/Person/property/property/name",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#/declares/shape/Person/property/property/name/scalar/default-scalar",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ]
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 0
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "name"
+              }
+            ]
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Person"
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/type-inside-type.graphql",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/type-inside-type.report
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/type-inside-type.report
@@ -1,0 +1,4 @@
+ModelId: file://amf-cli/shared/src/test/resources/graphql/syntax-recovery/type-inside-type.graphql
+Profile: GraphQL
+Conforms: true
+Number of results: 0

--- a/amf-cli/shared/src/test/resources/validations/reports/graphql/sudden-eof.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/graphql/sudden-eof.report
@@ -10,11 +10,11 @@ Level: Violation
   Severity: Violation
   Target: 
   Property: 
-  Range: [(6,4)-(6,38)]
+  Range: [(6,4)-(5,18)]
   Location: 
 
 - Constraint: http://a.ml/vocabularies/amf/parser#invalid-ast
-  Message: Unknown input type syntax
+  Message: Missing name for root type field
   Severity: Violation
   Target: 
   Property: 

--- a/amf-cli/shared/src/test/scala/amf/parser/GraphQLSyntaxRecoveryTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/parser/GraphQLSyntaxRecoveryTest.scala
@@ -1,0 +1,45 @@
+package amf.parser
+
+import amf.core.client.scala.config.RenderOptions
+import amf.core.internal.remote.Mimes.`application/ld+json`
+import amf.graphql.client.scala.GraphQLConfiguration
+
+import scala.concurrent.Future
+
+class GraphQLSyntaxRecoveryTest extends GraphQLValidationTest {
+  override def basePath: String = "amf-cli/shared/src/test/resources/graphql/syntax-recovery"
+
+  fs.syncFile(basePath)
+    .list
+    .groupBy(apiName)
+    .values
+    .collect {
+      case toValidate if toValidate.length > 1 =>
+        apiName(toValidate.head) // contains the API and it's report, thus should be validated
+    }
+    .foreach { api =>
+      test(s"GraphQL TCK > Apis > Invalid > $api: should not conform") {
+        for {
+          _         <- dumpJsonLDFor(api)
+          assertion <- assertReport(s"$basePath/$api.graphql")
+        } yield {
+          assertion
+        }
+      }
+    }
+
+  private def apiName(api: String): String = api.split('.').dropRight(1).mkString(".")
+
+  def dumpJsonLDFor(api: String): Future[Unit] = {
+    val ro = RenderOptions().withPrettyPrint.withCompactUris.withoutFlattenedJsonLd
+    val client = GraphQLConfiguration.GraphQL().withRenderOptions(ro).baseUnitClient()
+    for {
+      parsing <- client.parse(s"file://$basePath/$api.graphql")
+      content <- Future.successful(client.render(parsing.baseUnit, `application/ld+json`))
+      _       <- fs.asyncFile(s"$basePath/$api.jsonld").write(content)
+    } yield {
+      Unit
+    }
+
+  }
+}

--- a/amf-cli/shared/src/test/scala/amf/parser/GraphQLTCKValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/parser/GraphQLTCKValidationTest.scala
@@ -1,15 +1,6 @@
 package amf.parser
 
-import amf.core.client.common.transform.PipelineId
-import amf.core.client.common.validation.GraphQLProfile
-import amf.core.client.scala.validation.AMFValidationReport
-import amf.cycle.GraphQLFunSuiteCycleTests
-import amf.graphql.client.scala.GraphQLConfiguration
-import org.scalatest.Assertion
-
-import scala.concurrent.Future
-
-class GraphQLTCKValidationTest extends GraphQLFunSuiteCycleTests {
+class GraphQLTCKValidationTest extends GraphQLValidationTest {
   override def basePath: String = "amf-cli/shared/src/test/resources/graphql/tck/apis"
 
   // Test valid APIs
@@ -40,36 +31,6 @@ class GraphQLTCKValidationTest extends GraphQLFunSuiteCycleTests {
   // Test valid singular API. Only used to debug a Singular test, this is run as part of the TCK
   ignore("interface-chain-covariant") {
     assertConforms(s"$basePath/valid/interface-chain-covariant.graphql")
-  }
-
-  def assertConforms(api: String): Future[Assertion] = {
-    val client = GraphQLConfiguration.GraphQL().baseUnitClient()
-    for {
-      parsing        <- client.parse(s"file://$api")
-      transformation <- Future.successful(client.transform(parsing.baseUnit, PipelineId.Cache))
-      validation     <- client.validate(transformation.baseUnit)
-    } yield {
-      assert(parsing.conforms && transformation.conforms && validation.conforms)
-    }
-  }
-
-  def assertReport(api: String): Future[Assertion] = {
-    val client = GraphQLConfiguration.GraphQL().baseUnitClient()
-    val apiUri = s"file://$api"
-    val report = api.replace(".graphql", ".report")
-    for {
-      parsing        <- client.parse(apiUri)
-      transformation <- Future.successful(client.transform(parsing.baseUnit, PipelineId.Cache))
-      validation     <- client.validate(transformation.baseUnit)
-      actualFile <- {
-        val combinedResults = parsing.results ++ transformation.results ++ validation.results
-        val actual          = AMFValidationReport(apiUri, GraphQLProfile, combinedResults)
-        writeTemporaryFile(report)(actual.toString)
-      }
-      assertion <- assertDifferences(actualFile, report)
-    } yield {
-      assertion
-    }
   }
 
   private def apiName(api: String): String = api.split('.').dropRight(1).mkString(".")

--- a/amf-cli/shared/src/test/scala/amf/parser/GraphQLValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/parser/GraphQLValidationTest.scala
@@ -1,0 +1,45 @@
+package amf.parser
+
+import amf.core.client.common.transform.PipelineId
+import amf.core.client.common.validation.GraphQLProfile
+import amf.core.client.scala.validation.AMFValidationReport
+import amf.cycle.GraphQLFunSuiteCycleTests
+import amf.graphql.client.scala.GraphQLConfiguration
+import org.scalatest.Assertion
+
+import scala.concurrent.Future
+
+trait GraphQLValidationTest extends GraphQLFunSuiteCycleTests {
+
+
+  def assertConforms(api: String): Future[Assertion] = {
+    val client = GraphQLConfiguration.GraphQL().baseUnitClient()
+    for {
+      parsing        <- client.parse(s"file://$api")
+      transformation <- Future.successful(client.transform(parsing.baseUnit, PipelineId.Cache))
+      validation     <- client.validate(transformation.baseUnit)
+    } yield {
+      assert(parsing.conforms && transformation.conforms && validation.conforms)
+    }
+  }
+
+  def assertReport(api: String): Future[Assertion] = {
+    val client = GraphQLConfiguration.GraphQL().baseUnitClient()
+    val apiUri = s"file://$api"
+    val report = api.replace(".graphql", ".report")
+    for {
+      parsing        <- client.parse(apiUri)
+      transformation <- Future.successful(client.transform(parsing.baseUnit, PipelineId.Cache))
+      validation     <- client.validate(transformation.baseUnit)
+      actualFile <- {
+        val combinedResults = parsing.results ++ transformation.results ++ validation.results
+        val actual          = AMFValidationReport(apiUri, GraphQLProfile, combinedResults)
+        writeTemporaryFile(report)(actual.toString)
+      }
+      assertion <- assertDifferences(actualFile, report)
+    } yield {
+      assertion
+    }
+  }
+
+}

--- a/amf-graphql/js/package-lock.json
+++ b/amf-graphql/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aml-org/amf-antlr-parsers": "0.6.21",
+        "@aml-org/amf-antlr-parsers": "0.6.22",
         "ajv": "6.12.6"
       }
     },
     "node_modules/@aml-org/amf-antlr-parsers": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.21.tgz",
-      "integrity": "sha512-QhVGMCeaLG0LqgTodJXflMl6gjr2ls0FeRBmUR5RQQWeT0YZWPE+kTRNGk810UbgvE1pnWKj7ERHyGxoMy/HXg=="
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
+      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@aml-org/amf-antlr-parsers": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.21.tgz",
-      "integrity": "sha512-QhVGMCeaLG0LqgTodJXflMl6gjr2ls0FeRBmUR5RQQWeT0YZWPE+kTRNGk810UbgvE1pnWKj7ERHyGxoMy/HXg=="
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
+      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/amf-graphql/js/package.json
+++ b/amf-graphql/js/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/aml-org/amf"
   },
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.21",
+    "@aml-org/amf-antlr-parsers": "0.6.22",
     "ajv": "6.12.6"
   }
 }

--- a/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/parser/syntax/GraphQLASTParserHelper.scala
+++ b/amf-graphql/shared/src/main/scala/amf/graphql/internal/spec/parser/syntax/GraphQLASTParserHelper.scala
@@ -104,10 +104,7 @@ trait GraphQLASTParserHelper extends AntlrASTParserHelper {
           }
         }
         shape
-      case _ =>
-        astError("Unknown input type syntax", toAnnotations(n))
-        val shape = AnyShape(toAnnotations(n))
-        shape
+      case _ => AnyShape(toAnnotations(n))
     }
   }
 

--- a/amf-grpc/js/package-lock.json
+++ b/amf-grpc/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aml-org/amf-antlr-parsers": "0.6.21",
+        "@aml-org/amf-antlr-parsers": "0.6.22",
         "ajv": "6.12.6"
       }
     },
     "node_modules/@aml-org/amf-antlr-parsers": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.21.tgz",
-      "integrity": "sha512-QhVGMCeaLG0LqgTodJXflMl6gjr2ls0FeRBmUR5RQQWeT0YZWPE+kTRNGk810UbgvE1pnWKj7ERHyGxoMy/HXg=="
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
+      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@aml-org/amf-antlr-parsers": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.21.tgz",
-      "integrity": "sha512-QhVGMCeaLG0LqgTodJXflMl6gjr2ls0FeRBmUR5RQQWeT0YZWPE+kTRNGk810UbgvE1pnWKj7ERHyGxoMy/HXg=="
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
+      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/amf-grpc/js/package.json
+++ b/amf-grpc/js/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/aml-org/amf"
   },
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.21",
+    "@aml-org/amf-antlr-parsers": "0.6.22",
     "ajv": "6.12.6"
   }
 }

--- a/amf-shapes/js/package-lock.json
+++ b/amf-shapes/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aml-org/amf-antlr-parsers": "0.6.21",
+        "@aml-org/amf-antlr-parsers": "0.6.22",
         "ajv": "6.12.6"
       }
     },
     "node_modules/@aml-org/amf-antlr-parsers": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.21.tgz",
-      "integrity": "sha512-QhVGMCeaLG0LqgTodJXflMl6gjr2ls0FeRBmUR5RQQWeT0YZWPE+kTRNGk810UbgvE1pnWKj7ERHyGxoMy/HXg=="
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
+      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@aml-org/amf-antlr-parsers": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.21.tgz",
-      "integrity": "sha512-QhVGMCeaLG0LqgTodJXflMl6gjr2ls0FeRBmUR5RQQWeT0YZWPE+kTRNGk810UbgvE1pnWKj7ERHyGxoMy/HXg=="
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
+      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/amf-shapes/js/package.json
+++ b/amf-shapes/js/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/aml-org/amf"
   },
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.21",
+    "@aml-org/amf-antlr-parsers": "0.6.22",
     "ajv": "6.12.6"
   }
 }


### PR DESCRIPTION
- Added GraphQL syntax recovery TCK
- Adopt amf-antlr-ast@0.6.22
- Adopt syntax errors from relaxed fieldDefinition rule in grammar
- [Accepted trade-off] with last commit's adoption this report became less clear
