### PR TITLE
fix annotation propagation

### DIFF
--- a/amf-cli/shared/src/test/resources/compatibility/raml10/complex-inheritance-2-and-optional-properties.raml
+++ b/amf-cli/shared/src/test/resources/compatibility/raml10/complex-inheritance-2-and-optional-properties.raml
@@ -1,0 +1,28 @@
+#%RAML 1.0
+title: API
+version: 1.0.0
+
+types:
+  A:
+    type: object
+
+  B:
+    type: object
+
+  Another:
+    properties:
+      prop?:
+        type: Union
+        description: asd
+
+  Union:
+    type: A | B
+
+/endpoint:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: Another
+

--- a/amf-cli/shared/src/test/resources/compatibility/raml10/complex-inheritance-and-optional-properties.raml
+++ b/amf-cli/shared/src/test/resources/compatibility/raml10/complex-inheritance-and-optional-properties.raml
@@ -1,0 +1,25 @@
+#%RAML 1.0
+title: API
+version: 1.0.0
+
+types:
+  Child:
+    type: Parent
+
+  Parent:
+    type: string
+
+  Another:
+    properties:
+      prop?:
+        type: Child
+        description: asd
+
+/endpoint:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: Another
+

--- a/amf-cli/shared/src/test/resources/poc/recursion-in-inherited-property.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-in-inherited-property.resolved.jsonld
@@ -1,7 +1,7 @@
 {
   "@graph": [
     {
-      "@id": "amf://id#33",
+      "@id": "amf://id#35",
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
@@ -10,7 +10,7 @@
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
-      "@id": "amf://id#34",
+      "@id": "amf://id#36",
       "@type": [
         "http://a.ml/vocabularies/apiContract#WebAPI",
         "http://a.ml/vocabularies/apiContract#API",
@@ -20,60 +20,6 @@
       "http://a.ml/vocabularies/core#name": "Healthcare EHR Appointments Process API",
       "http://a.ml/vocabularies/core#version": "v2",
       "http://a.ml/vocabularies/apiContract#endpoint": [
-        {
-          "@id": "amf://id#35"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#34/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#35",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#EndPoint",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/apiContract#path": "/appointments",
-      "http://a.ml/vocabularies/apiContract#supportedOperation": [
-        {
-          "@id": "amf://id#36"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#35/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#34/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#34/source-map/lexical/element_2"
-        },
-        {
-          "@id": "amf://id#34/source-map/lexical/element_0"
-        },
-        {
-          "@id": "amf://id#34/source-map/lexical/element_1"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#36",
-      "@type": [
-        "http://a.ml/vocabularies/apiContract#Operation",
-        "http://a.ml/vocabularies/core#Operation",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/apiContract#method": "get",
-      "http://a.ml/vocabularies/apiContract#returns": [
         {
           "@id": "amf://id#37"
         }
@@ -85,47 +31,15 @@
       ]
     },
     {
-      "@id": "amf://id#35/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#35/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#35/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#34/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(3,0)]"
-    },
-    {
-      "@id": "amf://id#34/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(3,0)-(5,0)]"
-    },
-    {
-      "@id": "amf://id#34/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#34",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(51,30)]"
-    },
-    {
       "@id": "amf://id#37",
       "@type": [
-        "http://a.ml/vocabularies/apiContract#Response",
-        "http://a.ml/vocabularies/core#Response",
-        "http://a.ml/vocabularies/apiContract#Message",
+        "http://a.ml/vocabularies/apiContract#EndPoint",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
-      "http://a.ml/vocabularies/apiContract#statusCode": "200",
-      "http://a.ml/vocabularies/core#name": "200",
-      "http://a.ml/vocabularies/apiContract#payload": [
+      "http://a.ml/vocabularies/apiContract#path": "/appointments",
+      "http://a.ml/vocabularies/apiContract#supportedOperation": [
         {
-          "@id": "amf://id#30"
+          "@id": "amf://id#38"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -141,37 +55,32 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#36/source-map/lexical/element_1"
+          "@id": "amf://id#36/source-map/lexical/element_2"
         },
         {
           "@id": "amf://id#36/source-map/lexical/element_0"
+        },
+        {
+          "@id": "amf://id#36/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#35/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#35",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(38,0)-(51,30)]"
-    },
-    {
-      "@id": "amf://id#35/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#path",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(38,0)-(38,13)]"
-    },
-    {
-      "@id": "amf://id#30",
+      "@id": "amf://id#38",
       "@type": [
-        "http://a.ml/vocabularies/apiContract#Payload",
-        "http://a.ml/vocabularies/core#Payload",
+        "http://a.ml/vocabularies/apiContract#Operation",
+        "http://a.ml/vocabularies/core#Operation",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
-      "http://a.ml/vocabularies/core#mediaType": "application/json",
-      "http://a.ml/vocabularies/shapes#schema": {
-        "@id": "amf://id#11"
-      },
+      "http://a.ml/vocabularies/apiContract#method": "get",
+      "http://a.ml/vocabularies/apiContract#returns": [
+        {
+          "@id": "amf://id#39"
+        }
+      ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#30/source-map"
+          "@id": "amf://id#38/source-map"
         }
       ]
     },
@@ -190,17 +99,108 @@
       ]
     },
     {
-      "@id": "amf://id#36/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(39,2)-(51,30)]"
+      "@id": "amf://id#36/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(3,0)]"
     },
     {
       "@id": "amf://id#36/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(3,0)-(5,0)]"
+    },
+    {
+      "@id": "amf://id#36/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#36",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(51,30)]"
+    },
+    {
+      "@id": "amf://id#39",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Response",
+        "http://a.ml/vocabularies/core#Response",
+        "http://a.ml/vocabularies/apiContract#Message",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/apiContract#statusCode": "200",
+      "http://a.ml/vocabularies/core#name": "200",
+      "http://a.ml/vocabularies/apiContract#payload": [
+        {
+          "@id": "amf://id#32"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#39/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#38/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#38/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#38/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#37/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(38,0)-(51,30)]"
+    },
+    {
+      "@id": "amf://id#37/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#path",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(38,0)-(38,13)]"
+    },
+    {
+      "@id": "amf://id#32",
+      "@type": [
+        "http://a.ml/vocabularies/apiContract#Payload",
+        "http://a.ml/vocabularies/core#Payload",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#mediaType": "application/json",
+      "http://a.ml/vocabularies/shapes#schema": {
+        "@id": "amf://id#13"
+      },
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#32/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#39/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#39/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#39/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#38/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#38",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(39,2)-(51,30)]"
+    },
+    {
+      "@id": "amf://id#38/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#returns",
       "http://a.ml/vocabularies/document-source-maps#value": "[(40,4)-(51,30)]"
     },
     {
-      "@id": "amf://id#11",
+      "@id": "amf://id#13",
       "@type": [
         "http://www.w3.org/ns/shacl#NodeShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -211,44 +211,44 @@
       "http://www.w3.org/ns/shacl#closed": false,
       "http://www.w3.org/ns/shacl#property": [
         {
-          "@id": "amf://id#12"
+          "@id": "amf://id#14"
         }
       ],
       "http://www.w3.org/ns/shacl#name": "Appointment",
       "http://a.ml/vocabularies/apiContract#examples": [
         {
-          "@id": "amf://id#21"
+          "@id": "amf://id#23"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#11/source-map"
+          "@id": "amf://id#13/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#30/source-map",
+      "@id": "amf://id#32/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#30/source-map/lexical/element_0"
+          "@id": "amf://id#32/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#37",
+      "@id": "amf://id#39/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#39",
       "http://a.ml/vocabularies/document-source-maps#value": "[(41,6)-(51,30)]"
     },
     {
-      "@id": "amf://id#37/source-map/lexical/element_0",
+      "@id": "amf://id#39/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/apiContract#payload",
       "http://a.ml/vocabularies/document-source-maps#value": "[(42,8)-(51,30)]"
     },
     {
-      "@id": "amf://id#12",
+      "@id": "amf://id#14",
       "@type": [
         "http://www.w3.org/ns/shacl#PropertyShape",
         "http://www.w3.org/ns/shacl#Shape",
@@ -261,74 +261,74 @@
         }
       ],
       "http://a.ml/vocabularies/shapes#range": {
-        "@id": "amf://id#13"
+        "@id": "amf://id#15"
       },
       "http://www.w3.org/ns/shacl#minCount": 1,
       "http://www.w3.org/ns/shacl#name": "participant",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#12/source-map"
+          "@id": "amf://id#14/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#21",
+      "@id": "amf://id#23",
       "@type": [
         "http://a.ml/vocabularies/apiContract#Example",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/document#strict": true,
       "http://a.ml/vocabularies/document#structuredValue": {
-        "@id": "amf://id#22"
+        "@id": "amf://id#24"
       },
       "http://a.ml/vocabularies/document#raw": "participant:\n  -\n    status: accepted\n    actor:\n      reference: Patient/9\n      display: Andreas Anderson\nstatus: proposed",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#21/source-map"
+          "@id": "amf://id#23/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#11/source-map",
+      "@id": "amf://id#13/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#11/source-map/synthesized-field/element_0"
+          "@id": "amf://id#13/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#resolved-link": [
         {
-          "@id": "amf://id#11/source-map/resolved-link/element_0"
+          "@id": "amf://id#13/source-map/resolved-link/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#11/source-map/lexical/element_1"
+          "@id": "amf://id#13/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#11/source-map/lexical/element_0"
+          "@id": "amf://id#13/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#declared-element": [
         {
-          "@id": "amf://id#11/source-map/declared-element/element_0"
+          "@id": "amf://id#13/source-map/declared-element/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#resolved-link-target": [
         {
-          "@id": "amf://id#11/source-map/resolved-link-target/element_0"
+          "@id": "amf://id#13/source-map/resolved-link-target/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#30/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#30",
+      "@id": "amf://id#32/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#32",
       "http://a.ml/vocabularies/document-source-maps#value": "[(43,10)-(51,30)]"
     },
     {
-      "@id": "amf://id#13",
+      "@id": "amf://id#15",
       "@type": [
         "http://a.ml/vocabularies/shapes#ArrayShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -337,113 +337,113 @@
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/shapes#items": {
-        "@id": "amf://id#14"
+        "@id": "amf://id#16"
       },
       "http://www.w3.org/ns/shacl#name": "participant",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#13/source-map"
+          "@id": "amf://id#15/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#12/source-map",
+      "@id": "amf://id#14/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#12/source-map/synthesized-field/element_1"
+          "@id": "amf://id#14/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#12/source-map/synthesized-field/element_0"
+          "@id": "amf://id#14/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#12/source-map/lexical/element_1"
+          "@id": "amf://id#14/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#12/source-map/lexical/element_0"
+          "@id": "amf://id#14/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#22",
+      "@id": "amf://id#24",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#participant": {
-        "@id": "amf://id#23"
+        "@id": "amf://id#25"
       },
       "http://a.ml/vocabularies/data#status": {
-        "@id": "amf://id#29"
+        "@id": "amf://id#31"
       },
       "http://a.ml/vocabularies/core#name": "object_1",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#22/source-map"
+          "@id": "amf://id#24/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#21/source-map",
+      "@id": "amf://id#23/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#21/source-map/synthesized-field/element_1"
+          "@id": "amf://id#23/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#21/source-map/synthesized-field/element_0"
+          "@id": "amf://id#23/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#21/source-map/lexical/element_0"
+          "@id": "amf://id#23/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#tracked-element": [
         {
-          "@id": "amf://id#21/source-map/tracked-element/element_0"
+          "@id": "amf://id#23/source-map/tracked-element/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#11/source-map/synthesized-field/element_0",
+      "@id": "amf://id#13/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#closed",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#11/source-map/resolved-link/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#11",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#31"
+      "@id": "amf://id#13/source-map/resolved-link/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#13",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#33"
     },
     {
-      "@id": "amf://id#11/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#11",
+      "@id": "amf://id#13/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#13",
       "http://a.ml/vocabularies/document-source-maps#value": "[(6,2)-(18,0)]"
     },
     {
-      "@id": "amf://id#11/source-map/lexical/element_0",
+      "@id": "amf://id#13/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(6,2)-(6,13)]"
     },
     {
-      "@id": "amf://id#11/source-map/declared-element/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#11",
+      "@id": "amf://id#13/source-map/declared-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#13",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#11/source-map/resolved-link-target/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#11",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#11"
+      "@id": "amf://id#13/source-map/resolved-link-target/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#13",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#13"
     },
     {
-      "@id": "amf://id#14",
+      "@id": "amf://id#16",
       "@type": [
         "http://www.w3.org/ns/shacl#NodeShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -454,63 +454,63 @@
       "http://www.w3.org/ns/shacl#closed": false,
       "http://www.w3.org/ns/shacl#property": [
         {
-          "@id": "amf://id#15"
+          "@id": "amf://id#17"
         },
         {
           "@id": "amf://id#2"
         },
         {
-          "@id": "amf://id#18"
+          "@id": "amf://id#20"
         },
         {
-          "@id": "amf://id#20"
+          "@id": "amf://id#22"
         }
       ],
       "http://www.w3.org/ns/shacl#name": "items",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#14/source-map"
+          "@id": "amf://id#16/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#13/source-map",
+      "@id": "amf://id#15/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#13/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#15/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#13/source-map/lexical/element_0"
+          "@id": "amf://id#15/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#12/source-map/synthesized-field/element_1",
+      "@id": "amf://id#14/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#path",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#12/source-map/synthesized-field/element_0",
+      "@id": "amf://id#14/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#minCount",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#12/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#12",
+      "@id": "amf://id#14/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#14",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,6)-(18,0)]"
     },
     {
-      "@id": "amf://id#12/source-map/lexical/element_0",
+      "@id": "amf://id#14/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#range",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,18)-(18,0)]"
     },
     {
-      "@id": "amf://id#23",
+      "@id": "amf://id#25",
       "@type": [
         "http://a.ml/vocabularies/data#Array",
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq",
@@ -519,18 +519,18 @@
       ],
       "http://www.w3.org/2000/01/rdf-schema#member": [
         {
-          "@id": "amf://id#24"
+          "@id": "amf://id#26"
         }
       ],
       "http://a.ml/vocabularies/core#name": "participant",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#23/source-map"
+          "@id": "amf://id#25/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#29",
+      "@id": "amf://id#31",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -545,54 +545,54 @@
       "http://a.ml/vocabularies/core#name": "status",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#29/source-map"
+          "@id": "amf://id#31/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#22/source-map",
+      "@id": "amf://id#24/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#22/source-map/synthesized-field/element_0"
+          "@id": "amf://id#24/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#22/source-map/lexical/element_2"
+          "@id": "amf://id#24/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#22/source-map/lexical/element_0"
+          "@id": "amf://id#24/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#22/source-map/lexical/element_1"
+          "@id": "amf://id#24/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#21/source-map/synthesized-field/element_1",
+      "@id": "amf://id#23/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#strict",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#21/source-map/synthesized-field/element_0",
+      "@id": "amf://id#23/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/document#raw",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#21/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#21",
+      "@id": "amf://id#23/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#23",
       "http://a.ml/vocabularies/document-source-maps#value": "[(45,12)-(51,30)]"
     },
     {
-      "@id": "amf://id#21/source-map/tracked-element/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#21",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#30"
+      "@id": "amf://id#23/source-map/tracked-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#23",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#32"
     },
     {
-      "@id": "amf://id#15",
+      "@id": "amf://id#17",
       "@type": [
         "http://www.w3.org/ns/shacl#PropertyShape",
         "http://www.w3.org/ns/shacl#Shape",
@@ -605,13 +605,13 @@
         }
       ],
       "http://a.ml/vocabularies/shapes#range": {
-        "@id": "amf://id#16"
+        "@id": "amf://id#18"
       },
       "http://www.w3.org/ns/shacl#minCount": 0,
       "http://www.w3.org/ns/shacl#name": "modifierExtension",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#15/source-map"
+          "@id": "amf://id#17/source-map"
         }
       ]
     },
@@ -640,7 +640,7 @@
       ]
     },
     {
-      "@id": "amf://id#18",
+      "@id": "amf://id#20",
       "@type": [
         "http://www.w3.org/ns/shacl#PropertyShape",
         "http://www.w3.org/ns/shacl#Shape",
@@ -653,18 +653,18 @@
         }
       ],
       "http://a.ml/vocabularies/shapes#range": {
-        "@id": "amf://id#19"
+        "@id": "amf://id#21"
       },
       "http://www.w3.org/ns/shacl#minCount": 1,
       "http://www.w3.org/ns/shacl#name": "status",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#18/source-map"
+          "@id": "amf://id#20/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#20",
+      "@id": "amf://id#22",
       "@type": [
         "http://www.w3.org/ns/shacl#PropertyShape",
         "http://www.w3.org/ns/shacl#Shape",
@@ -683,118 +683,118 @@
       "http://www.w3.org/ns/shacl#name": "actor",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#20/source-map"
+          "@id": "amf://id#22/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#14/source-map",
+      "@id": "amf://id#16/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#14/source-map/synthesized-field/element_0"
+          "@id": "amf://id#16/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#14/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#16/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#14/source-map/lexical/element_0"
+          "@id": "amf://id#16/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#inherited-shapes": [
         {
-          "@id": "amf://id#14/source-map/inherited-shapes/element_0"
+          "@id": "amf://id#16/source-map/inherited-shapes/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#13/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#13",
+      "@id": "amf://id#15/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#15",
       "http://a.ml/vocabularies/document-source-maps#value": "[(9,8)-(9,12)]"
     },
     {
-      "@id": "amf://id#13/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#13",
+      "@id": "amf://id#15/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#15",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,6)-(18,0)]"
     },
     {
-      "@id": "amf://id#24",
+      "@id": "amf://id#26",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#status": {
-        "@id": "amf://id#25"
+        "@id": "amf://id#27"
       },
       "http://a.ml/vocabularies/data#actor": {
-        "@id": "amf://id#26"
+        "@id": "amf://id#28"
       },
       "http://a.ml/vocabularies/core#name": "object_3",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#24/source-map"
+          "@id": "amf://id#26/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#23/source-map",
+      "@id": "amf://id#25/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#23/source-map/lexical/element_0"
+          "@id": "amf://id#25/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#29/source-map",
+      "@id": "amf://id#31/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#29/source-map/synthesized-field/element_1"
+          "@id": "amf://id#31/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#29/source-map/synthesized-field/element_0"
+          "@id": "amf://id#31/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#29/source-map/lexical/element_0"
+          "@id": "amf://id#31/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#22/source-map/synthesized-field/element_0",
+      "@id": "amf://id#24/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#22/source-map/lexical/element_2",
+      "@id": "amf://id#24/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#participant",
       "http://a.ml/vocabularies/document-source-maps#value": "[(46,14)-(51,0)]"
     },
     {
-      "@id": "amf://id#22/source-map/lexical/element_0",
+      "@id": "amf://id#24/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#status",
       "http://a.ml/vocabularies/document-source-maps#value": "[(51,14)-(51,30)]"
     },
     {
-      "@id": "amf://id#22/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#22",
+      "@id": "amf://id#24/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#24",
       "http://a.ml/vocabularies/document-source-maps#value": "[(46,0)-(51,30)]"
     },
     {
-      "@id": "amf://id#16",
+      "@id": "amf://id#18",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -810,34 +810,34 @@
       "http://www.w3.org/ns/shacl#name": "modifierExtension?",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#16/source-map"
+          "@id": "amf://id#18/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#15/source-map",
+      "@id": "amf://id#17/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#15/source-map/synthesized-field/element_1"
+          "@id": "amf://id#17/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#15/source-map/synthesized-field/element_0"
+          "@id": "amf://id#17/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#15/source-map/lexical/element_1"
+          "@id": "amf://id#17/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#15/source-map/lexical/element_0"
+          "@id": "amf://id#17/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#inheritance-provenance": [
         {
-          "@id": "amf://id#15/source-map/inheritance-provenance/element_0"
+          "@id": "amf://id#17/source-map/inheritance-provenance/element_0"
         }
       ]
     },
@@ -891,7 +891,7 @@
       ]
     },
     {
-      "@id": "amf://id#19",
+      "@id": "amf://id#21",
       "@type": [
         "http://a.ml/vocabularies/shapes#ScalarShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -907,51 +907,7 @@
       "http://www.w3.org/ns/shacl#name": "status",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#19/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#18/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-        {
-          "@id": "amf://id#18/source-map/synthesized-field/element_1"
-        },
-        {
-          "@id": "amf://id#18/source-map/synthesized-field/element_0"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "amf://id#18/source-map/lexical/element_1"
-        },
-        {
-          "@id": "amf://id#18/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
-      "@id": "amf://id#5",
-      "@type": [
-        "http://www.w3.org/ns/shacl#NodeShape",
-        "http://a.ml/vocabularies/shapes#AnyShape",
-        "http://www.w3.org/ns/shacl#Shape",
-        "http://a.ml/vocabularies/shapes#Shape",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://www.w3.org/ns/shacl#closed": false,
-      "http://www.w3.org/ns/shacl#property": [
-        {
-          "@id": "amf://id#6"
-        }
-      ],
-      "http://www.w3.org/ns/shacl#name": "Reference",
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "amf://id#5/source-map"
+          "@id": "amf://id#21/source-map"
         }
       ]
     },
@@ -978,27 +934,71 @@
       ]
     },
     {
-      "@id": "amf://id#14/source-map/synthesized-field/element_0",
+      "@id": "amf://id#5",
+      "@type": [
+        "http://www.w3.org/ns/shacl#NodeShape",
+        "http://a.ml/vocabularies/shapes#AnyShape",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/shapes#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/ns/shacl#closed": false,
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "amf://id#6"
+        }
+      ],
+      "http://www.w3.org/ns/shacl#name": "Reference",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "amf://id#5/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#22/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+        {
+          "@id": "amf://id#22/source-map/synthesized-field/element_1"
+        },
+        {
+          "@id": "amf://id#22/source-map/synthesized-field/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "amf://id#22/source-map/lexical/element_1"
+        },
+        {
+          "@id": "amf://id#22/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id#16/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#closed",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#14/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#14",
+      "@id": "amf://id#16/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#16",
       "http://a.ml/vocabularies/document-source-maps#value": "[(11,10)-(11,14)]"
     },
     {
-      "@id": "amf://id#14/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#14",
+      "@id": "amf://id#16/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#16",
       "http://a.ml/vocabularies/document-source-maps#value": "[(10,8)-(18,0)]"
     },
     {
-      "@id": "amf://id#14/source-map/inherited-shapes/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#14",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#17"
+      "@id": "amf://id#16/source-map/inherited-shapes/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#16",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#19"
     },
     {
-      "@id": "amf://id#25",
+      "@id": "amf://id#27",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1013,110 +1013,110 @@
       "http://a.ml/vocabularies/core#name": "status",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#25/source-map"
+          "@id": "amf://id#27/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#26",
+      "@id": "amf://id#28",
       "@type": [
         "http://a.ml/vocabularies/data#Object",
         "http://a.ml/vocabularies/data#Node",
         "http://a.ml/vocabularies/document#DomainElement"
       ],
       "http://a.ml/vocabularies/data#reference": {
-        "@id": "amf://id#27"
+        "@id": "amf://id#29"
       },
       "http://a.ml/vocabularies/data#display": {
-        "@id": "amf://id#28"
+        "@id": "amf://id#30"
       },
       "http://a.ml/vocabularies/core#name": "actor",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#26/source-map"
+          "@id": "amf://id#28/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#24/source-map",
+      "@id": "amf://id#26/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#24/source-map/synthesized-field/element_0"
+          "@id": "amf://id#26/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#24/source-map/lexical/element_2"
+          "@id": "amf://id#26/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#24/source-map/lexical/element_0"
+          "@id": "amf://id#26/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#24/source-map/lexical/element_1"
+          "@id": "amf://id#26/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#23/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#23",
+      "@id": "amf://id#25/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#25",
       "http://a.ml/vocabularies/document-source-maps#value": "[(46,26)-(51,0)]"
     },
     {
-      "@id": "amf://id#29/source-map/synthesized-field/element_1",
+      "@id": "amf://id#31/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#29/source-map/synthesized-field/element_0",
+      "@id": "amf://id#31/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#29/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#29",
+      "@id": "amf://id#31/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#31",
       "http://a.ml/vocabularies/document-source-maps#value": "[(51,22)-(51,30)]"
     },
     {
-      "@id": "amf://id#16/source-map",
+      "@id": "amf://id#18/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#16/source-map/lexical/element_1"
+          "@id": "amf://id#18/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#16/source-map/lexical/element_0"
+          "@id": "amf://id#18/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#15/source-map/synthesized-field/element_1",
+      "@id": "amf://id#17/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#path",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#15/source-map/synthesized-field/element_0",
+      "@id": "amf://id#17/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#minCount",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#15/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#15",
+      "@id": "amf://id#17/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#17",
       "http://a.ml/vocabularies/document-source-maps#value": "[(21,6)-(23,0)]"
     },
     {
-      "@id": "amf://id#15/source-map/lexical/element_0",
+      "@id": "amf://id#17/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#range",
       "http://a.ml/vocabularies/document-source-maps#value": "[(21,26)-(21,32)]"
     },
     {
-      "@id": "amf://id#15/source-map/inheritance-provenance/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#15",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#17"
+      "@id": "amf://id#17/source-map/inheritance-provenance/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#17",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#19"
     },
     {
       "@id": "amf://id#4",
@@ -1202,41 +1202,41 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
     },
     {
-      "@id": "amf://id#19/source-map",
+      "@id": "amf://id#21/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#19/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#21/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#19/source-map/lexical/element_1"
+          "@id": "amf://id#21/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#19/source-map/lexical/element_0"
+          "@id": "amf://id#21/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#18/source-map/synthesized-field/element_1",
+      "@id": "amf://id#20/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#path",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#18/source-map/synthesized-field/element_0",
+      "@id": "amf://id#20/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#minCount",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#18/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#18",
+      "@id": "amf://id#20/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#20",
       "http://a.ml/vocabularies/document-source-maps#value": "[(15,12)-(18,0)]"
     },
     {
-      "@id": "amf://id#18/source-map/lexical/element_0",
+      "@id": "amf://id#20/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#range",
       "http://a.ml/vocabularies/document-source-maps#value": "[(15,19)-(18,0)]"
     },
@@ -1306,46 +1306,46 @@
       ]
     },
     {
-      "@id": "amf://id#20/source-map/synthesized-field/element_1",
+      "@id": "amf://id#22/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#path",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#20/source-map/synthesized-field/element_0",
+      "@id": "amf://id#22/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#minCount",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#20/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#20",
+      "@id": "amf://id#22/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#22",
       "http://a.ml/vocabularies/document-source-maps#value": "[(13,12)-(15,0)]"
     },
     {
-      "@id": "amf://id#20/source-map/lexical/element_0",
+      "@id": "amf://id#22/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/shapes#range",
       "http://a.ml/vocabularies/document-source-maps#value": "[(13,19)-(15,0)]"
     },
     {
-      "@id": "amf://id#25/source-map",
+      "@id": "amf://id#27/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#25/source-map/synthesized-field/element_1"
+          "@id": "amf://id#27/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#25/source-map/synthesized-field/element_0"
+          "@id": "amf://id#27/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#25/source-map/lexical/element_0"
+          "@id": "amf://id#27/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#27",
+      "@id": "amf://id#29",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1360,12 +1360,12 @@
       "http://a.ml/vocabularies/core#name": "reference",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#27/source-map"
+          "@id": "amf://id#29/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#28",
+      "@id": "amf://id#30",
       "@type": [
         "http://a.ml/vocabularies/data#Scalar",
         "http://a.ml/vocabularies/data#Node",
@@ -1380,59 +1380,59 @@
       "http://a.ml/vocabularies/core#name": "display",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#28/source-map"
+          "@id": "amf://id#30/source-map"
         }
       ]
     },
     {
-      "@id": "amf://id#26/source-map",
+      "@id": "amf://id#28/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#26/source-map/synthesized-field/element_0"
+          "@id": "amf://id#28/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#26/source-map/lexical/element_2"
+          "@id": "amf://id#28/source-map/lexical/element_2"
         },
         {
-          "@id": "amf://id#26/source-map/lexical/element_0"
+          "@id": "amf://id#28/source-map/lexical/element_0"
         },
         {
-          "@id": "amf://id#26/source-map/lexical/element_1"
+          "@id": "amf://id#28/source-map/lexical/element_1"
         }
       ]
     },
     {
-      "@id": "amf://id#24/source-map/synthesized-field/element_0",
+      "@id": "amf://id#26/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#24/source-map/lexical/element_2",
+      "@id": "amf://id#26/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#status",
       "http://a.ml/vocabularies/document-source-maps#value": "[(47,18)-(48,0)]"
     },
     {
-      "@id": "amf://id#24/source-map/lexical/element_0",
+      "@id": "amf://id#26/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#actor",
       "http://a.ml/vocabularies/document-source-maps#value": "[(48,18)-(51,0)]"
     },
     {
-      "@id": "amf://id#24/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#24",
+      "@id": "amf://id#26/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#26",
       "http://a.ml/vocabularies/document-source-maps#value": "[(47,18)-(51,0)]"
     },
     {
-      "@id": "amf://id#16/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#16",
+      "@id": "amf://id#18/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#18",
       "http://a.ml/vocabularies/document-source-maps#value": "[(21,6)-(23,0)]"
     },
     {
-      "@id": "amf://id#16/source-map/lexical/element_0",
+      "@id": "amf://id#18/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(21,26)-(21,32)]"
     },
