### PR TITLE
W-12670897: add mediatype to the payload validators cache key

### DIFF
--- a/amf-cli/shared/src/test/resources/validations/raml/examples/different-formats/api.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/examples/different-formats/api.raml
@@ -1,0 +1,22 @@
+#%RAML 1.0
+title: test api
+description: test api
+
+types:
+  TestType:
+    type: object
+    properties:
+      testString: string
+      testNumber: number
+    examples:
+      xml: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testString>this is a string</testString>
+        <testNumber>404</testNumber>
+
+      json: |
+        {
+          "testString": "this is a string",
+          "testNumber": 404
+        }
+

--- a/amf-cli/shared/src/test/resources/validations/reports/model/raml/different-example-formats.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/model/raml/different-example-formats.report
@@ -1,0 +1,14 @@
+ModelId: file://amf-cli/shared/src/test/resources/validations/raml/examples/different-formats/api.raml
+Profile: RAML 1.0
+Conforms: true
+Number of results: 1
+
+Level: Warning
+
+- Constraint: http://a.ml/vocabularies/amf/validation#unsupported-example-media-type-warning
+  Message: Unsupported validation for mediatype: application/xml and shape file://amf-cli/shared/src/test/resources/validations/raml/examples/different-formats/api.raml#/declares/shape/TestType
+  Severity: Warning
+  Target: file://amf-cli/shared/src/test/resources/validations/raml/examples/different-formats/api.raml#/declares/shape/TestType/examples/example/xml
+  Property: http://a.ml/vocabularies/document#value
+  Range: [(12,6)-(17,0)]
+  Location: file://amf-cli/shared/src/test/resources/validations/raml/examples/different-formats/api.raml

--- a/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/RamlModelUniquePlatformReportTest.scala
@@ -738,4 +738,9 @@ class RamlModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
   test("RAML discriminator cannot be defined inline") {
     validate("/raml/discriminator-inline.raml", Some("raml/discriminator-inline.report"))
   }
+
+  // W-12670897
+  test("RAML type with JSON & XML examples should only fail XML") {
+    validate("/raml/examples/different-formats/api.raml", Some("raml/different-example-formats.report"))
+  }
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ExampleDataParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ExampleDataParser.scala
@@ -9,7 +9,7 @@ import amf.shapes.internal.annotations.ExternalReferenceUrl
 import amf.shapes.client.scala.model.domain.Example
 import amf.shapes.internal.domain.metamodel.ExampleModel
 import org.yaml.model.YNode.MutRef
