### PR TITLE
cherry-pick SN fixes, publish RC.2

### DIFF
--- a/amf-apicontract.versions
+++ b/amf-apicontract.versions
@@ -1,6 +1,6 @@
-amf.apicontract=5.3.0-RC.1
+amf.apicontract=5.3.0-RC.2
 amf.aml=6.3.0-RC.1
 amf.model=3.8.2
-antlr4Version=0.6.22
+antlr4Version=0.6.23
 amf.validation.profile.dialect=1.4.0
 amf.validation.report.dialect=1.1.0

--- a/amf-cli/shared/src/test/resources/shape-transformation-pipeline-test/array-with-inherits/api.raml
+++ b/amf-cli/shared/src/test/resources/shape-transformation-pipeline-test/array-with-inherits/api.raml
@@ -1,0 +1,15 @@
+#%RAML 1.0
+title: asd
+version: 12
+types:
+  a:
+    type: object
+    properties:
+      b: string
+      c: string
+      d: string
+  ar:
+    type: array
+    items:
+      type: a
+    example: [b: "hello world", c: "hello world", d: "hello world"]

--- a/amf-cli/shared/src/test/resources/shape-transformation-pipeline-test/cyclic-shape/api.raml
+++ b/amf-cli/shared/src/test/resources/shape-transformation-pipeline-test/cyclic-shape/api.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: API
+version: 1.0
+types:
+  A:
+    properties:
+      nameA: string
+      b: B
+  B:
+    properties:
+      nameB: string
+      a?: A

--- a/amf-cli/shared/src/test/resources/shape-transformation-pipeline-test/shape-with-inherits/api.raml
+++ b/amf-cli/shared/src/test/resources/shape-transformation-pipeline-test/shape-with-inherits/api.raml
@@ -1,0 +1,55 @@
+#%RAML 1.0
+title: ExampleSpec
+
+types:
+  Person:
+    properties:
+      name:
+        type: string
+        default: 'John'
+      surname:
+        type: string
+        default: 'Doe'
+      age:
+        type: number
+        maximum: 120
+        minimum: 18
+      birthday:
+        type: date-only
+        displayName: 'Bday'
+      cv:
+        type: Cv
+  Cv:
+    properties:
+      application:
+        type: ApplicationType
+      file:
+        type: file
+      photo:
+        type: file
+  ApplicationType:
+    properties:
+      position:
+        enum:
+          - Developer
+          - Architect
+          - Senior Developer
+          - Principal
+          - Director
+          - Manager
+      wageRequested:
+        type: number
+      specializedIn:
+        type: array
+/cv/{id}:
+  get:
+    queryParameters:
+      bringPhoto:
+        type: boolean
+      bringWageRequested:
+        type: boolean
+    responses:
+      200:
+        body:
+          application/json:
+            type: Cv