@@ -1489,17 +1489,17 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#3"
     },
     {
-      "@id": "amf://id#19/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#19",
+      "@id": "amf://id#21/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#21",
       "http://a.ml/vocabularies/document-source-maps#value": "[(16,14)-(16,18)]"
     },
     {
-      "@id": "amf://id#19/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#19",
+      "@id": "amf://id#21/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#21",
       "http://a.ml/vocabularies/document-source-maps#value": "[(15,12)-(18,0)]"
     },
     {
-      "@id": "amf://id#19/source-map/lexical/element_0",
+      "@id": "amf://id#21/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "[(16,14)-(18,0)]"
     },
@@ -1559,7 +1559,7 @@
     {
       "@id": "amf://id#5/source-map/resolved-link-target/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#5",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#5"
     },
     {
       "@id": "amf://id#5/source-map/declared-element/element_0",
@@ -1569,12 +1569,12 @@
     {
       "@id": "amf://id#5/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#5",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(26,2)-(32,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,2)-(26,0)]"
     },
     {
       "@id": "amf://id#5/source-map/type-property-lexical-info/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#5",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(27,4)-(27,8)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(24,4)-(24,8)]"
     },
     {
       "@id": "amf://id#5/source-map/resolved-link/element_0",
@@ -1587,76 +1587,76 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
     },
     {
-      "@id": "amf://id#25/source-map/synthesized-field/element_1",
+      "@id": "amf://id#27/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#25/source-map/synthesized-field/element_0",
+      "@id": "amf://id#27/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#25/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#25",
+      "@id": "amf://id#27/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#27",
       "http://a.ml/vocabularies/document-source-maps#value": "[(47,26)-(47,34)]"
     },
     {
-      "@id": "amf://id#27/source-map",
+      "@id": "amf://id#29/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#27/source-map/synthesized-field/element_1"
+          "@id": "amf://id#29/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#27/source-map/synthesized-field/element_0"
+          "@id": "amf://id#29/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#27/source-map/lexical/element_0"
+          "@id": "amf://id#29/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#28/source-map",
+      "@id": "amf://id#30/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#28/source-map/synthesized-field/element_1"
+          "@id": "amf://id#30/source-map/synthesized-field/element_1"
         },
         {
-          "@id": "amf://id#28/source-map/synthesized-field/element_0"
+          "@id": "amf://id#30/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#28/source-map/lexical/element_0"
+          "@id": "amf://id#30/source-map/lexical/element_0"
         }
       ]
     },
     {
-      "@id": "amf://id#26/source-map/synthesized-field/element_0",
+      "@id": "amf://id#28/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#26/source-map/lexical/element_2",
+      "@id": "amf://id#28/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#reference",
       "http://a.ml/vocabularies/document-source-maps#value": "[(49,20)-(50,0)]"
     },
     {
-      "@id": "amf://id#26/source-map/lexical/element_0",
+      "@id": "amf://id#28/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/data#display",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,20)-(51,0)]"
     },
     {
-      "@id": "amf://id#26/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#26",
+      "@id": "amf://id#28/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#28",
       "http://a.ml/vocabularies/document-source-maps#value": "[(49,0)-(51,0)]"
     },
     {
@@ -1736,33 +1736,33 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
     },
     {
-      "@id": "amf://id#27/source-map/synthesized-field/element_1",
+      "@id": "amf://id#29/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#27/source-map/synthesized-field/element_0",
+      "@id": "amf://id#29/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#27/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#27",
+      "@id": "amf://id#29/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#29",
       "http://a.ml/vocabularies/document-source-maps#value": "[(49,31)-(49,40)]"
     },
     {
-      "@id": "amf://id#28/source-map/synthesized-field/element_1",
+      "@id": "amf://id#30/source-map/synthesized-field/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#datatype",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#28/source-map/synthesized-field/element_0",
+      "@id": "amf://id#30/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#28/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#28",
+      "@id": "amf://id#30/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#30",
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,29)-(50,45)]"
     },
     {
@@ -1797,13 +1797,13 @@
           "@id": "amf://id#1"
         },
         {
-          "@id": "amf://id#11"
+          "@id": "amf://id#13"
         },
         {
           "@id": "amf://id#5"
         },
         {
-          "@id": "amf://id#17"
+          "@id": "amf://id#19"
         },
         {
           "@id": "amf://id#3"
@@ -1816,11 +1816,11 @@
         "http://a.ml/vocabularies/document#Unit"
       ],
       "http://a.ml/vocabularies/document#encodes": {
-        "@id": "amf://id#34"
+        "@id": "amf://id#36"
       },
       "http://a.ml/vocabularies/document#root": true,
       "http://a.ml/vocabularies/document#processingData": {
-        "@id": "amf://id#33"
+        "@id": "amf://id#35"
       }
     },
     {
@@ -1846,7 +1846,7 @@
       ]
     },
     {
-      "@id": "amf://id#17",
+      "@id": "amf://id#19",
       "@type": [
         "http://www.w3.org/ns/shacl#NodeShape",
         "http://a.ml/vocabularies/shapes#AnyShape",
@@ -1857,7 +1857,7 @@
       "http://www.w3.org/ns/shacl#closed": false,
       "http://www.w3.org/ns/shacl#property": [
         {
-          "@id": "amf://id#15"
+          "@id": "amf://id#17"
         },
         {
           "@id": "amf://id#2"
@@ -1866,7 +1866,7 @@
       "http://www.w3.org/ns/shacl#name": "BackboneElement",
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
-          "@id": "amf://id#17/source-map"
+          "@id": "amf://id#19/source-map"
         }
       ]
     },
@@ -1910,46 +1910,46 @@
       ]
     },
     {
-      "@id": "amf://id#17/source-map",
+      "@id": "amf://id#19/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#synthesized-field": [
         {
-          "@id": "amf://id#17/source-map/synthesized-field/element_0"
+          "@id": "amf://id#19/source-map/synthesized-field/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#resolved-link-target": [
         {
-          "@id": "amf://id#17/source-map/resolved-link-target/element_0"
+          "@id": "amf://id#19/source-map/resolved-link-target/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#declared-element": [
         {
-          "@id": "amf://id#17/source-map/declared-element/element_0"
+          "@id": "amf://id#19/source-map/declared-element/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "amf://id#17/source-map/lexical/element_1"
+          "@id": "amf://id#19/source-map/lexical/element_1"
         },
         {
-          "@id": "amf://id#17/source-map/lexical/element_0"
+          "@id": "amf://id#19/source-map/lexical/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
         {
-          "@id": "amf://id#17/source-map/type-property-lexical-info/element_0"
+          "@id": "amf://id#19/source-map/type-property-lexical-info/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#resolved-link": [
         {
-          "@id": "amf://id#17/source-map/resolved-link/element_0"
+          "@id": "amf://id#19/source-map/resolved-link/element_0"
         }
       ],
       "http://a.ml/vocabularies/document-source-maps#inherited-shapes": [
         {
-          "@id": "amf://id#17/source-map/inherited-shapes/element_0"
+          "@id": "amf://id#19/source-map/inherited-shapes/element_0"
         }
       ]
     },
@@ -1961,7 +1961,7 @@
     {
       "@id": "amf://id#1/source-map/resolved-link/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "amf://id#1",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#10"
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#12"
     },
     {
       "@id": "amf://id#1/source-map/type-property-lexical-info/element_0",
@@ -1989,43 +1989,43 @@
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
     },
     {
-      "@id": "amf://id#17/source-map/synthesized-field/element_0",
+      "@id": "amf://id#19/source-map/synthesized-field/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#closed",
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "amf://id#17/source-map/resolved-link-target/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#17",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#17"
+      "@id": "amf://id#19/source-map/resolved-link-target/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#19",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#19"
     },
     {
-      "@id": "amf://id#17/source-map/declared-element/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#17",
+      "@id": "amf://id#19/source-map/declared-element/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#19",
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "amf://id#17/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#17",
+      "@id": "amf://id#19/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#19",
       "http://a.ml/vocabularies/document-source-maps#value": "[(18,2)-(23,0)]"
     },
     {
-      "@id": "amf://id#17/source-map/lexical/element_0",
+      "@id": "amf://id#19/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(18,2)-(18,17)]"
     },
     {
-      "@id": "amf://id#17/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#17",
+      "@id": "amf://id#19/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#19",
       "http://a.ml/vocabularies/document-source-maps#value": "[(19,4)-(19,8)]"
     },
     {
-      "@id": "amf://id#17/source-map/resolved-link/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#17",
-      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#32"
+      "@id": "amf://id#19/source-map/resolved-link/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#19",
+      "http://a.ml/vocabularies/document-source-maps#value": "amf://id#34"
     },
     {
-      "@id": "amf://id#17/source-map/inherited-shapes/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#17",
+      "@id": "amf://id#19/source-map/inherited-shapes/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "amf://id#19",
       "http://a.ml/vocabularies/document-source-maps#value": "amf://id#1"
     }
   ]

--- a/amf-cli/shared/src/test/resources/production/lib-types/lib.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/lib-types/lib.expanded.jsonld
@@ -12,7 +12,7 @@
     ],
     "doc:processingData": [
       {
-        "@id": "#15",
+        "@id": "#17",
         "@type": [
           "doc:APIContractProcessingData"
         ],
@@ -236,24 +236,15 @@
                                   "synthesized-field": {
                                     "shacl:closed": "true"
                                   },
-                                  "resolved-link-target": {
-                                    "#7": "amf://id#1"
-                                  },
-                                  "declared-element": {
-                                    "#7": ""
+                                  "type-property-lexical-info": {
+                                    "#7": "[(26,8)-(26,12)]"
                                   },
                                   "lexical": {
                                     "core:name": "[(25,8)-(26,0)]",
-                                    "#7": "[(8,2)-(15,0)]"
-                                  },
-                                  "type-property-lexical-info": {
-                                    "#7": "[(9,4)-(9,8)]"
-                                  },
-                                  "resolved-link": {
-                                    "#7": "amf://id#11"
+                                    "#7": "[(24,6)-(26,21)]"
                                   },
                                   "inherited-shapes": {
-                                    "#7": "amf://id#1,amf://id#12"
+                                    "#7": "amf://id#11"
                                   }
                                 }
                               }
@@ -290,7 +281,7 @@
                             "shacl:closed": "true"
                           },
                           "resolved-link": {
-                            "#5": "amf://id#13"
+                            "#5": "amf://id#12"
                           },
                           "type-property-lexical-info": {
                             "#5": "[(22,4)-(22,8)]"
@@ -390,7 +381,7 @@
             "shacl:closed": "true"
           },
           "resolved-link": {
-            "#1": "amf://id#11"
+            "#1": "amf://id#13"
           },
           "type-property-lexical-info": {
             "#1": "[(9,4)-(9,8)]"
@@ -546,24 +537,15 @@
                   "synthesized-field": {
                     "shacl:closed": "true"
                   },
-                  "resolved-link-target": {
-                    "#7": "amf://id#1"
-                  },
-                  "declared-element": {
-                    "#7": ""
+                  "type-property-lexical-info": {
+                    "#7": "[(26,8)-(26,12)]"
                   },
                   "lexical": {
                     "core:name": "[(25,8)-(26,0)]",
-                    "#7": "[(8,2)-(15,0)]"
-                  },
-                  "type-property-lexical-info": {
-                    "#7": "[(9,4)-(9,8)]"
-                  },
-                  "resolved-link": {
-                    "#7": "amf://id#11"
+                    "#7": "[(24,6)-(26,21)]"
                   },
                   "inherited-shapes": {
-                    "#7": "amf://id#1,amf://id#12"
+                    "#7": "amf://id#11"
                   }
                 }
               }
@@ -600,7 +582,7 @@
             "shacl:closed": "true"
           },
           "resolved-link": {
-            "#5": "amf://id#13"
+            "#5": "amf://id#12"
           },
           "type-property-lexical-info": {
             "#5": "[(22,4)-(22,8)]"
@@ -785,24 +767,15 @@
                           "synthesized-field": {
                             "shacl:closed": "true"
                           },
-                          "resolved-link-target": {
-                            "#7": "amf://id#1"
-                          },
-                          "declared-element": {
-                            "#7": ""
+                          "type-property-lexical-info": {
+                            "#7": "[(26,8)-(26,12)]"
                           },
                           "lexical": {
                             "core:name": "[(25,8)-(26,0)]",
-                            "#7": "[(8,2)-(15,0)]"
-                          },
-                          "type-property-lexical-info": {
-                            "#7": "[(9,4)-(9,8)]"
-                          },
-                          "resolved-link": {
-                            "#7": "amf://id#11"
+                            "#7": "[(24,6)-(26,21)]"
                           },
                           "inherited-shapes": {
-                            "#7": "amf://id#1,amf://id#12"
+                            "#7": "amf://id#11"
                           }
                         }
                       }
@@ -839,7 +812,7 @@
                     "shacl:closed": "true"
                   },
                   "resolved-link": {
-                    "#5": "amf://id#13"
+                    "#5": "amf://id#12"
                   },
                   "type-property-lexical-info": {
                     "#5": "[(22,4)-(22,8)]"
@@ -907,7 +880,7 @@
         }
       },
       {
-        "@id": "#12",
+        "@id": "#11",
         "@type": [
           "shacl:NodeShape",
           "raml-shapes:AnyShape",
@@ -1103,24 +1076,15 @@
                                   "synthesized-field": {
                                     "shacl:closed": "true"
                                   },
-                                  "resolved-link-target": {
-                                    "#7": "amf://id#1"
-                                  },
-                                  "declared-element": {
-                                    "#7": ""
+                                  "type-property-lexical-info": {
+                                    "#7": "[(26,8)-(26,12)]"
                                   },
                                   "lexical": {
                                     "core:name": "[(25,8)-(26,0)]",
-                                    "#7": "[(8,2)-(15,0)]"
-                                  },
-                                  "type-property-lexical-info": {
-                                    "#7": "[(9,4)-(9,8)]"
-                                  },
-                                  "resolved-link": {
-                                    "#7": "amf://id#11"
+                                    "#7": "[(24,6)-(26,21)]"
                                   },
                                   "inherited-shapes": {
-                                    "#7": "amf://id#1,amf://id#12"
+                                    "#7": "amf://id#11"
                                   }
                                 }
                               }
@@ -1157,7 +1121,7 @@
                             "shacl:closed": "true"
                           },
                           "resolved-link": {
-                            "#5": "amf://id#13"
+                            "#5": "amf://id#12"
                           },
                           "type-property-lexical-info": {
                             "#5": "[(22,4)-(22,8)]"
@@ -1257,27 +1221,27 @@
             "shacl:closed": "true"
           },
           "resolved-link-target": {
-            "#12": "amf://id#1"
+            "#11": "amf://id#11"
           },
           "declared-element": {
-            "#12": ""
+            "#11": ""
           },
           "lexical": {
-            "#12": "[(8,2)-(15,0)]"
+            "#11": "[(3,2)-(5,0)]"
           },
           "type-property-lexical-info": {
-            "#12": "[(9,4)-(9,8)]"
+            "#11": "[(4,4)-(4,8)]"
           },
           "resolved-link": {
-            "#12": "amf://id#11"
+            "#11": "amf://id#15"
           },
           "inherited-shapes": {
-            "#12": "amf://id#1"
+            "#11": "amf://id#1"
           }
         }
       },
       {
-        "@id": "#14",
+        "@id": "#16",
         "@type": [
           "raml-shapes:ArrayShape",
           "raml-shapes:AnyShape",
@@ -1287,7 +1251,7 @@
         ],
         "raml-shapes:items": [
           {
-            "@id": "#12",
+            "@id": "#11",
             "@type": [
               "shacl:NodeShape",
               "raml-shapes:AnyShape",
@@ -1483,24 +1447,15 @@
                                       "synthesized-field": {
                                         "shacl:closed": "true"
                                       },
-                                      "resolved-link-target": {
-                                        "#7": "amf://id#1"
-                                      },
-                                      "declared-element": {
-                                        "#7": ""
+                                      "type-property-lexical-info": {
+                                        "#7": "[(26,8)-(26,12)]"
                                       },
                                       "lexical": {
                                         "core:name": "[(25,8)-(26,0)]",
-                                        "#7": "[(8,2)-(15,0)]"
-                                      },
-                                      "type-property-lexical-info": {
-                                        "#7": "[(9,4)-(9,8)]"
-                                      },
-                                      "resolved-link": {
-                                        "#7": "amf://id#11"
+                                        "#7": "[(24,6)-(26,21)]"
                                       },
                                       "inherited-shapes": {
-                                        "#7": "amf://id#1,amf://id#12"
+                                        "#7": "amf://id#11"
                                       }
                                     }
                                   }
@@ -1537,7 +1492,7 @@
                                 "shacl:closed": "true"
                               },
                               "resolved-link": {
-                                "#5": "amf://id#13"
+                                "#5": "amf://id#12"
                               },
                               "type-property-lexical-info": {
                                 "#5": "[(22,4)-(22,8)]"
@@ -1637,22 +1592,22 @@
                 "shacl:closed": "true"
               },
               "resolved-link-target": {
-                "#12": "amf://id#1"
+                "#11": "amf://id#11"
               },
               "declared-element": {
-                "#12": ""
+                "#11": ""
               },
               "lexical": {
-                "#12": "[(8,2)-(15,0)]"
+                "#11": "[(3,2)-(5,0)]"
               },
               "type-property-lexical-info": {
-                "#12": "[(9,4)-(9,8)]"
+                "#11": "[(4,4)-(4,8)]"
               },
               "resolved-link": {
-                "#12": "amf://id#11"
+                "#11": "amf://id#15"
               },
               "inherited-shapes": {
-                "#12": "amf://id#1"
+                "#11": "amf://id#1"
               }
             }
           }