-import org.yaml.model.{YScalar, YSequence, YType}
+import org.yaml.model.{YNode, YScalar, YSequence, YType}
 import org.yaml.render.YamlRender
 
 case class ExampleDataParser(entryLike: YMapEntryLike, example: Example, options: ExampleOptions)(implicit
@@ -37,15 +37,7 @@ case class ExampleDataParser(entryLike: YMapEntryLike, example: Example, options
 
     }
 
-    node.toOption[YScalar] match {
-      case Some(value) if node.tagType == YType.Null =>
-        if (isNullLiteral(value))
-          example.setWithoutId(ExampleModel.Raw, AmfScalar("null"), Annotations.synthesized())
-      case Some(scalar) =>
-        example.setWithoutId(ExampleModel.Raw, AmfScalar(scalar.text), Annotations.synthesized())
-      case _ =>
-        example.set(ExampleModel.Raw, AmfScalar(YamlRender.render(targetNode)), Annotations.synthesized())
-    }
+    setRawField(targetNode)
 
     val result = NodeDataNodeParser(targetNode, example.id, options.quiet, mutTarget, options.isScalar).parse()
 
@@ -55,6 +47,18 @@ case class ExampleDataParser(entryLike: YMapEntryLike, example: Example, options
     }
 
     example
+  }
+
+  private def setRawField(targetNode: YNode): Any = {
+    node.toOption[YScalar] match {
+      case Some(value) if node.tagType == YType.Null =>
+        if (isNullLiteral(value))
+          example.setWithoutId(ExampleModel.Raw, AmfScalar("null"), Annotations.synthesized())
+      case Some(scalar) =>
+        example.setWithoutId(ExampleModel.Raw, AmfScalar(scalar.text), Annotations.synthesized())
+      case _ =>
+        example.set(ExampleModel.Raw, AmfScalar(YamlRender.render(targetNode)), Annotations.synthesized())
+    }
   }
 
   private def isNullLiteral(value: YScalar) = value.text.nonEmpty

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ExampleParsers.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ExampleParsers.scala
@@ -216,10 +216,11 @@ case class RamlSingleExampleValueParser(entry: YMapEntry, producer: () => Exampl
 ) extends QuickFieldParserOps {
   def parse(): Example = {
     val example = producer().add(Annotations(entry))
+    val value   = entry.value
 
-    entry.value.tagType match {
+    value.tagType match {
       case YType.Map =>
-        val map = entry.value.as[YMap]
+        val map = value.as[YMap]
 
         if (map.key("value").nonEmpty) {
           map.key("displayName", (ExampleModel.DisplayName in example).allowingAnnotations)
@@ -235,9 +236,10 @@ case class RamlSingleExampleValueParser(entry: YMapEntry, producer: () => Exampl
           AnnotationParser(example, map, List(VocabularyMappings.example)).parse()
 
           if (ctx.spec.isRaml) ctx.closedShape(example, map, "example")
-        } else ExampleDataParser(YMapEntryLike(entry.value), example, options).parse()
+        } else ExampleDataParser(YMapEntryLike(value), example, options).parse()
       case YType.Null => // ignore
-      case _          => ExampleDataParser(YMapEntryLike(entry.value), example, options).parse()
+      case _ =>
+        ExampleDataParser(YMapEntryLike(value), example, options).parse()
     }
 
     example

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/payload/UnitPayloadsValidation.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/payload/UnitPayloadsValidation.scala
@@ -32,8 +32,8 @@ case class UnitPayloadsValidation(baseUnit: BaseUnit, collectors: Seq[Validation
   def validate(
       config: ValidationConfiguration
   )(implicit executionContext: ExecutionContext): Future[Seq[AMFValidationResult]] = {
-    val nextConfig = config.amfConfig.withPlugin(ErrorFallbackValidationPlugin(SeverityLevels.WARNING))
-    CandidateValidator.validateAll(candidates, config.copy(nextConfig)).map(groupResults)
+    val configWithFallback = config.amfConfig.withPlugin(ErrorFallbackValidationPlugin(SeverityLevels.WARNING))
+    CandidateValidator.validateAll(candidates, config.copy(configWithFallback)).map(groupResults)
   }
 
   private def groupResults(report: AMFValidationReport): Seq[AMFValidationResult] = {

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/payload/collector/PayloadsCollector.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/validation/payload/collector/PayloadsCollector.scala
@@ -81,11 +81,11 @@ object PayloadsCollector extends ValidationCandidateCollector {
       override val a: Annotations
   ) extends CollectedElement(id, raw, a)
 
-  private def buildFragment(shape: Shape, collectedElement: CollectedElement) = {
+  private def buildFragment(shape: Shape, collectedElement: CollectedElement): PayloadFragment = {
     val fragment = collectedElement match {
       case dn: DataNodeCollectedElement => // the example has been parsed, so i can use native validation like json or any default
         PayloadFragment(dn.dataNode, `text/vnd.yaml`)
-      case s: StringCollectedElement =>
+      case s: StringCollectedElement => // for xml examples that don't have dataNode for example
         PayloadFragment(
           ScalarNode(s.raw, None, s.a),
           s.raw.guessMediaType(shape.isInstanceOf[ScalarShape])


### PR DESCRIPTION
Added mediatype to the payload validators cache key to avoid caching a JSON payload validator and then trying to use it on an XML example, or viceversa.