--- a/amf-cli/shared/src/test/scala/amf/resolution/element/ShapeTransformationPipelineWithFilesTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/element/ShapeTransformationPipelineWithFilesTest.scala
@@ -1,0 +1,86 @@
+package amf.resolution.element
+
+import amf.apicontract.client.scala.{AMFConfiguration, APIConfiguration}
+import amf.core.client.common.validation.ProfileNames
+import amf.core.client.scala.errorhandling.UnhandledErrorHandler
+import amf.core.client.scala.model.document.{BaseUnit, DeclaresModel}
+import amf.core.client.scala.model.domain.Shape
+import amf.shapes.client.scala.model.domain._
+import amf.shapes.internal.domain.resolution.elements.CompleteShapeTransformationPipeline
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.ExecutionContext
+import scala.reflect.ClassTag
+
+class ShapeTransformationPipelineWithFilesTest extends AsyncFunSuite with Matchers {
+
+  override implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  val base = "file://amf-cli/shared/src/test/resources/shape-transformation-pipeline-test"
+
+  test("Array with inherits") {
+    val client = APIConfiguration.API().baseUnitClient()
+    client.parseDocument(s"$base/array-with-inherits/api.raml").flatMap { result =>
+      val conf = APIConfiguration.fromSpec(result.sourceSpec)
+      val assertion = for {
+        shape <- findShapeInDeclares[ArrayShape](result.baseUnit) { arr =>
+          arr.name.value() == "ar"
+        }
+      } yield {
+        val resolvedShape = resolveShape(shape, conf)
+        resolvedShape mustBe a[ArrayShape]
+
+        val array = resolvedShape.asInstanceOf[ArrayShape]
+
+        array.items mustBe a[NodeShape]
+
+        val node = array.items.asInstanceOf[NodeShape]
+        node.inherits should have size 0
+        node.properties should have size 3
+      }
+      assertion.getOrElse(fail("Array shape not found"))
+    }
+  }
+
+  // This explodes with SOF during link resolution that happens before Shape Normalization. This is not a regression, it
+  // was already failing in 5.2.6
+  ignore("Cyclic shape") {
+    val client = APIConfiguration.API().baseUnitClient()
+    client.parseDocument(s"$base/cyclic-shape/api.raml").flatMap { result =>
+      val conf = APIConfiguration.fromSpec(result.sourceSpec)
+      val assertion = for {
+        shape <- findShapeInDeclares[NodeShape](result.baseUnit) { node =>
+          node.name.value() == "A"
+        }
+      } yield {
+        val resolvedShape = resolveShape(shape, conf)
+        resolvedShape mustBe a[NodeShape]
+      }
+      assertion.getOrElse(fail("Array shape not found"))
+    }
+  }
+
+  private def resolveShape(shape: Shape, conf: AMFConfiguration) = {
+    val pipeline = new CompleteShapeTransformationPipeline(shape, UnhandledErrorHandler, ProfileNames.RAML10)
+    pipeline.transform(conf)
+  }
+
+  private def findShapeInDeclares[T <: Shape](
+      unit: BaseUnit
+  )(selector: T => Boolean)(implicit ct: ClassTag[T]): Option[T] = {
+    unit match {
+      case d: DeclaresModel =>
+        d.declares
+          .find {
+            case s: T => selector(s)
+            case _    => false
+          }
+          .map(_.asInstanceOf[T])
+      case _ => None
+    }
+
+  }
+
+}

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/AmfUpdaterIterator.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/AmfUpdaterIterator.scala
@@ -1,6 +1,6 @@
 package amf.shapes.internal.domain.resolution
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.client.scala.model.domain.{AmfArray, AmfElement, AmfObject, DataNode}
+import amf.core.client.scala.model.domain.{AmfArray, AmfElement, AmfObject, DataNode, Shape}
 import amf.core.client.scala.traversal.iterator.{AmfIterator, InstanceCollector, VisitedCollector}
 import amf.shapes.client.scala.model.domain.Example
 