@@ -1664,14 +1619,14 @@
         ],
         "smaps": {
           "declared-element": {
-            "#14": ""
+            "#16": ""
           },
           "lexical": {
             "shacl:name": "[(5,2)-(5,10)]",
-            "#14": "[(5,2)-(8,0)]"
+            "#16": "[(5,2)-(8,0)]"
           },
           "type-property-lexical-info": {
-            "#14": "[(6,4)-(6,8)]"
+            "#16": "[(6,4)-(6,8)]"
           }
         }
       }

--- a/amf-cli/shared/src/test/resources/production/lib-types/lib.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/lib-types/lib.flattened.jsonld
@@ -1,7 +1,7 @@
 {
   "@graph": [
     {
-      "@id": "#15",
+      "@id": "#17",
       "@type": [
         "doc:APIContractProcessingData"
       ],
@@ -22,10 +22,10 @@
           "@id": "#3"
         },
         {
-          "@id": "#12"
+          "@id": "#11"
         },
         {
-          "@id": "#14"
+          "@id": "#16"
         }
       ],
       "@type": [
@@ -34,7 +34,7 @@
       ],
       "doc:root": true,
       "doc:processingData": {
-        "@id": "#15"
+        "@id": "#17"
       },
       "smaps": {
         "lexical": {
@@ -63,7 +63,7 @@
           "shacl:closed": "true"
         },
         "resolved-link": {
-          "#1": "amf://id#11"
+          "#1": "amf://id#13"
         },
         "type-property-lexical-info": {
           "#1": "[(9,4)-(9,8)]"
@@ -101,7 +101,7 @@
           "shacl:closed": "true"
         },
         "resolved-link": {
-          "#5": "amf://id#13"
+          "#5": "amf://id#12"
         },
         "type-property-lexical-info": {
           "#5": "[(22,4)-(22,8)]"
@@ -157,7 +157,7 @@
       }
     },
     {
-      "@id": "#12",
+      "@id": "#11",
       "@type": [
         "shacl:NodeShape",
         "raml-shapes:AnyShape",
@@ -177,27 +177,27 @@
           "shacl:closed": "true"
         },
         "resolved-link-target": {
-          "#12": "amf://id#1"
+          "#11": "amf://id#11"
         },
         "declared-element": {
-          "#12": ""
+          "#11": ""
         },
         "lexical": {
-          "#12": "[(8,2)-(15,0)]"
+          "#11": "[(3,2)-(5,0)]"
         },
         "type-property-lexical-info": {
-          "#12": "[(9,4)-(9,8)]"
+          "#11": "[(4,4)-(4,8)]"
         },
         "resolved-link": {
-          "#12": "amf://id#11"
+          "#11": "amf://id#15"
         },
         "inherited-shapes": {
-          "#12": "amf://id#1"
+          "#11": "amf://id#1"
         }
       }
     },
     {
-      "@id": "#14",
+      "@id": "#16",
       "@type": [
         "raml-shapes:ArrayShape",
         "raml-shapes:AnyShape",
@@ -206,19 +206,19 @@
         "doc:DomainElement"
       ],
       "raml-shapes:items": {
-        "@id": "#12"
+        "@id": "#11"
       },
       "shacl:name": "accounts",
       "smaps": {
         "declared-element": {
-          "#14": ""
+          "#16": ""
         },
         "lexical": {
           "shacl:name": "[(5,2)-(5,10)]",
-          "#14": "[(5,2)-(8,0)]"
+          "#16": "[(5,2)-(8,0)]"
         },
         "type-property-lexical-info": {
-          "#14": "[(6,4)-(6,8)]"
+          "#16": "[(6,4)-(6,8)]"
         }
       }
     },
