### PR TITLE
W-11802973: add warning when using a JSON Schema in type expressions

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/model/APIRawValidations.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/model/APIRawValidations.scala
@@ -540,6 +540,13 @@ object APIRawValidations extends CommonValidationDefinitions {
         owlClass = security("SecurityScheme"),
         owlProperty = doc("-"),
         constraint = shape("exclusiveQueryStringAndQueryParametersProperties")
+      ),
+      AMFValidation(
+        uri = amfParser("inheritance-from-json-schema"),
+        owlClass = shape("AnyShape"),
+        owlProperty = doc("-"),
+        constraint = shape("inheritanceFromJsonSchema"),
+        severity = SeverityLevels.WARNING
       )
     )
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/shacl/graphql/GraphQLValidator.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/shacl/graphql/GraphQLValidator.scala
@@ -3,15 +3,14 @@ package amf.apicontract.internal.validation.shacl.graphql
 import amf.apicontract.internal.validation.shacl.graphql.values.ValueValidator
 import amf.core.client.scala.model.domain.extensions.PropertyShape
 import amf.core.client.scala.model.domain._
-import amf.core.internal.metamodel.Field
-import amf.core.internal.metamodel.domain.{DomainElementModel, ScalarNodeModel}
+import amf.core.internal.metamodel.domain.DomainElementModel
 import amf.core.internal.metamodel.domain.extensions.{DomainExtensionModel, PropertyShapePathModel}
-import amf.core.internal.parser.domain.Annotations
 import amf.shapes.client.scala.model.domain._
 import amf.shapes.client.scala.model.domain.federation.Key
 import amf.shapes.internal.domain.metamodel.NodeShapeModel
 import amf.shapes.internal.domain.metamodel.operations.AbstractParameterModel
 import amf.validation.internal.shacl.custom.CustomShaclValidator.ValidationInfo
+import amf.validation.internal.shacl.custom.CustomShaclValidator.ValidationInfo.validationInfo
 
 import scala.annotation.tailrec
 
@@ -310,9 +309,5 @@ object GraphQLValidator {
     case u: UnionShape   => GraphQLNullable(u).name
     case arr: ArrayShape => s"[${getShapeName(arr.items)}]"
     case s               => s.name.value()
-  }
-
-  private def validationInfo(field: Field, message: String, annotations: Annotations): Some[ValidationInfo] = {
-    Some(ValidationInfo(field, Some(message), Some(annotations)))
   }
 }

--- a/amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-types/api.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-types/api.raml
@@ -1,0 +1,37 @@
+#%RAML 1.0
+
+title: Pets API
+version: 1.0
+
+types:
+  MyJsonType: |
+    {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "string",
+        "minLength": 1
+    }
+
+  MyRamlType:
+    type: integer
+    minimum: 100
+
+  JsonRamlUnionType: MyJsonType | MyRamlType # Should not be valid
+
+  JsonArrayType1: MyJsonType[] # Should not be valid
+
+  JsonArrayType2:
+    type: array
+    items: MyJsonType # Should not be valid
+
+  JsonInheritedType:
+    type: MyJsonType
+    maxLength: 100 # Should not be valid
+
+
+/test:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: JsonInheritedType

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/json_schema_inheritance.report.js
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/json_schema_inheritance.report.js
@@ -1,7 +1,7 @@
 ModelId: file://amf-cli/shared/src/test/resources/validations/production/json_schema_inheritance/api.raml
 Profile: RAML 1.0
 Conforms: true
-Number of results: 3
+Number of results: 4
 
 Level: Warning
 
@@ -11,6 +11,14 @@ Level: Warning
   Target: 
   Property: http://a.ml/vocabularies/shapes#inherits
   Range: [(11,0)-(16,0)]
+  Location: file://amf-cli/shared/src/test/resources/validations/production/json_schema_inheritance/api.raml
+
+- Constraint: http://a.ml/vocabularies/amf/parser#inheritance-from-json-schema
+  Message: JSON Schemas can't be used in type expressions or type inheritance
+  Severity: Warning
+  Target: file://amf-cli/shared/src/test/resources/validations/production/json_schema_inheritance/api.raml#/declares/array/PersonArray
+  Property: http://a.ml/vocabularies/shapes#items
+  Range: [(16,2)-(21,0)]
   Location: file://amf-cli/shared/src/test/resources/validations/production/json_schema_inheritance/api.raml
 
 - Constraint: http://a.ml/vocabularies/amf/parser#json-schema-inheritance

