### PR TITLE
(ci): use 1.3.1 ci image version. This sets Eclipse Temurin as JDK distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/aml-org/amf-ci-tools-base-image:1.3.0
+FROM ghcr.io/aml-org/amf-ci-tools-base-image:1.3.1

--- a/amf-apicontract.versions
+++ b/amf-apicontract.versions
@@ -1,5 +1,5 @@
-amf.apicontract=5.3.0-RC.0
-amf.aml=6.3.0-RC.0
+amf.apicontract=5.3.0-RC.1
+amf.aml=6.3.0-RC.1
 amf.model=3.8.2
 antlr4Version=0.6.22
 amf.validation.profile.dialect=1.4.0


### PR DESCRIPTION
- (ci): use 1.3.1 ci image version. This sets Eclipse Temurin as JDK distribution
- publish 5.3.0-RC.1