@@ -330,24 +330,15 @@
         "synthesized-field": {
           "shacl:closed": "true"
         },
-        "resolved-link-target": {
-          "#7": "amf://id#1"
-        },
-        "declared-element": {
-          "#7": ""
+        "type-property-lexical-info": {
+          "#7": "[(26,8)-(26,12)]"
         },
         "lexical": {
           "core:name": "[(25,8)-(26,0)]",
-          "#7": "[(8,2)-(15,0)]"
-        },
-        "type-property-lexical-info": {
-          "#7": "[(9,4)-(9,8)]"
-        },
-        "resolved-link": {
-          "#7": "amf://id#11"
+          "#7": "[(24,6)-(26,21)]"
         },
         "inherited-shapes": {
-          "#7": "amf://id#1,amf://id#12"
+          "#7": "amf://id#11"
         }
       }
     },

--- a/amf-cli/shared/src/test/resources/production/recursive-union.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/recursive-union.raml.expanded.jsonld
@@ -548,21 +548,6 @@
                                 ]
                               }
                             ],
-                            "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-                              {
-                                "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/type-property-lexical-info/element_0",
-                                "http://a.ml/vocabularies/document-source-maps#element": [
-                                  {
-                                    "@value": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType"
-                                  }
-                                ],
-                                "http://a.ml/vocabularies/document-source-maps#value": [
-                                  {
-                                    "@value": "[(15,4)-(15,8)]"
-                                  }
-                                ]
-                              }
-                            ],
                             "http://a.ml/vocabularies/document-source-maps#lexical": [
                               {
                                 "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/lexical/element_1",
@@ -587,6 +572,21 @@
                                 "http://a.ml/vocabularies/document-source-maps#value": [
                                   {
                                     "@value": "[(14,2)-(14,13)]"
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/type-property-lexical-info/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "[(15,4)-(15,8)]"
                                   }
                                 ]
                               }
@@ -888,21 +888,6 @@
                         ]
                       }
                     ],