--- a/amf-cli/shared/src/test/resources/validations/reports/examples/json_schema_inheritance.report.jvm
+++ b/amf-cli/shared/src/test/resources/validations/reports/examples/json_schema_inheritance.report.jvm
@@ -1,7 +1,7 @@
 ModelId: file://amf-cli/shared/src/test/resources/validations/production/json_schema_inheritance/api.raml
 Profile: RAML 1.0
 Conforms: true
-Number of results: 3
+Number of results: 4
 
 Level: Warning
 
@@ -11,6 +11,14 @@ Level: Warning
   Target: 
   Property: http://a.ml/vocabularies/shapes#inherits
   Range: [(11,0)-(16,0)]
+  Location: file://amf-cli/shared/src/test/resources/validations/production/json_schema_inheritance/api.raml
+
+- Constraint: http://a.ml/vocabularies/amf/parser#inheritance-from-json-schema
+  Message: JSON Schemas can't be used in type expressions or type inheritance
+  Severity: Warning
+  Target: file://amf-cli/shared/src/test/resources/validations/production/json_schema_inheritance/api.raml#/declares/array/PersonArray
+  Property: http://a.ml/vocabularies/shapes#items
+  Range: [(16,2)-(21,0)]
   Location: file://amf-cli/shared/src/test/resources/validations/production/json_schema_inheritance/api.raml
 
 - Constraint: http://a.ml/vocabularies/amf/parser#json-schema-inheritance

--- a/amf-cli/shared/src/test/resources/validations/reports/model/raml/json-schema-inheritance.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/model/raml/json-schema-inheritance.report
@@ -1,0 +1,30 @@
+ModelId: file://amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-types/api.raml
+Profile: RAML 1.0
+Conforms: true
+Number of results: 3
+
+Level: Warning
+
+- Constraint: http://a.ml/vocabularies/amf/parser#inheritance-from-json-schema
+  Message: MyJsonType is a JSON Schema and can't be used in type expressions or type inheritance
+  Severity: Warning
+  Target: file://amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-types/api.raml#/declares/union/JsonRamlUnionType
+  Property: http://a.ml/vocabularies/shapes#anyOf
+  Range: [(18,2)-(20,0)]
+  Location: file://amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-types/api.raml
+
+- Constraint: http://a.ml/vocabularies/amf/parser#inheritance-from-json-schema
+  Message: JSON Schemas can't be used in type expressions or type inheritance
+  Severity: Warning
+  Target: file://amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-types/api.raml#/declares/array/JsonArrayType1
+  Property: http://a.ml/vocabularies/shapes#items
+  Range: [(20,2)-(22,0)]
+  Location: file://amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-types/api.raml
+
+- Constraint: http://a.ml/vocabularies/amf/parser#inheritance-from-json-schema
+  Message: JSON Schemas can't be used in type expressions or type inheritance
+  Severity: Warning
+  Target: file://amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-types/api.raml#/declares/array/JsonArrayType2
+  Property: http://a.ml/vocabularies/shapes#items
+  Range: [(22,2)-(26,0)]
+  Location: file://amf-cli/shared/src/test/resources/validations/raml/raml-with-invalid-types/api.raml

