### PR TITLE
W-12521486: fixed wrong type expression parsing

### DIFF
--- a/amf-cli/shared/src/test/resources/validations/raml/empty-array-in-union-type-expression.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/empty-array-in-union-type-expression.raml
@@ -1,0 +1,9 @@
+#%RAML 1.0
+title: Something
+version: 1.0
+
+/test:
+  post:
+    body:
+      multipart/form-data:
+        type: file[] | []

--- a/amf-cli/shared/src/test/resources/validations/raml/standalone-array-as-type.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/standalone-array-as-type.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: Something
+version: 1.0
+
+/test:
+  post:
+    body:
+      multipart/form-data:
+        type: []
+
+types:
+  EmptyArray: []

--- a/amf-cli/shared/src/test/resources/validations/reports/model/raml/empty-array-in-union-type-expression.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/model/raml/empty-array-in-union-type-expression.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/validations/raml/empty-array-in-union-type-expression.raml
+Profile: 
+Conforms: false
+Number of results: 1
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#invalid-type-expression
+  Message: Syntax error, generating empty array
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(9,23)-(9,24)]
+  Location: file://amf-cli/shared/src/test/resources/validations/raml/empty-array-in-union-type-expression.raml

--- a/amf-cli/shared/src/test/resources/validations/reports/model/raml/standalone-array-as-type.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/model/raml/standalone-array-as-type.report
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/validations/raml/standalone-array-as-type.raml
+Profile: 
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#empty-type-expression-array
+  Message: [] is not a valid type
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(9,14)-(9,16)]
+  Location: file://amf-cli/shared/src/test/resources/validations/raml/standalone-array-as-type.raml
+
+- Constraint: http://a.ml/vocabularies/amf/parser#empty-type-expression-array
+  Message: [] is not a valid type
+  Severity: Violation
+  Target: 
+  Property: 
+  Range: [(12,14)-(12,16)]
+  Location: file://amf-cli/shared/src/test/resources/validations/raml/standalone-array-as-type.raml

--- a/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -719,4 +719,8 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
       Some("raml/empty-array-in-union-type-expression.report")
     )
   }
+
+  test("Standalone array as type") {
+    validate("/raml/standalone-array-as-type.raml", Some("raml/standalone-array-as-type.report"))
+  }
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -712,4 +712,11 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
   test("nested JSON Schema reference by id in draft 4") {
     validate("/raml/nested-json-schema-ref/api.raml", Some("raml/nested-json-schema-ref.report"))
   }