-                    "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-                      {
-                        "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/type-property-lexical-info/element_0",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(15,4)-(15,8)]"
-                          }
-                        ]
-                      }
-                    ],
                     "http://a.ml/vocabularies/document-source-maps#lexical": [
                       {
                         "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/lexical/element_1",
@@ -927,6 +912,21 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "[(14,2)-(14,13)]"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/type-property-lexical-info/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(15,4)-(15,8)]"
                           }
                         ]
                       }
@@ -986,21 +986,6 @@
                 ]
               }
             ],
-            "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-              {
-                "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/type-property-lexical-info/element_0",
-                "http://a.ml/vocabularies/document-source-maps#element": [
-                  {
-                    "@value": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType"
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#value": [
-                  {
-                    "@value": "[(6,4)-(6,8)]"
-                  }
-                ]
-              }
-            ],
             "http://a.ml/vocabularies/document-source-maps#lexical": [
               {
                 "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/lexical/element_1",
@@ -1025,6 +1010,21 @@
                 "http://a.ml/vocabularies/document-source-maps#value": [
                   {
                     "@value": "[(5,2)-(5,10)]"
+                  }
+                ]
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/type-property-lexical-info/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(6,4)-(6,8)]"
                   }
                 ]
               }

--- a/amf-cli/shared/src/test/resources/production/recursive-union.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/recursive-union.raml.flattened.jsonld
@@ -273,17 +273,17 @@
           "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/declared-element/element_0"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/type-property-lexical-info/element_0"