--- a/amf-cli/shared/src/test/scala/amf/testing/BaseUnitUtils.scala
+++ b/amf-cli/shared/src/test/scala/amf/testing/BaseUnitUtils.scala
@@ -4,6 +4,8 @@ import amf.apicontract.client.scala.model.domain.api.{Api, AsyncApi, WebApi}
 import amf.apicontract.client.scala.model.domain._
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.{DomainElement, Shape}
+import amf.core.internal.annotations.SourceYPart
+import amf.shapes.client.scala.model.document.JsonSchemaDocument
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
@@ -40,5 +42,13 @@ object BaseUnitUtils {
 
   def await[R](eventualResult: Future[R]): R = {
     Await.result(eventualResult, Duration.Inf)
+  }
+
+  def sourcePartOf(unit: BaseUnit, extract: JsonSchemaDocument => Shape): String = {
+    val doc             = unit.asInstanceOf[JsonSchemaDocument]
+    val shapeOfInterest = extract(doc)
+    val sourceYPart     = shapeOfInterest.annotations.find(_.isInstanceOf[SourceYPart]).get.asInstanceOf[SourceYPart]
+    val obtainedAst     = sourceYPart.ast.toString
+    obtainedAst
   }
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
@@ -8,11 +8,9 @@ import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.extensions.PropertyShape
 import amf.core.client.scala.model.domain.{AmfArray, Annotation, ExternalSourceElement, Shape}
-import amf.core.internal.annotations.{DeclaredElement, Inferred, SourceYPart, VirtualElement, VirtualNode}
+import amf.core.internal.annotations.{DeclaredElement, Inferred, VirtualElement, VirtualNode}
 import amf.core.internal.parser.domain.Annotations
 import amf.graphql.client.scala.GraphQLConfiguration
-import amf.shapes.client.scala.config.JsonSchemaConfiguration
-import amf.shapes.client.scala.model.document.JsonSchemaDocument
 import amf.shapes.client.scala.model.domain._
 import amf.shapes.internal.annotations.{BaseVirtualNode, TargetName}
 import amf.shapes.internal.domain.metamodel.AnyShapeModel
@@ -43,9 +41,9 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   def modelAssertion(
       path: String,
       pipelineId: String = PipelineId.Default,
-      transform: Boolean = true,
-      client: AMFBaseUnitClient = APIConfiguration.APIWithJsonSchema().baseUnitClient()
+      transform: Boolean = true
   )(assertion: BaseUnit => Assertion): Future[Assertion] = {
+    val client = APIConfiguration.APIWithJsonSchema().baseUnitClient()
     client.parse(path) flatMap { parseResult =>
       if (!transform) assertion(parseResult.baseUnit)
       else {
@@ -480,13 +478,5 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
       val expectedAst         = """{"properties": {}}"""
       obtainedAst.trim shouldEqual expectedAst.trim
     }
-  }
-
-  private def sourcePartOf(unit: BaseUnit, extract: JsonSchemaDocument => Shape) = {
-    val doc             = unit.asInstanceOf[JsonSchemaDocument]
-    val shapeOfInterest = extract(doc)
-    val sourceYPart     = shapeOfInterest.annotations.find(_.isInstanceOf[SourceYPart]).get.asInstanceOf[SourceYPart]
-    val obtainedAst     = sourceYPart.ast.toString
-    obtainedAst
   }
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/JsonSchemaExampleValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/JsonSchemaExampleValidationTest.scala
@@ -1,8 +1,5 @@
 package amf.validation
 
-import amf.core.client.common.validation.Raml08Profile
-import amf.core.internal.remote.{Hint, Raml08YamlHint, Raml10YamlHint}
-
 class JsonSchemaExampleValidationTest extends MultiPlatformReportGenTest {
   override val basePath = "file://amf-cli/shared/src/test/resources/validations/jsonschema/"
 
@@ -137,6 +134,7 @@ class JsonSchemaExampleValidationTest extends MultiPlatformReportGenTest {
   test("JSON Schema path with spaces 1") {
     validate("/json-schema-space/api.raml")
   }
+
   test("JSON Schema path with spaces 2") {
     validate("/json-schema-space other/api.raml")
   }

--- a/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -728,4 +728,9 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
   test("a json example with @context that points to nowhere should not throw an error") {
     validate("/raml/raml-with-json-schema/api.raml")
   }
+
+  // W-11802973: github issue 1559
+  test("JSON schemas should not participate in type inheritance") {
+    validate("/raml/raml-with-invalid-types/api.raml", Some("raml/json-schema-inheritance.report"))
+  }
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/ValidApiExamplesValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/ValidApiExamplesValidationTest.scala
@@ -1,9 +1,5 @@
 package amf.validation
 
-import amf.core.client.common.validation.AmfProfile.profile
-import amf.core.client.common.validation._
-import amf.core.internal.remote.{Hint, Raml08YamlHint, Raml10YamlHint}
-
 class ValidApiExamplesValidationTest extends ValidModelTest {
 
   override val reportsPath: String = "amf-cli/shared/src/test/resources/validations/reports/examples/"

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/Raml10TypeParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/raml/parser/Raml10TypeParser.scala
@@ -124,13 +124,6 @@ trait RamlTypeSyntax {
       false
     } else
       RamlTypeDefMatcher.matchWellKnownType(TypeName(str), default = UndefinedType, isRef = isRef) != UndefinedType
-
-  def isTypeExpression(str: String): Boolean = {
-    try { RamlTypeDefMatcher.matchWellKnownType(TypeName(str), default = UndefinedType) == TypeExpressionType }
-    catch {
-      case _: Exception => false
-    }
-  }
 }
 
 // Default RAML types
@@ -223,7 +216,7 @@ case class Raml08TypeParser(
     val shape = ScalarShape(node).withName(name, Annotations(key))
     adopt(shape)
     val optionalParsedShape = node.tagType match {
-      case YType.Map => parseSchemaOrTypeDeclarationAndExamples
+      case YType.Map => parseSchemaOrTypeDeclarationAndExamples()
       case YType.Seq => parseUnion(shape)
       case _         => Raml08TextParser(node, adopt, name, defaultType).parse()
     }
@@ -287,16 +280,7 @@ case class Raml08TypeParser(
           val shape = UnresolvedShape(text, node).withName(text, Annotations())
           shape.withContext(ctx)
           adopt(shape)
-          if (!text.validReferencePath && ctx.libraries.keys.exists(_ == text.split("\\.").head)) {
-            ctx.eh.violation(
-              ChainedReferenceSpecification,
-              shape,
-              s"Chained reference '$text",
-              node.location
-            )
-          } else {
-            shape.unresolved(text, Nil, Some(node.location))
-          }
+          checkChainedReference(shape, text, node)
           shape
       }
       Some(shape)
@@ -593,7 +577,7 @@ sealed abstract class RamlTypeParser(
       default: DefaultType
   ): RamlTypeParser
 
-  def parseDefaultType(defaultType: DefaultType): Shape = {
+  private def parseDefaultType(defaultType: DefaultType): Shape = {
     val defaultShape = defaultType.typeDef match {
       case typeDef if typeDef.isScalar => parseScalarType(typeDef)
       case ObjectType                  => parseObjectType()
@@ -601,6 +585,19 @@ sealed abstract class RamlTypeParser(
     }
     defaultShape.annotations += DefaultNode()
     defaultShape
+  }
+
+  protected def checkChainedReference(shape: UnresolvedShape, text: String, node: YNode): Any = {
+    if (!text.validReferencePath && ctx.libraries.keys.exists(_ == text.split("\\.").head)) {
+      ctx.eh.violation(
+        ChainedReferenceSpecification,
+        shape,
+        s"Chained reference '$text",
+        node.location
+      )
+    } else {
+      shape.unresolved(text, Nil, Some(node.location))
+    }
   }
 
   def parse(): Option[Shape] = {
@@ -829,16 +826,7 @@ sealed abstract class RamlTypeParser(
                 ).withName(text, nameAnnotations)
                 unresolve.withContext(ctx)
                 adopt(unresolve)
-                if (!text.validReferencePath && ctx.libraries.keys.exists(_ == text.split("\\.").head)) {
-                  ctx.eh.violation(
-                    ChainedReferenceSpecification,
-                    shape,
-                    s"Chained reference '$text",
-                    node.location
-                  )
-                } else {
-                  unresolve.unresolved(text, Nil, Some(node.location))
-                }
+                checkChainedReference(unresolve, text, node)
                 shape.annotations.reject(isLexical)
                 shape.annotations ++= unresolve.annotations
                 shape.withLinkTarget(unresolve).withLinkLabel(text)
@@ -856,13 +844,13 @@ sealed abstract class RamlTypeParser(
       .withId(linkId)
   }
 
-  private def parseReference(node: YNode, parendId: String, createLink: AnyShape => Shape): Option[Shape] = {
+  private def parseReference(node: YNode, parentId: String, createLink: AnyShape => Shape): Option[Shape] = {
     ctx.link(node) match {
       case Left(key) =>
         val referenced = ctx.findType(
           key,
           SearchScope.Fragments,
-          Some((s: String) => ctx.eh.violation(InvalidFragmentType, parendId, s, node.location))
+          Some((s: String) => ctx.eh.violation(InvalidFragmentType, parentId, s, node.location))
         )
         referenced.map(createLink(_).add(ExternalFragmentRef(key)))
       case _ =>
@@ -1044,25 +1032,13 @@ sealed abstract class RamlTypeParser(
         "anyOf",
         { entry =>
           entry.value.to[Seq[YNode]] match {
-            case Right(seq) =>
-              val unionNodes: Seq[Shape] = seq.zipWithIndex
-                .map { case (unionNode, index) =>
-                  typeParser(
-                    YMapEntryLike(unionNode),
-                    s"item$index",
-                    item => Unit,
-                    typeInfo.isAnnotation,
-                    AnyDefaultType
-                  ).parse()
-                }
-                .filter(_.isDefined)
-                .map(_.get)
+            case Right(nodes) =>
+              val unionNodes: Seq[Shape] = parseUnionFromNodes(nodes)
               shape.setWithoutId(
                 UnionShapeModel.AnyOf,
                 AmfArray(unionNodes, Annotations(entry.value)),
                 Annotations(entry)
               )
-
             case _ =>
               ctx.eh.violation(InvalidUnionType, shape, "Unions are built from multiple shape nodes", entry.location)
           }
@@ -1080,21 +1056,9 @@ sealed abstract class RamlTypeParser(
         "or".asRamlAnnotation,
         { entry =>
           entry.value.to[Seq[YNode]] match {
-            case Right(seq) =>
-              val nodes = seq.zipWithIndex
-                .map { case (unionNode, index) =>
-                  typeParser(
-                    YMapEntryLike(unionNode),
-                    s"item$index",
-                    item => Unit,
-                    typeInfo.isAnnotation,
-                    AnyDefaultType
-                  ).parse()
-                }
-                .filter(_.isDefined)
-                .map(_.get)
+            case Right(yNodes) =>
+              val nodes = parseUnionFromNodes(yNodes)
               shape.setArray(ShapeModel.Or, nodes, Annotations(entry.value))
-
             case _ =>
               ctx.eh
                 .violation(InvalidOrType, shape, "Or constraints are built from multiple shape nodes", entry.location)
@@ -1104,6 +1068,20 @@ sealed abstract class RamlTypeParser(
     }
   }
 
+  private def parseUnionFromNodes(seq: Seq[YNode]): Seq[Shape] = {
+    seq.zipWithIndex
+      .map { case (unionNode, index) =>
+        typeParser(
+          YMapEntryLike(unionNode),
+          s"item$index",
+          item => Unit,
+          typeInfo.isAnnotation,
+          AnyDefaultType
+        ).parse()
+      }
+      .filter(_.isDefined)
+      .map(_.get)
+  }
   case class AndConstraintParser(map: YMap, shape: Shape) {
 
     def parse(): Unit = {
@@ -1111,19 +1089,8 @@ sealed abstract class RamlTypeParser(
         "and".asRamlAnnotation,
         { entry =>
           entry.value.to[Seq[YNode]] match {
-            case Right(seq) =>
-              val nodes = seq.zipWithIndex
-                .map { case (unionNode, index) =>
-                  typeParser(
-                    YMapEntryLike(unionNode),
-                    s"item$index",
-                    item => Unit,
-                    typeInfo.isAnnotation,
-                    AnyDefaultType
-                  ).parse()
-                }
-                .filter(_.isDefined)
-                .map(_.get)
+            case Right(yNodes) =>
+              val nodes = parseUnionFromNodes(yNodes)
               shape.setArray(ShapeModel.And, nodes, Annotations(entry.value))
 
             case _ =>
@@ -1144,19 +1111,8 @@ sealed abstract class RamlTypeParser(
         "xor".asRamlAnnotation,
         { entry =>
           entry.value.to[Seq[YNode]] match {
-            case Right(seq) =>
-              val nodes = seq.zipWithIndex
-                .map { case (unionNode, index) =>
-                  typeParser(
-                    YMapEntryLike(unionNode),
-                    s"item$index",
-                    item => Unit,
-                    typeInfo.isAnnotation,
-                    AnyDefaultType
-                  ).parse()
-                }
-                .filter(_.isDefined)
-                .map(_.get)
+            case Right(yNodes) =>
+              val nodes = parseUnionFromNodes(yNodes)
               shape.setArray(ShapeModel.Xone, nodes, Annotations(entry.value))
 
             case _ =>
@@ -1521,28 +1477,17 @@ sealed abstract class RamlTypeParser(
             Annotations(entry)
           )
         case YType.Map =>
-          Raml10TypeParser(entry, s => Unit)
-            .parse()
-            .foreach { s =>
-              checkSchemaInheritance(shape, Seq(s), entry.range)
-              shape.setWithoutId(ShapeModel.Inherits, AmfArray(Seq(s), Annotations(entry.value)), Annotations(entry))
-            }
+          parseInheritedShape()
 
         case _ if RamlTypeDefMatcher.TypeExpression.unapply(entry.value.as[YScalar].text).isDefined =>
-          Raml10TypeParser(entry, s => Unit)
-            .parse()
-            .foreach { s =>
-              checkSchemaInheritance(shape, Seq(s), entry.range)
-              shape.setWithoutId(ShapeModel.Inherits, AmfArray(Seq(s), Annotations(entry.value)), Annotations(entry))
-            }
+          parseInheritedShape()
 
         case YType.Str if XMLSchema.unapply(entry.value).isDefined =>
           val parsed =
             RamlExternalParserFactory
               .createXml("schema", entry.value, xmlSchemaShape => xmlSchemaShape.withId(shape.id + "/xmlSchema"))
               .parse()
-          checkSchemaInheritance(shape, Seq(parsed), entry.range)
-          shape.setWithoutId(ShapeModel.Inherits, AmfArray(Seq(parsed), Annotations(entry.value)), Annotations(entry))
+          inheritShape(parsed)
 
         case _ if !wellKnownType(entry.value.as[YScalar].text) =>
           val text = entry.value.as[YScalar].text
@@ -1598,6 +1543,14 @@ sealed abstract class RamlTypeParser(
       }
     }
 
+    private def parseInheritedShape(): Unit =
+      Raml10TypeParser(entry, _ => Unit).parse().foreach(inheritShape)
+
+    private def inheritShape(s: Shape): shape.type = {
+      checkSchemaInheritance(shape, Seq(s), entry.range)
+      shape.setWithoutId(ShapeModel.Inherits, AmfArray(Seq(s), Annotations(entry.value)), Annotations(entry))
+    }
+
     private def unresolved(node: YNode, shape: Shape): UnresolvedShape = {
       val reference = node.as[YScalar].text
       // we need to pass the extension parser to the unresolved, in order to not only have the father at the moment of resolve the future ref in Value, also we need the parser itself, for modular dependency (We cannot create an instance of this parser in core)
@@ -1613,16 +1566,7 @@ sealed abstract class RamlTypeParser(
         )
       )
       unresolvedShape.withContext(ctx)
-      if (!reference.validReferencePath && ctx.libraries.keys.exists(_ == reference.split("\\.").head)) {
-        ctx.eh.violation(
-          ChainedReferenceSpecification,
-          unresolvedShape,
-          s"Chained reference '$reference",
-          node.location
-        )
-      } else {
-        unresolvedShape.unresolved(reference, Nil, Some(node.location))
-      }
+      checkChainedReference(unresolvedShape, reference, node)
       adopt(unresolvedShape)
       unresolvedShape
     }
@@ -1642,13 +1586,13 @@ sealed abstract class RamlTypeParser(
       if (shape.inherits.isEmpty)
         shape.setWithoutId(NodeShapeModel.Closed, AmfScalar(false), Annotations.synthesized())
       else if (map.key("additionalProperties").isEmpty) {
-        val closedInInhertiance = shape.effectiveInherits.exists(s =>
+        val closedInInheritance = shape.effectiveInherits.exists(s =>
           s.isInstanceOf[NodeShape] && s.asInstanceOf[NodeShape].closed.option().isDefined && s
             .asInstanceOf[NodeShape]
             .closed
             .value()
         )
-        shape.setWithoutId(NodeShapeModel.Closed, AmfScalar(closedInInhertiance), Annotations.synthesized())
+        shape.setWithoutId(NodeShapeModel.Closed, AmfScalar(closedInInheritance), Annotations.synthesized())
       }
       map.key("additionalProperties", (NodeShapeModel.Closed in shape).negated.explicit)
       map.key("additionalProperties".asRamlAnnotation).foreach { entry =>


### PR DESCRIPTION
- (chore): refactor some Raml10TypeParser methods
- (chore): move helper method to BU utils
- (chore): remove unused imports, correct formatting
- (refactor): improve ValidationInfo creation
- W-11802973: add warning when using a JSON Schema in type expressions