+
+  test("empty array expression in union should be invalid") {
+    validate(
+      "/raml/empty-array-in-union-type-expression.raml",
+      Some("raml/empty-array-in-union-type-expression.report")
+    )
+  }
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/RamlTypeDetector.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/RamlTypeDetector.scala
@@ -123,7 +123,7 @@ case class RamlTypeDetector(
 
   private def parseAndMatchTypeExpression(node: YNode, text: String) = {
     RamlExpressionParser
-      .check(shape => shape.withId("/"), text)
+      .check(shape => shape.withId("/"), text, node)
       .flatMap(s => ShapeClassTypeDefMatcher(s, node, recursive))
       .map {
         case TypeDef.UnionType | TypeDef.ArrayType if !recursive => TypeExpressionType

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/expression/AbstractParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/expression/AbstractParser.scala
@@ -9,29 +9,31 @@ private[expression] trait AbstractParser {
     previous()
   }
 
-  protected def check(token: String) = {
+  protected def expect(token: String) = {
     if (isAtEnd) false
-    else peek().token == token
+    else peek().exists(_.token == token)
   }
 
-  protected def peek() = tokens(current)
+  protected def peek() = tokens.lift(current)
 
   protected def previous(): Token = tokens(current - 1)
 
+  protected def expectPrevious(token: String) = tokens.lift(current - 2).exists(_.token == token)
+
   protected def consume(token: String) = {
-    if (check(token)) Some(advance())
+    if (expect(token)) Some(advance())
     else None
   }
 
   protected def consumeToEnd(): Seq[Token] = {
-    val rest = tokens.splitAt(current)._2
+    val (_, rest) = tokens.splitAt(current)
     current = tokens.size
     rest
   }
 
   protected def consumeUntil(token: String): Seq[Token] = {
     var accumulated = Seq[Token]()
-    while (!check(token) && !isAtEnd) {
+    while (!expect(token) && !isAtEnd) {
       accumulated = accumulated :+ advance()
     }
     accumulated

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/expression/AnnotationHelper.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/expression/AnnotationHelper.scala
@@ -20,9 +20,9 @@ private[expression] trait AnnotationHelper {
   }
 
   protected def setShapeAnnotation(shapeToAnnotate: Shape, leftShape: Shape, rightShape: Shape): Shape = {
-    val leftLexical     = leftShape.annotations.find(classOf[LexicalInformation]).get
-    val rightLexical    = rightShape.annotations.find(classOf[LexicalInformation]).get
-    val nextAnnotations = annotations.copy() += LexicalInformation(leftLexical.range.start, rightLexical.range.`end`)
+    val leftLexical     = leftShape.annotations.lexical()
+    val rightLexical    = rightShape.annotations.lexical()
+    val nextAnnotations = annotations.copy() += LexicalInformation(leftLexical.start, rightLexical.`end`)
     shapeToAnnotate.annotations ++= nextAnnotations
     shapeToAnnotate
   }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/expression/RamlExpressionASTBuilder.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/expression/RamlExpressionASTBuilder.scala
@@ -55,7 +55,7 @@ private[expression] class RamlExpressionASTBuilder(
         union
       case Some(previousShape) =>
         val tokens        = consumeToEnd()
-        val optionalShape = parse(tokens, previous)
+        val optionalShape = parse(tokens)
         optionalShape match {
           case Some(shape) =>
             val nextAnyOf = calculateAnyOf(previousShape, shape)
@@ -65,6 +65,8 @@ private[expression] class RamlExpressionASTBuilder(
         }
     }
   }
+
+  private def parse(tokens: Seq[Token]): Option[Shape] = parse(tokens, None)
 
   private def parse(tokens: Seq[Token], previous: Option[Shape]): Option[Shape] = {
     new RamlExpressionASTBuilder(tokens, declarationFinder, annotations, unresolvedRegister).build(previous)

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/expression/RamlExpressionParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/expression/RamlExpressionParser.scala
@@ -1,5 +1,6 @@
 package amf.shapes.internal.spec.raml.parser.expression
 
+import amf.core.client.scala.errorhandling.IgnoringErrorHandler
 import amf.core.client.scala.model.domain.Shape
 import amf.core.internal.annotations.{LexicalInformation, SourceAST, SourceNode}
 import amf.core.internal.parser.domain.Annotations

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/definitions/ShapeParserSideValidations.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/definitions/ShapeParserSideValidations.scala
@@ -387,6 +387,11 @@ object ShapeParserSideValidations extends Validations {
     "The definition key present in the ref is not the correct for the JSON Schema"
   )
 
+  val EmptyTypeExpressionArray = validation(
+    "empty-type-expression-array",
+    "Empty type expression array"
+  )
+
   override val levels: Map[String, Map[ProfileName, String]] = Map(
     InvalidShapeFormat.id            -> all(WARNING),
     JsonSchemaInheritanceWarning.id  -> all(WARNING),
@@ -442,6 +447,7 @@ object ShapeParserSideValidations extends Validations {
     JsonSchemaDefinitionNotFound,
     InvalidJsonSchemaReference,
     MultipleDefinitionKey,
-    IncorrectDefinitionKey
+    IncorrectDefinitionKey,
+    EmptyTypeExpressionArray
   )
 }


### PR DESCRIPTION
- (refactor): prepare for fix and exploratory refactoring
- W-12521486: fix case where an empty array is defined at the right side of an union
- (fix): added error when an empty array is used as a type