-        }
-      ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/lexical/element_1"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/lexical/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
@@ -368,11 +368,6 @@
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(6,4)-(6,8)]"
-    },
-    {
       "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType",
       "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(8,0)]"
@@ -381,6 +376,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(5,10)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/SomeType",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(6,4)-(6,8)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/array/SomeUnion/inherits/union/default-union/anyOf/array/default-array/recursive",
@@ -463,17 +463,17 @@
           "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/declared-element/element_0"
         }
       ],
-      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/type-property-lexical-info/element_0"
-        }
-      ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/lexical/element_1"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/lexical/element_0"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/type-property-lexical-info/element_0"
         }
       ]
     },
@@ -540,11 +540,6 @@
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/type-property-lexical-info/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(15,4)-(15,8)]"
-    },
-    {
       "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType",
       "http://a.ml/vocabularies/document-source-maps#value": "[(14,2)-(18,0)]"
@@ -553,6 +548,11 @@
       "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(14,2)-(14,13)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType/source-map/type-property-lexical-info/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/any/OneMoreType",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(15,4)-(15,8)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/production/recursive-union.raml#/declares/array/SomeUnion/inherits/union/default-union/anyOf/array/default-array/recursive/source-map/synthesized-field/element_0",

--- a/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/avoid-extract-to-declares.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/avoid-extract-to-declares.expanded.jsonld
@@ -124,24 +124,15 @@
                                     ],
                                     "smaps": {
                                       "inherited-shapes": {
-                                        "#3": "amf://id#5"
-                                      },
-                                      "resolved-link": {
                                         "#3": "amf://id#4"
-                                      },
-                                      "type-property-lexical-info": {
-                                        "#3": "[(13,4)-(13,8)]"
                                       },
                                       "lexical": {
                                         "core:description": "[(8,8)-(10,0)]",
-                                        "#3": "[(12,2)-(15,0)]",
+                                        "#3": "[(7,6)-(12,0)]",
                                         "shacl:datatype": "[(13,4)-(15,0)]"
                                       },
-                                      "declared-element": {
-                                        "#3": ""
-                                      },
-                                      "resolved-link-target": {
-                                        "#3": "amf://id#5"
+                                      "type-property-lexical-info": {
+                                        "#3": "[(10,8)-(10,12)]"
                                       }
                                     }
                                   }
@@ -326,24 +317,15 @@
                 ],
                 "smaps": {
                   "inherited-shapes": {
-                    "#3": "amf://id#5"
-                  },
-                  "resolved-link": {
                     "#3": "amf://id#4"
-                  },
-                  "type-property-lexical-info": {
-                    "#3": "[(13,4)-(13,8)]"
                   },
                   "lexical": {
                     "core:description": "[(8,8)-(10,0)]",
-                    "#3": "[(12,2)-(15,0)]",
+                    "#3": "[(7,6)-(12,0)]",
                     "shacl:datatype": "[(13,4)-(15,0)]"
                   },
-                  "declared-element": {
-                    "#3": ""
-                  },
-                  "resolved-link-target": {
-                    "#3": "amf://id#5"
+                  "type-property-lexical-info": {
+                    "#3": "[(10,8)-(10,12)]"
                   }
                 }
               }
@@ -383,7 +365,7 @@
             "shacl:closed": "true"
           },
           "resolved-link": {
-            "#1": "amf://id#6"
+            "#1": "amf://id#5"
           },
           "lexical": {
             "shacl:name": "[(5,2)-(5,21)]",
@@ -398,7 +380,7 @@
         }
       },
       {
-        "@id": "#5",
+        "@id": "#4",
         "@type": [
           "raml-shapes:ScalarShape",
           "raml-shapes:AnyShape",
@@ -418,21 +400,21 @@
         ],
         "smaps": {
           "resolved-link-target": {
-            "#5": "amf://id#5"
+            "#4": "amf://id#4"
           },
           "declared-element": {
-            "#5": ""
+            "#4": ""
           },
           "lexical": {
             "shacl:name": "[(12,2)-(12,31)]",
-            "#5": "[(12,2)-(15,0)]",
+            "#4": "[(12,2)-(15,0)]",
             "shacl:datatype": "[(13,4)-(15,0)]"
           },
           "type-property-lexical-info": {
-            "#5": "[(13,4)-(13,8)]"
+            "#4": "[(13,4)-(13,8)]"
           },
           "resolved-link": {
-            "#5": "amf://id#4"
+            "#4": "amf://id#6"
           }
         }
       }

