### PR TITLE
W-11680259: avoid throwing remote context error in canParse method

### DIFF
--- a/amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-json-schema/api.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-json-schema/api.raml
@@ -1,0 +1,9 @@
+#%RAML 1.0
+title: API body demo
+version: v1
+baseUri: http://api.domain.com/
+
+types:
+  JsonSchema:
+    type: !include person.json
+    example: !include person-example.json

--- a/amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-json-schema/person-example.json
+++ b/amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-json-schema/person-example.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "@context": "nowhere.json",
+  "name": "John Smith",
+  "birthday": "1990-10-12",
+  "gender": "male",
+  "url": "https://www.domain.com/people/Qawer63J73HJ6khjswuqyq62382jG21s",
+  "image": {
+    "url": "https://www.domain.com/people/Qawer63J73HJ6khjswuqyq62382jG21s/image",
+    "thumb": "https://www.domain.com/people/Qawer63J73HJ6khjswuqyq62382jG21s/image/thumb"
+  },
+  "tagline": "Hi, I'm John!",
+  "language": "en_US"
+}

--- a/amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-json-schema/person.json
+++ b/amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-json-schema/person.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "birthday": {
+      "type": "string"
+    },
+    "gender": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "thumb": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "url",
+        "thumb"
+      ]
+    },
+    "tagline": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "birthday",
+    "gender",
+    "url",
+    "image",
+    "tagline",
+    "language"
+  ]
+}

--- a/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -723,4 +723,9 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
   test("Standalone array as type") {
     validate("/raml/standalone-array-as-type.raml", Some("raml/standalone-array-as-type.report"))
   }
+
+  // W-11680259
+  test("a json example with @context that points to nowhere should not throw an error") {
+    validate("/raml/raml-with-json-schema/api.raml")
+  }
 }


### PR DESCRIPTION
tests for Core PR https://github.com/aml-org/amf-core/pull/581