@@ -61,5 +61,9 @@ case class AmfUpdaterIterator private (var buffer: Queue[AmfElement], updater: A
 object AmfUpdaterIterator {
   def apply(unit: BaseUnit, updater: AmfElement => AmfElement): AmfUpdaterIterator = {
     AmfUpdaterIterator(Queue(unit), updater)
+  }
+
+  def apply(shape: Shape, updater: AmfElement => AmfElement): AmfUpdaterIterator = {
+    AmfUpdaterIterator(Queue(shape), updater)
   }
 }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ShapeNormalizationForElementStage.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ShapeNormalizationForElementStage.scala
@@ -3,16 +3,70 @@ package amf.shapes.internal.domain.resolution
 import amf.core.client.common.validation.ProfileName
 import amf.core.client.scala.AMFGraphConfiguration
 import amf.core.client.scala.errorhandling.AMFErrorHandler
-import amf.core.client.scala.model.domain.Shape
+import amf.core.client.scala.model.document.BaseUnit
+import amf.core.client.scala.model.domain.{AmfObject, DomainElement, Shape}
+import amf.core.client.scala.traversal.{
+  DomainElementSelectorAdapter,
+  DomainElementTransformationAdapter,
+  TransformationData,
+  TransformationTraversal
+}
+import amf.core.client.scala.traversal.iterator.DomainElementIterator
 import amf.core.internal.transform.stages.elements.resolution.ElementStageTransformer
-import amf.shapes.internal.domain.resolution.shape_normalization.{NormalizationContext, ShapeNormalizationInheritanceResolver, ShapeNormalizationReferencesUpdater}
+import amf.core.internal.transform.stages.selectors.ShapeSelector
+import amf.shapes.internal.domain.resolution.shape_normalization.{
+  NormalizationContext,
+  ShapeNormalizationInheritanceResolver,
+  ShapeNormalizationRecursionAnalyzer,
+  ShapeNormalizationReferencesUpdater
+}
 
 class ShapeNormalizationForElementStage(context: NormalizationContext) extends ElementStageTransformer[Shape] {
 
   override def transform(shape: Shape, configuration: AMFGraphConfiguration): Option[Shape] = {
-    val resolvedInheritance = ShapeNormalizationInheritanceResolver(context).normalize(shape)
-    val fixedReferences     = ShapeNormalizationReferencesUpdater(context).updateShape(resolvedInheritance)
-    Some(fixedReferences)
+    // resolve inheritance
+    resolveInheritanceInSubTree(shape)
+
+    // update model
+    val updater = ShapeNormalizationReferencesUpdater(context)
+    updateReferencesInSubTree(shape, updater)
+
+    val updatedShape = updater.updateShape(shape)
+
+    // place recursions
+    validateAndPlaceRecursionsInSubTree(updatedShape)
+
+    Some(updatedShape)
+  }
+
+  private def validateAndPlaceRecursionsInSubTree(shape: Shape): Unit = {
+    val recursionAnalyzer = ShapeNormalizationRecursionAnalyzer(context)
+
+    def placeRecursions(element: DomainElement): Option[DomainElement] = {
+      element match {
+        case shape: Shape => Some(recursionAnalyzer.analyze(shape))
+        case other        => Some(other)
+      }
+    }
+
+    val domainElementAdapter  = new DomainElementSelectorAdapter(ShapeSelector)
+    val transformationAdapter = new DomainElementTransformationAdapter((elem, _) => placeRecursions(elem))
+    new TransformationTraversal(TransformationData(domainElementAdapter, transformationAdapter)).traverse(shape)
+  }
+
+  def resolveInheritanceInSubTree(shape: Shape): Unit = {
+    DomainElementIterator(List(shape)).foreach {
+      case s: Shape => ShapeNormalizationInheritanceResolver(context).normalize(s)
+      case _        => // nothing
+    }
+  }
+
+  private def updateReferencesInSubTree(shape: Shape, updater: ShapeNormalizationReferencesUpdater): Unit = {
+    val iterator = AmfUpdaterIterator(shape, e => updater.update(e))
+    iterator.foreach {
+      case o: AmfObject => updater.updateFields(o)
+      case _            => // skip
+    }
   }
 }
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ShapeNormalizationForElementStage.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/domain/resolution/ShapeNormalizationForElementStage.scala
@@ -29,9 +29,8 @@ class ShapeNormalizationForElementStage(context: NormalizationContext) extends E
 
     // update model
     val updater = ShapeNormalizationReferencesUpdater(context)
-    updateReferencesInSubTree(shape, updater)
-
     val updatedShape = updater.updateShape(shape)
+    updateReferencesInSubTree(updatedShape, updater)
 
     // place recursions
     validateAndPlaceRecursionsInSubTree(updatedShape)


### PR DESCRIPTION
- W-11460908: fix no iteration on element pipeline
- W-11460908: fix starting update iteration on non-updated shape
- publish 5.3.0-RC.2