--- a/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/avoid-extract-to-declares.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/avoid-extract-to-declares.flattened.jsonld
@@ -194,24 +194,15 @@
       "core:description": "The coregistrant of this product list.",
       "smaps": {
         "inherited-shapes": {
-          "#3": "amf://id#5"
-        },
-        "resolved-link": {
           "#3": "amf://id#4"
-        },
-        "type-property-lexical-info": {
-          "#3": "[(13,4)-(13,8)]"
         },
         "lexical": {
           "core:description": "[(8,8)-(10,0)]",
-          "#3": "[(12,2)-(15,0)]",
+          "#3": "[(7,6)-(12,0)]",
           "shacl:datatype": "[(13,4)-(15,0)]"
         },
-        "declared-element": {
-          "#3": ""
-        },
-        "resolved-link-target": {
-          "#3": "amf://id#5"
+        "type-property-lexical-info": {
+          "#3": "[(10,8)-(10,12)]"
         }
       }
     },
@@ -222,7 +213,7 @@
           "@id": "#1"
         },
         {
-          "@id": "#5"
+          "@id": "#4"
         }
       ],
       "@type": [
@@ -260,7 +251,7 @@
           "shacl:closed": "true"
         },
         "resolved-link": {
-          "#1": "amf://id#6"
+          "#1": "amf://id#5"
         },
         "lexical": {
           "shacl:name": "[(5,2)-(5,21)]",
@@ -275,7 +266,7 @@
       }
     },
     {
-      "@id": "#5",
+      "@id": "#4",
       "@type": [
         "raml-shapes:ScalarShape",
         "raml-shapes:AnyShape",
@@ -291,21 +282,21 @@
       "shacl:name": "CustomerProductListRegistrant",
       "smaps": {
         "resolved-link-target": {
-          "#5": "amf://id#5"
+          "#4": "amf://id#4"
         },
         "declared-element": {
-          "#5": ""
+          "#4": ""
         },
         "lexical": {
           "shacl:name": "[(12,2)-(12,31)]",
-          "#5": "[(12,2)-(15,0)]",
+          "#4": "[(12,2)-(15,0)]",
           "shacl:datatype": "[(13,4)-(15,0)]"
         },
         "type-property-lexical-info": {
-          "#5": "[(13,4)-(13,8)]"
+          "#4": "[(13,4)-(13,8)]"
         },
         "resolved-link": {
-          "#5": "amf://id#4"
+          "#4": "amf://id#6"
         }
       }
     }

--- a/amf-cli/shared/src/test/resources/resolution/unresolved-shape.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/unresolved-shape.raml.expanded.jsonld
@@ -138,9 +138,15 @@
           "synthesized-field": {
             "shacl:closed": "true"
           },
+          "declared-element": {
+            "#1": ""
+          },
           "lexical": {
             "shacl:name": "[(3,2)-(3,3)]",
-            "#1": "[(4,10)-(4,13)]"
+            "#1": "[(3,2)-(6,18)]"
+          },
+          "type-property-lexical-info": {
+            "#1": "[(4,4)-(4,8)]"
           },
           "inherited-shapes": {
             "#1": "amf://id#5"

--- a/amf-cli/shared/src/test/resources/resolution/unresolved-shape.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/unresolved-shape.raml.flattened.jsonld
@@ -64,9 +64,15 @@
         "synthesized-field": {
           "shacl:closed": "true"
         },
+        "declared-element": {
+          "#1": ""
+        },
         "lexical": {
           "shacl:name": "[(3,2)-(3,3)]",
-          "#1": "[(4,10)-(4,13)]"
+          "#1": "[(3,2)-(6,18)]"
+        },
+        "type-property-lexical-info": {
+          "#1": "[(4,4)-(4,8)]"
         },
         "inherited-shapes": {
           "#1": "amf://id#5"

--- a/amf-cli/shared/src/test/resources/validations/healthcare_reduced_v1.raml.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/healthcare_reduced_v1.raml.resolved.jsonld
@@ -786,7 +786,7 @@
                                             ],
                                             "http://a.ml/vocabularies/document-source-maps#value": [
                                               {
-                                                "@value": "[(27,4)-(27,8)]"
+                                                "@value": "[(24,4)-(24,8)]"
                                               }
                                             ]
                                           }
@@ -801,7 +801,7 @@
                                             ],
                                             "http://a.ml/vocabularies/document-source-maps#value": [
                                               {
-                                                "@value": "[(26,2)-(32,0)]"
+                                                "@value": "[(23,2)-(26,0)]"
                                               }
                                             ]
                                           }
@@ -1443,7 +1443,7 @@
                                     ],
                                     "http://a.ml/vocabularies/document-source-maps#value": [
                                       {
-                                        "@value": "[(27,4)-(27,8)]"
+                                        "@value": "[(24,4)-(24,8)]"
                                       }
                                     ]
                                   }
@@ -1458,7 +1458,7 @@
                                     ],
                                     "http://a.ml/vocabularies/document-source-maps#value": [
                                       {
-                                        "@value": "[(26,2)-(32,0)]"
+                                        "@value": "[(23,2)-(26,0)]"
                                       }
                                     ]
                                   }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/MinShapeAlgorithm.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/MinShapeAlgorithm.scala
@@ -33,7 +33,7 @@ class InheritanceIncompatibleShapeError(
 
 private[resolution] class MinShapeAlgorithm()(implicit val context: NormalizationContext) {
 
-  protected def computeNarrowRestrictions(
+  private def computeNarrowRestrictions(
       fields: Seq[Field],
       baseShape: Shape,
       superShape: Shape,
@@ -65,13 +65,13 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     baseShape
   }
 
-  def inheritAnnotations(annotations: Annotations, from: Shape) = {
+  private def inheritAnnotations(annotations: Annotations, from: Shape) = {
     if (!annotations.contains(classOf[InheritanceProvenance]))
       annotations += InheritanceProvenance(from.id)
     annotations
   }
 
-  protected def restrictShape(restriction: Shape, shape: Shape): Shape = {
+  private def restrictShape(restriction: Shape, shape: Shape): Shape = {
     shape.id = restriction.id
     restriction.fields.foreach { case (field, derivedValue) =>
       if (field != NodeShapeModel.Inherits) {
@@ -84,12 +84,10 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     shape
   }
 
-  protected def computeNumericRestriction(
+  private def computeNumericRestriction(
       comparison: String,
       lvalue: AmfElement,
-      rvalue: AmfElement,
-      property: Option[String] = None,
-      lexicalInfo: Option[LexicalInformation] = None
+      rvalue: AmfElement
   ): AmfElement = {
     lvalue match {
       case scalar: AmfScalar
@@ -118,10 +116,9 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     }
   }
 
-  protected def computeEnum(
+  private def computeEnum(
       derivedEnumeration: Seq[AmfElement],
-      superEnumeration: Seq[AmfElement],
-      annotations: Annotations
+      superEnumeration: Seq[AmfElement]
   ): Unit = {
     if (derivedEnumeration.nonEmpty && superEnumeration.nonEmpty) {
       val headOption = derivedEnumeration.headOption
@@ -153,7 +150,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     }
   }
 
-  protected def computeStringEquality(
+  private def computeStringEquality(
       lvalue: AmfElement,
       rvalue: AmfElement,
       property: Option[String] = None,
@@ -177,7 +174,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     }
   }
 
-  protected def stringValue(value: AmfElement): Option[String] = {
+  private def stringValue(value: AmfElement): Option[String] = {
     value match {
       case scalar: AmfScalar
           if Option(scalar.value).isDefined && value
@@ -187,7 +184,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     }
   }
 
-  protected def computeNumericComparison(
+  private def computeNumericComparison(
       comparison: String,
       lvalue: AmfElement,
       rvalue: AmfElement,
@@ -225,13 +222,11 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     }
   }
 
-  protected def computeBooleanComparison(
+  private def computeBooleanComparison(
       lcomparison: Boolean,
       rcomparison: Boolean,
       lvalue: AmfElement,
-      rvalue: AmfElement,
-      property: Option[String] = None,
-      lexicalInformaiton: Option[LexicalInformation] = None
+      rvalue: AmfElement
   ): Boolean = {
     lvalue match {
       case scalar: AmfScalar
@@ -245,7 +240,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     }
   }
 
-  protected def computeNarrow(field: Field, derivedValue: AmfElement, superValue: AmfElement): AmfElement = {
+  private def computeNarrow(field: Field, derivedValue: AmfElement, superValue: AmfElement): AmfElement = {
     field match {
 
       case ShapeModel.Name =>
@@ -271,9 +266,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
           computeNumericRestriction(
             "max",
             superValue,
-            derivedValue,
-            Some(NodeShapeModel.MinProperties.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         } else {
           throw new InheritanceIncompatibleShapeError(
@@ -298,9 +291,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
           computeNumericRestriction(
             "min",
             superValue,
-            derivedValue,
-            Some(NodeShapeModel.MaxProperties.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         } else {
           throw new InheritanceIncompatibleShapeError(
@@ -325,9 +316,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
           computeNumericRestriction(
             "max",
             superValue,
-            derivedValue,
-            Some(ScalarShapeModel.MinLength.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         } else {
           throw new InheritanceIncompatibleShapeError(
@@ -352,9 +341,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
           computeNumericRestriction(
             "min",
             superValue,
-            derivedValue,
-            Some(ScalarShapeModel.MaxLength.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         } else {
           throw new InheritanceIncompatibleShapeError(
@@ -379,9 +366,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
           computeNumericRestriction(
             "max",
             superValue,
-            derivedValue,
-            Some(ScalarShapeModel.Minimum.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         } else {
           throw new InheritanceIncompatibleShapeError(
@@ -406,9 +391,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
           computeNumericRestriction(
             "min",
             superValue,
-            derivedValue,
-            Some(ScalarShapeModel.Maximum.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         } else {
           throw new InheritanceIncompatibleShapeError(
@@ -433,9 +416,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
           computeNumericRestriction(
             "max",
             superValue,
-            derivedValue,
-            Some(ArrayShapeModel.MinItems.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         } else {
           throw new InheritanceIncompatibleShapeError(
@@ -461,9 +442,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
           computeNumericRestriction(
             "min",
             superValue,
-            derivedValue,
-            Some(ArrayShapeModel.MaxItems.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         } else {
           throw new InheritanceIncompatibleShapeError(
@@ -557,8 +536,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
       case ShapeModel.Values =>
         computeEnum(
           derivedValue.asInstanceOf[AmfArray].values,
-          superValue.asInstanceOf[AmfArray].values,
-          derivedValue.annotations
+          superValue.asInstanceOf[AmfArray].values
         )
         derivedValue
 
@@ -568,25 +546,19 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
             lcomparison = true,
             rcomparison = true,
             superValue,
-            derivedValue,
-            Some(ArrayShapeModel.UniqueItems.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           ) ||
           computeBooleanComparison(
             lcomparison = false,
             rcomparison = false,
             superValue,
-            derivedValue,
-            Some(ArrayShapeModel.UniqueItems.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           ) ||
           computeBooleanComparison(
             lcomparison = false,
             rcomparison = true,
             superValue,
-            derivedValue,
-            Some(ArrayShapeModel.UniqueItems.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         ) {
           derivedValue
@@ -613,9 +585,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
           computeNumericRestriction(
             "max",
             superValue,
-            derivedValue,
-            Some(PropertyShapeModel.MinCount.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         } else {
           throw new InheritanceIncompatibleShapeError(
@@ -640,9 +610,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
           computeNumericRestriction(
             "min",
             superValue,
-            derivedValue,
-            Some(PropertyShapeModel.MaxCount.value.iri()),
-            derivedValue.annotations.find(classOf[LexicalInformation])
+            derivedValue
           )
         } else {
           throw new InheritanceIncompatibleShapeError(
@@ -698,7 +666,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
   }
 
   // this is inverted, it is safe because recursive shape does not have facets
-  def computeMinRecursive(baseShape: Shape, recursiveShape: RecursiveShape): Shape = {
+  private def computeMinRecursive(baseShape: Shape, recursiveShape: RecursiveShape): Shape = {
     restrictShape(baseShape, recursiveShape)
   }
 
@@ -795,7 +763,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     schema
   }
 
-  protected def computeMinScalar(baseScalar: ScalarShape, superScalar: ScalarShape): ScalarShape = {
+  private def computeMinScalar(baseScalar: ScalarShape, superScalar: ScalarShape): ScalarShape = {
     computeNarrowRestrictions(
       ScalarShapeModel.fields,
       baseScalar,
@@ -808,12 +776,12 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
   private val allShapeFields =
     (ScalarShapeModel.fields ++ ArrayShapeModel.fields ++ NodeShapeModel.fields ++ AnyShapeModel.fields).distinct
 
-  protected def computeMinAny(baseShape: Shape, anyShape: AnyShape): Shape = {
+  private def computeMinAny(baseShape: Shape, anyShape: AnyShape): Shape = {
     computeNarrowRestrictions(allShapeFields, baseShape, anyShape)
     baseShape
   }
 
-  protected def computeMinMatrix(baseMatrix: MatrixShape, superMatrix: MatrixShape): Shape = {
+  private def computeMinMatrix(baseMatrix: MatrixShape, superMatrix: MatrixShape): Shape = {
 
     val superItems = superMatrix.items
     val baseItems  = baseMatrix.items
@@ -835,9 +803,9 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     baseMatrix
   }
 
-  protected def isArrayOfAnyShapes(shape: ArrayShape): Boolean = shape.items.isInstanceOf[AnyShape]
+  private def isArrayOfAnyShapes(shape: ArrayShape): Boolean = shape.items.isInstanceOf[AnyShape]
 
-  protected def computeMinMatrixWithAnyShape(baseMatrix: MatrixShape, superArray: ArrayShape): Shape = {
+  private def computeMinMatrixWithAnyShape(baseMatrix: MatrixShape, superArray: ArrayShape): Shape = {
 
     val superItems = superArray
     val baseItems  = baseMatrix.items
@@ -859,7 +827,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     baseMatrix
   }
 
-  protected def computeMinTuple(baseTuple: TupleShape, superTuple: TupleShape): Shape = {
+  private def computeMinTuple(baseTuple: TupleShape, superTuple: TupleShape): Shape = {
     val superItems = baseTuple.items
     val baseItems  = superTuple.items
 
@@ -903,7 +871,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     }
   }
 
-  protected def computeMinArray(baseArray: ArrayShape, superArray: ArrayShape): Shape = {
+  private def computeMinArray(baseArray: ArrayShape, superArray: ArrayShape): Shape = {
     val superItemsOption = Option(superArray.items)
     val baseItemsOption  = Option(baseArray.items)
 
@@ -929,7 +897,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     baseArray
   }
 
-  protected def computeMinNode(baseNode: NodeShape, superNode: NodeShape): Shape = {
+  private def computeMinNode(baseNode: NodeShape, superNode: NodeShape): Shape = {
     val superProperties = superNode.properties
     val baseProperties  = baseNode.properties
 
@@ -940,7 +908,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
 
     superProperties.foreach(p => commonProps.put(p.path.value(), false))
     baseProperties.foreach { p =>
-      if (commonProps.get(p.path.value()).isDefined) {
+      if (commonProps.contains(p.path.value())) {
         commonProps.put(p.path.value(), true)
       } else {
         commonProps.put(p.path.value(), false)
@@ -995,7 +963,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     baseNode
   }
 
-  def inheritProp(from: Shape)(prop: PropertyShape): PropertyShape = {
+  private def inheritProp(from: Shape)(prop: PropertyShape): PropertyShape = {
     if (prop.annotations.find(classOf[InheritanceProvenance]).isEmpty) {
       prop.annotations += InheritanceProvenance(from.id)
     }
@@ -1016,7 +984,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
       )
     }
   }
-  protected def computeMinUnion(baseUnion: UnionShape, superUnion: UnionShape): Shape = {
+  private def computeMinUnion(baseUnion: UnionShape, superUnion: UnionShape): Shape = {
 
     val unionContext: NormalizationContext = UnionErrorHandler.wrapContext(context)
     val newUnionItems =
@@ -1077,7 +1045,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
       case _ =>
     }
 
-  protected def computeMinUnionNode(baseUnion: UnionShape, superNode: NodeShape): Shape = {
+  private def computeMinUnionNode(baseUnion: UnionShape, superNode: NodeShape): Shape = {
     val unionContext: NormalizationContext = UnionErrorHandler.wrapContext(context)
     val newUnionItems = for {
       baseUnionElement <- baseUnion.anyOf
@@ -1096,7 +1064,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     baseUnion
   }
 
-  protected def shouldComputeInheritanceForUnionMembers(child: Shape, parent: UnionShape): Boolean = {
+  private def shouldComputeInheritanceForUnionMembers(child: Shape, parent: UnionShape): Boolean = {
     shouldComputeInheritanceForUnionScalarShapeMembers(
       child,
       parent
@@ -1114,7 +1082,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     true
   }
 
-  protected def shouldComputeInheritanceForUnionScalarShapeMembers(child: Shape, parent: UnionShape): Boolean = {
+  private def shouldComputeInheritanceForUnionScalarShapeMembers(child: Shape, parent: UnionShape): Boolean = {
     lazy val childFields = Seq(
       ScalarShapeModel.Format,
       ScalarShapeModel.Minimum,
@@ -1134,7 +1102,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     areAllOfType[ScalarShape](parent.anyOf) && existsSome(child, childFields)
   }
 
-  protected def shouldComputeInheritanceForUnionNodeShapeMembers(child: Shape, parent: UnionShape): Boolean = {
+  private def shouldComputeInheritanceForUnionNodeShapeMembers(child: Shape, parent: UnionShape): Boolean = {
     lazy val childFields = Seq(
       NodeShapeModel.Properties
     )
@@ -1142,7 +1110,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     areAllOfType[NodeShape](parent.anyOf) && existsSome(child, childFields)
   }
 
-  protected def computeMinSuperUnion(baseShape: Shape, superUnion: UnionShape): Shape = {
+  private def computeMinSuperUnion(baseShape: Shape, superUnion: UnionShape): Shape = {
     val unionContext: NormalizationContext = UnionErrorHandler.wrapContext(context)
     var newUnionItems                      = superUnion.anyOf
     if (shouldComputeInheritanceForUnionMembers(baseShape, superUnion)) {
@@ -1238,7 +1206,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     }
   }
 
-  def computeMinProperty(baseProperty: PropertyShape, superProperty: PropertyShape): Shape = {
+  private def computeMinProperty(baseProperty: PropertyShape, superProperty: PropertyShape): Shape = {
     if (isExactlyAny(baseProperty.range) && !isInferred(baseProperty) && isSubtypeOfAny(superProperty.range)) {
       context.errorHandler.violation(
         InvalidTypeInheritanceErrorSpecification,
@@ -1279,7 +1247,7 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     baseProperty
   }
 
-  def computeMinFile(baseFile: FileShape, superFile: FileShape): Shape = {
+  private def computeMinFile(baseFile: FileShape, superFile: FileShape): Shape = {
     computeNarrowRestrictions(FileShapeModel.fields, baseFile, superFile)
     baseFile
   }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/MinShapeAlgorithm.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/shape_normalization/MinShapeAlgorithm.scala
@@ -71,7 +71,8 @@ private[resolution] class MinShapeAlgorithm()(implicit val context: Normalizatio
     annotations
   }
 
-  private def restrictShape(restriction: Shape, shape: Shape): Shape = {
+  private def restrictShape(restriction: Shape, parent: Shape): Shape = {
+    val shape = parent.copyShape(restriction.annotations)
     shape.id = restriction.id
     restriction.fields.foreach { case (field, derivedValue) =>
       if (field != NodeShapeModel.Inherits) {


### PR DESCRIPTION
Problem was when computing inheritance some children were incorrectly propagated the "DeclaredElement" annotation from its parent. 

When this happened in inline nodes of optional properties in RAML, e.g.:
```yaml
Parent:
  type: object 
  
Node:
  properties:
    prop?:
      type: Parent 
      description: asd
      # inline type ☝️ 
```
the property range was emitted as a declaration in OAS 3.0 with the `?` as part of its name, which is invalid in OAS 3.0
