### PR TITLE
W-13191540: bump to ScalaJS 1.6 & Scala 2.12.15 & SBT 1.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
 scala:
-  - 2.12.13
+  - 2.12.15
 sbt_args: -mem 4096 -Dfile.encoding=UTF-8
 script: sbt ++$TRAVIS_SCALA_VERSION clean test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ behavior that is not occurring.
 
 ### Development Requirements
 * Scala 2.12.13
-* sbt 1.7.1
+* sbt 1.7.3
 * Node
 
 ### Version control branching

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ behavior that is not occurring.
 ## Code Contributions
 
 ### Development Requirements
-* Scala 2.12.13
+* Scala 2.12.15
 * sbt 1.7.3
 * Node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/aml-org/amf-ci-tools-base-image:1.3.1
+FROM ghcr.io/aml-org/amf-ci-tools-base-image:1.3.2

--- a/amf-antlr-syntax/js/package-lock.json
+++ b/amf-antlr-syntax/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aml-org/amf-antlr-parsers": "0.6.22",
+        "@aml-org/amf-antlr-parsers": "0.7.24",
         "ajv": "6.12.6"
       }
     },
     "node_modules/@aml-org/amf-antlr-parsers": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
-      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.7.24.tgz",
+      "integrity": "sha512-RmDT1ljRUuRvwZQViWgEUtq4OFZ8FHptFbB512ljY44+g+p4DOWm+J6MxWvx0tRuH8IYBUXsK3c5SchaWb85Lw=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@aml-org/amf-antlr-parsers": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
-      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.7.24.tgz",
+      "integrity": "sha512-RmDT1ljRUuRvwZQViWgEUtq4OFZ8FHptFbB512ljY44+g+p4DOWm+J6MxWvx0tRuH8IYBUXsK3c5SchaWb85Lw=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/amf-antlr-syntax/js/package.json
+++ b/amf-antlr-syntax/js/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/aml-org/amf"
   },
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.22",
+    "@aml-org/amf-antlr-parsers": "0.7.24",
     "ajv": "6.12.6"
   }
 }

--- a/amf-api-contract/js/package-lock.json
+++ b/amf-api-contract/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aml-org/amf-antlr-parsers": "0.6.22",
+        "@aml-org/amf-antlr-parsers": "0.7.24",
         "ajv": "6.12.6"
       }
     },
     "node_modules/@aml-org/amf-antlr-parsers": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
-      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.7.24.tgz",
+      "integrity": "sha512-RmDT1ljRUuRvwZQViWgEUtq4OFZ8FHptFbB512ljY44+g+p4DOWm+J6MxWvx0tRuH8IYBUXsK3c5SchaWb85Lw=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@aml-org/amf-antlr-parsers": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
-      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.7.24.tgz",
+      "integrity": "sha512-RmDT1ljRUuRvwZQViWgEUtq4OFZ8FHptFbB512ljY44+g+p4DOWm+J6MxWvx0tRuH8IYBUXsK3c5SchaWb85Lw=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/amf-api-contract/js/package.json
+++ b/amf-api-contract/js/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/aml-org/amf"
   },
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.22",
+    "@aml-org/amf-antlr-parsers": "0.7.24",
     "ajv": "6.12.6"
   }
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/platform/common/TypeUtil.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/platform/common/TypeUtil.scala
@@ -1,0 +1,86 @@
+package amf.apicontract.client.platform.common
+
+import amf.apicontract.internal.metamodel.domain.api.WebApiModel
+import amf.apicontract.internal.metamodel.domain.security.{
+  OAuth1SettingsModel,
+  OAuth2SettingsModel,
+  SecuritySchemeModel
+}
+import amf.apicontract.internal.metamodel.domain.{EndPointModel, RequestModel, ResponseModel, ServerModel}
+import amf.core.client.platform.model.AmfObjectWrapper
+import amf.core.client.scala.model.domain.AmfObject
+import amf.core.internal.metamodel.Type
+import amf.core.internal.metamodel.document.{BaseUnitModel, DocumentModel}
+import amf.core.internal.metamodel.domain.extensions.{CustomDomainPropertyModel, PropertyShapeModel}
+import amf.core.internal.metamodel.domain._
+import amf.shapes.internal.domain.metamodel._
+import amf.apicontract.client.scala.common.{TypeUtil => InternalTypeUtil}
+import amf.apicontract.internal.convert.ApiClientConverters._
+
+import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
+
+@JSExportTopLevel("TypeUtil")
+@JSExportAll
+object TypeUtil {
+
+  /** Checks if some AmfObject is of an specific type
+    *
+    * @param element
+    *   AmfObject to validate the type
+    * @param typeIri
+    *   IRI of the type wanted to validate. It could be one of the IRIs defined in [[TypeIRI]] or other
+    * @return
+    *   a boolean value indicating if the AmfElement is of that type (true if it is, false if not)
+    */
+  def isTypeOf(element: AmfObjectWrapper, typeIri: String): Boolean = InternalTypeUtil.isTypeOf(element, typeIri)
+
+  /** Checks if some AmfObject is of at least one type of a type list
+    *
+    * @param element
+    *   AmfObject to validate the type
+    * @param typeIris
+    *   list of IRIs of the types wanted to validate. They could be some of the IRIs defined in [[TypeIRI]] or other
+    * @return
+    *   a boolean value indicating if the AmfElement is of at least one type of the list (true if it is, false if not)
+    */
+  def isTypeOf(element: AmfObject, typeIris: Seq[String]): Boolean = {
+    typeIris.exists(typeIri => isTypeOf(element, typeIri))
+  }
+
+}
+
+@JSExportTopLevel("TypeIRI")
+@JSExportAll
+object TypeIRI {
+  val Shape: String                = getTypeIri(ShapeModel)
+  val RecursiveShape: String       = getTypeIri(RecursiveShapeModel)
+  val PropertyShape: String        = getTypeIri(PropertyShapeModel)
+  val AnyShape: String             = getTypeIri(AnyShapeModel)
+  val NodeShape: String            = getTypeIri(NodeShapeModel)
+  val ArrayShape: String           = getTypeIri(ArrayShapeModel)
+  val ScalarShape: String          = getTypeIri(ScalarShapeModel)
+  val NilShape: String             = getTypeIri(NilShapeModel)
+  val FileShape: String            = getTypeIri(FileShapeModel)
+  val SchemaShape: String          = getTypeIri(SchemaShapeModel)
+  val UnionShape: String           = getTypeIri(UnionShapeModel)
+  val MatrixShape: String          = getTypeIri(MatrixShapeModel)
+  val TupleShape: String           = getTypeIri(TupleShapeModel)
+  val Document: String             = getTypeIri(DocumentModel)
+  val BaseUnit: String             = getTypeIri(BaseUnitModel)
+  val SecurityScheme: String       = getTypeIri(SecuritySchemeModel)
+  val Request: String              = getTypeIri(RequestModel)
+  val Response: String             = getTypeIri(ResponseModel)
+  val OAuth1Settings: String       = getTypeIri(OAuth1SettingsModel)
+  val OAuth2Settings: String       = getTypeIri(OAuth2SettingsModel)
+  val EndPoint: String             = getTypeIri(EndPointModel)
+  val Server: String               = getTypeIri(ServerModel)
+  val CustomDomainProperty: String = getTypeIri(CustomDomainPropertyModel)
+  val ScalarNode: String           = getTypeIri(ScalarNodeModel)
+  val ObjectNode: String           = getTypeIri(ObjectNodeModel)
+  val ArrayNode: String            = getTypeIri(ArrayNodeModel)
+  val WebApi: String               = getTypeIri(WebApiModel)
+
+  private def getTypeIri(model: Type) = {
+    model.`type`.head.iri()
+  }
+}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/common/TypeUtil.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/common/TypeUtil.scala
@@ -1,0 +1,11 @@
+package amf.apicontract.client.scala.common
+
+import amf.core.client.scala.model.domain.AmfObject
+
+object TypeUtil {
+
+  def isTypeOf(element: AmfObject, typeIri: String): Boolean = {
+    element.meta.`type`.map(_.iri()).contains(typeIri)
+  }
+
+}

--- a/amf-api-contract/shared/src/test/scala/amf/common/TypeUtilTest.scala
+++ b/amf-api-contract/shared/src/test/scala/amf/common/TypeUtilTest.scala
@@ -1,0 +1,26 @@
+package amf.common
+
+import amf.apicontract.client.platform.common.TypeIRI
+import amf.apicontract.client.scala.common.TypeUtil
+import amf.shapes.client.scala.model.domain.{NilShape, NodeShape, ScalarShape}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class TypeUtilTest extends AnyFunSuite with Matchers {
+
+  test("Test TypeUtil NodeShape") {
+    TypeUtil.isTypeOf(NodeShape(), TypeIRI.NodeShape) shouldBe true
+  }
+
+  test("Test TypeUtil ScalarShape") {
+    TypeUtil.isTypeOf(ScalarShape(), TypeIRI.ScalarShape) shouldBe true
+  }
+
+  test("Test TypeUtil NilShape") {
+    TypeUtil.isTypeOf(NilShape(), TypeIRI.ScalarShape) shouldBe false
+    TypeUtil.isTypeOf(NilShape(), TypeIRI.Shape) shouldBe true
+    TypeUtil.isTypeOf(NilShape(), TypeIRI.NilShape) shouldBe true
+    TypeUtil.isTypeOf(NilShape(), "http://a.ml/vocabularies/shapes#NilShape") shouldBe true
+  }
+
+}

--- a/amf-apicontract.versions
+++ b/amf-apicontract.versions
@@ -1,6 +1,6 @@
 amf.apicontract=5.4.0-SNAPSHOT
 amf.aml=6.4.0-SNAPSHOT
 amf.model=3.8.2
-antlr4Version=0.6.23
+antlr4Version=0.7.24
 amf.validation.profile.dialect=1.4.0
 amf.validation.report.dialect=1.1.0

--- a/amf-cli/js/package.json
+++ b/amf-cli/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amf-client-js",
-  "version": "4.0.0",
+  "version": "5.4.0-SNAPSHOT",
   "description": "AMF Library",
   "main": "amf.js",
   "author": "amf team",
@@ -16,7 +16,7 @@
   "types": "./typings/amf-client-js.d.ts",
   "typings": "./typings/amf-client-js.d.ts",
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.22",
+    "@aml-org/amf-antlr-parsers": "0.7.24",
     "ajv": "6.12.6"
   }
 }

--- a/amf-cli/js/typings/amf-client-js.d.ts
+++ b/amf-cli/js/typings/amf-client-js.d.ts
@@ -5549,8 +5549,10 @@ declare module "amf-client-js" {
   export class ResourceLoaderFactory {
     static create(loader: ClientResourceLoader): any;
   }
-  export class ResourceNotFound {
+  export class ResourceNotFound implements FileLoaderException{
     readonly msj: string;
+    readonly code: string;
+    readonly message: string;
 
     constructor(msj: string);
   }
@@ -6991,6 +6993,57 @@ declare module "amf-client-js" {
 
     withWrapped(wrapped: boolean): this;
   }
+  export interface AmfException {
+    readonly code: string;
+    readonly message: string;
+  }
+  export interface FileLoaderException extends AmfException {}
+  export class AmfExceptionCode {
+    static readonly ResourceNotFound: "resource-not-found";
+    static readonly PathResolutionError: "path-resolution-error";
+    static readonly UnsupportedUrlScheme: "unsupported-url-scheme";
+    static readonly UnexpectedStatusCode: "unexpected-status-code";
+    static readonly NetworkError: "network-error";
+    static readonly SocketTimeout: "socket-timeout";
+    static readonly FileNotFound: "file-not-found";
+  }
+  export class ExceptionUtil {
+    static isExceptionType(exception: AmfException, exceptionCode: String): Boolean;
+  }
+  export class TypeIRI {
+    static readonly Shape: string;
+    static readonly RecursiveShape: string;
+    static readonly PropertyShape: string;
+    static readonly AnyShape: string;
+    static readonly NodeShape: string;
+    static readonly ArrayShape: string;
+    static readonly ScalarShape: string;
+    static readonly NilShape: string;
+    static readonly FileShape: string;
+    static readonly SchemaShape: string;
+    static readonly UnionShape: string;
+    static readonly MatrixShape: string;
+    static readonly TupleShape: string;
+    static readonly Document: string;
+    static readonly BaseUnit: string;
+    static readonly SecurityScheme: string;
+    static readonly Request: string;
+    static readonly Response: string;
+    static readonly OAuth1Settings: string;
+    static readonly OAuth2Settings: string;
+    static readonly EndPoint: string;
+    static readonly Server: string;
+    static readonly CustomDomainProperty: string;
+    static readonly ScalarNode: string;
+    static readonly ObjectNode: string;
+    static readonly ArrayNode: string;
+    static readonly WebApi: string;
+  }
+  export class TypeUtil {
+    static isTypeOf(element: AmfObjectWrapper, typeIri: String): Boolean;
+    static isTypeOf(element: AmfObjectWrapper, typeIri: Array<String>): Boolean;
+  }
+
   namespace org {
     namespace mulesoft {
       namespace common {

--- a/amf-cli/shared/src/main/scala/amf/cli/internal/commands/ParserConfig.scala
+++ b/amf-cli/shared/src/main/scala/amf/cli/internal/commands/ParserConfig.scala
@@ -25,7 +25,8 @@ object StdErrWriter extends ProcWriter {
 }
 
 object RuntimeProc extends Proc {
-  override def exit(statusCode: Int): Unit = System.exit(statusCode)
+  override def exit(statusCode: Int): Unit =
+    throw new RuntimeException() // Should find a suitable replacement for System.exit()
 }
 
 case class ParserConfig(

--- a/amf-graphql/js/package-lock.json
+++ b/amf-graphql/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aml-org/amf-antlr-parsers": "0.6.22",
+        "@aml-org/amf-antlr-parsers": "0.7.24",
         "ajv": "6.12.6"
       }
     },
     "node_modules/@aml-org/amf-antlr-parsers": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
-      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.7.24.tgz",
+      "integrity": "sha512-RmDT1ljRUuRvwZQViWgEUtq4OFZ8FHptFbB512ljY44+g+p4DOWm+J6MxWvx0tRuH8IYBUXsK3c5SchaWb85Lw=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@aml-org/amf-antlr-parsers": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
-      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.7.24.tgz",
+      "integrity": "sha512-RmDT1ljRUuRvwZQViWgEUtq4OFZ8FHptFbB512ljY44+g+p4DOWm+J6MxWvx0tRuH8IYBUXsK3c5SchaWb85Lw=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/amf-graphql/js/package.json
+++ b/amf-graphql/js/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/aml-org/amf"
   },
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.22",
+    "@aml-org/amf-antlr-parsers": "0.7.24",
     "ajv": "6.12.6"
   }
 }

--- a/amf-grpc/js/package-lock.json
+++ b/amf-grpc/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aml-org/amf-antlr-parsers": "0.6.22",
+        "@aml-org/amf-antlr-parsers": "0.7.24",
         "ajv": "6.12.6"
       }
     },
     "node_modules/@aml-org/amf-antlr-parsers": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
-      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.7.24.tgz",
+      "integrity": "sha512-RmDT1ljRUuRvwZQViWgEUtq4OFZ8FHptFbB512ljY44+g+p4DOWm+J6MxWvx0tRuH8IYBUXsK3c5SchaWb85Lw=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@aml-org/amf-antlr-parsers": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
-      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.7.24.tgz",
+      "integrity": "sha512-RmDT1ljRUuRvwZQViWgEUtq4OFZ8FHptFbB512ljY44+g+p4DOWm+J6MxWvx0tRuH8IYBUXsK3c5SchaWb85Lw=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/amf-grpc/js/package.json
+++ b/amf-grpc/js/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/aml-org/amf"
   },
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.22",
+    "@aml-org/amf-antlr-parsers": "0.7.24",
     "ajv": "6.12.6"
   }
 }

--- a/amf-shapes/js/package-lock.json
+++ b/amf-shapes/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aml-org/amf-antlr-parsers": "0.6.22",
+        "@aml-org/amf-antlr-parsers": "0.7.24",
         "ajv": "6.12.6"
       }
     },
     "node_modules/@aml-org/amf-antlr-parsers": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
-      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.7.24.tgz",
+      "integrity": "sha512-RmDT1ljRUuRvwZQViWgEUtq4OFZ8FHptFbB512ljY44+g+p4DOWm+J6MxWvx0tRuH8IYBUXsK3c5SchaWb85Lw=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@aml-org/amf-antlr-parsers": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.6.22.tgz",
-      "integrity": "sha512-29ZCQiNsa2DZ4CEE+FXMuro+sg+UIYDNLCj/ovlWSL1F7PBlDCMQ2DK5shd/pwM904jwSjPDQmPGFl2Z4wUFKQ=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.7.24.tgz",
+      "integrity": "sha512-RmDT1ljRUuRvwZQViWgEUtq4OFZ8FHptFbB512ljY44+g+p4DOWm+J6MxWvx0tRuH8IYBUXsK3c5SchaWb85Lw=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/amf-shapes/js/package.json
+++ b/amf-shapes/js/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/aml-org/amf"
   },
   "dependencies": {
-    "@aml-org/amf-antlr-parsers": "0.6.22",
+    "@aml-org/amf-antlr-parsers": "0.7.24",
     "ajv": "6.12.6"
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ name := "amf"
 
 ThisBuild / version      := versions("amf.apicontract")
 ThisBuild / organization := "com.github.amlorg"
-ThisBuild / scalaVersion := "2.12.13"
+ThisBuild / scalaVersion := "2.12.15"
 ThisBuild / resolvers ++= List(
   ivyLocal,
   Common.releases,
@@ -340,8 +340,8 @@ addCommandAlias(
 )
 
 ThisBuild / libraryDependencies ++= Seq(
-  compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.1" cross CrossVersion.constant("2.12.13")),
-  "com.github.ghik" % "silencer-lib" % "1.7.1" % Provided cross CrossVersion.constant("2.12.13")
+  compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.6" cross CrossVersion.constant("2.12.15")),
+  "com.github.ghik" % "silencer-lib" % "1.7.6" % Provided cross CrossVersion.constant("2.12.15")
 )
 
 lazy val sonarUrl   = sys.env.getOrElse("SONAR_SERVER_URL", "Not found url.")

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import Common.snapshots
 import NpmOpsPlugin.autoImport._
-import org.scalajs.core.tools.linker.ModuleKind
 import sbt.Keys.{libraryDependencies, resolvers}
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import sbtsonar.SonarPlugin.autoImport.sonarProperties
@@ -37,7 +36,7 @@ jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv()
 val commonSettings = Common.settings ++ Common.publish ++ Seq(
   assembly / aggregate := false,
   libraryDependencies ++= Seq(
-    "org.mule.common" %%% "scala-common-test" % "0.1.12" % Test,
+    "org.mule.common" %%% "scala-common-test" % "0.1.13" % Test,
     "org.slf4j"         % "slf4j-nop"         % "1.7.36" % Test
   ),
   Test / logBuffered := false
@@ -48,12 +47,12 @@ val amlVersion = versions("amf.aml")
 lazy val amlJVMRef = ProjectRef(Common.workspaceDirectory / "amf-aml", "amlJVM")
 lazy val amlJSRef  = ProjectRef(Common.workspaceDirectory / "amf-aml", "amlJS")
 lazy val amlLibJVM = "com.github.amlorg" %% "amf-aml"        % amlVersion
-lazy val amlLibJS  = "com.github.amlorg" %% "amf-aml_sjs0.6" % amlVersion
+lazy val amlLibJS  = "com.github.amlorg" %% "amf-aml_sjs1" % amlVersion
 
 lazy val rdfJVMRef = ProjectRef(Common.workspaceDirectory / "amf-aml", "rdfJVM")
 lazy val rdfLibJVM = "com.github.amlorg" %% "amf-rdf"        % amlVersion
 lazy val rdfJSRef  = ProjectRef(Common.workspaceDirectory / "amf-aml", "rdfJS")
-lazy val rdfLibJS  = "com.github.amlorg" %% "amf-rdf_sjs0.6" % amlVersion
+lazy val rdfLibJS  = "com.github.amlorg" %% "amf-rdf_sjs1" % amlVersion
 
 lazy val defaultProfilesGenerationTask = TaskKey[Unit](
   "defaultValidationProfilesGeneration",
@@ -71,15 +70,14 @@ lazy val shapes = crossProject(JSPlatform, JVMPlatform)
   .in(file("./amf-shapes"))
   .settings(commonSettings)
   .jvmSettings(
-    libraryDependencies += "org.scala-js"                     %% "scalajs-stubs"          % scalaJSVersion % "provided",
+    libraryDependencies += "org.scala-js"                     %% "scalajs-stubs"          % "1.1.0" % "provided",
     libraryDependencies += "com.github.everit-org.json-schema" % "org.everit.json.schema" % "1.12.2",
     libraryDependencies += "org.json"                          % "json"                   % "20230227",
     Compile / packageDoc / artifactPath := baseDirectory.value / "target" / "artifact" / "amf-shapes-javadoc.jar"
   )
   .jsSettings(
-    scalaJSModuleKind                  := ModuleKind.CommonJSModule,
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
     Compile / fullOptJS / artifactPath := baseDirectory.value / "target" / "artifact" / "amf-shapes-module.js",
-    scalacOptions += "-P:scalajs:suppressExportDeprecations",
     npmDependencies ++= npmDeps
   )
 
@@ -93,7 +91,8 @@ lazy val shapesJS =
   shapes.js
     .in(file("./amf-shapes/js"))
     .sourceDependency(amlJSRef, amlLibJS)
-    .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin, ScoverageSbtPlugin)
+    .disablePlugins(SonarPlugin, ScoverageSbtPlugin)
+//    .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin, ScoverageSbtPlugin)
 
 /** ********************************************** AMF-Api-contract *********************************************
   */
@@ -114,15 +113,14 @@ lazy val apiContract = crossProject(JSPlatform, JVMPlatform)
   )
   .dependsOn(shapes)
   .jvmSettings(
-    libraryDependencies += "org.scala-js"   %% "scalajs-stubs" % scalaJSVersion % "provided",
+    libraryDependencies += "org.scala-js"   %% "scalajs-stubs" % "1.1.0" % "provided",
     libraryDependencies += "org.reflections" % "reflections"   % "0.10.2"       % Test,
     Compile / packageDoc / artifactPath := baseDirectory.value / "target" / "artifact" / "amf-api-contract-javadoc.jar",
     Compile / packageBin / mappings += file("amf-apicontract.versions") -> "amf-apicontract.versions"
   )
   .jsSettings(
-    scalaJSModuleKind                  := ModuleKind.CommonJSModule,
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
     Compile / fullOptJS / artifactPath := baseDirectory.value / "target" / "artifact" / "amf-api-contract-module.js",
-    scalacOptions += "-P:scalajs:suppressExportDeprecations",
     npmDependencies ++= npmDeps
   )
 
@@ -133,7 +131,8 @@ lazy val apiContractJVM =
 lazy val apiContractJS =
   apiContract.js
     .in(file("./amf-api-contract/js"))
-    .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin, ScoverageSbtPlugin)
+    .disablePlugins(SonarPlugin, ScoverageSbtPlugin)
+//    .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin, ScoverageSbtPlugin)
 
 /** ********************************************** AMF-ANTLR-SYNTAX *********************************************
   */
@@ -142,7 +141,7 @@ lazy val antlrv4JVMRef = ProjectRef(Common.workspaceDirectory / "amf-antlr-ast",
 lazy val antlrv4JSRef  = ProjectRef(Common.workspaceDirectory / "amf-antlr-ast", "antlrastJS")
 val antlr4Version      = versions("antlr4Version")
 lazy val antlrv4LibJVM = "com.github.amlorg" %% "antlr-ast"        % antlr4Version
-lazy val antlrv4LibJS  = "com.github.amlorg" %% "antlr-ast_sjs0.6" % antlr4Version
+lazy val antlrv4LibJS  = "com.github.amlorg" %% "antlr-ast_sjs1" % antlr4Version
 
 lazy val antlr = crossProject(JSPlatform, JVMPlatform)
   .settings(
@@ -154,16 +153,15 @@ lazy val antlr = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .dependsOn(apiContract)
   .jvmSettings(
-    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % scalaJSVersion % "provided",
+    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % "1.1.0" % "provided",
     libraryDependencies += antlrv4LibJVM,
     Compile / packageDoc / artifactPath := baseDirectory.value / "target" / "artifact" / "amf-antlr-syntax-javadoc.jar",
     Compile / packageBin / mappings += file("amf-apicontract.versions") -> "amf-apicontract.versions"
   )
   .jsSettings(
     libraryDependencies += antlrv4LibJS,
-    scalaJSModuleKind                  := ModuleKind.CommonJSModule,
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
     Compile / fullOptJS / artifactPath := baseDirectory.value / "target" / "artifact" / "amf-antlr-syntax.js",
-    scalacOptions += "-P:scalajs:suppressExportDeprecations",
     npmDependencies ++= npmDeps
   )
 
@@ -177,7 +175,8 @@ lazy val antlrJS =
   antlr.js
     .in(file("./amf-antlr-syntax/js"))
     .sourceDependency(antlrv4JSRef, antlrv4LibJS)
-    .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin, ScoverageSbtPlugin)
+    .disablePlugins(SonarPlugin, ScoverageSbtPlugin)
+//    .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin, ScoverageSbtPlugin)
 
 /** ********************************************** AMF-GRPC *********************************************
   */
@@ -192,14 +191,14 @@ lazy val grpc = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .dependsOn(apiContract, antlr)
   .jvmSettings(
-    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % scalaJSVersion % "provided",
+    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % "1.1.0" % "provided",
     Compile / packageDoc / artifactPath   := baseDirectory.value / "target" / "artifact" / "amf-grpc-javadoc.jar",
     Compile / packageBin / mappings += file("amf-apicontract.versions") -> "amf-apicontract.versions"
   )
   .jsSettings(
-    scalaJSModuleKind                  := ModuleKind.CommonJSModule,
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
     Compile / fullOptJS / artifactPath := baseDirectory.value / "target" / "artifact" / "amf-grpc.js",
-    scalacOptions += "-P:scalajs:suppressExportDeprecations",
+
     npmDependencies ++= npmDeps
   )
 
@@ -211,7 +210,8 @@ lazy val grpcJVM =
 lazy val grpcJS =
   grpc.js
     .in(file("./amf-grpc/js"))
-    .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin, ScoverageSbtPlugin)
+    .disablePlugins(SonarPlugin, ScoverageSbtPlugin)
+//    .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin, ScoverageSbtPlugin)
 
 /** ********************************************** AMF-GRAPHQL *********************************************
   */
@@ -226,14 +226,13 @@ lazy val graphql = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .dependsOn(apiContract, antlr)
   .jvmSettings(
-    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % scalaJSVersion % "provided",
+    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % "1.1.0" % "provided",
     Compile / packageDoc / artifactPath   := baseDirectory.value / "target" / "artifact" / "amf-graphql-javadoc.jar",
     Compile / packageBin / mappings += file("amf-apicontract.versions") -> "amf-apicontract.versions"
   )
   .jsSettings(
-    scalaJSModuleKind                  := ModuleKind.CommonJSModule,
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
     Compile / fullOptJS / artifactPath := baseDirectory.value / "target" / "artifact" / "amf-graphql.js",
-    scalacOptions += "-P:scalajs:suppressExportDeprecations",
     npmDependencies ++= npmDeps
   )
 
@@ -245,7 +244,8 @@ lazy val graphqlJVM =
 lazy val graphqlJS =
   graphql.js
     .in(file("./amf-graphql/js"))
-    .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin, ScoverageSbtPlugin)
+    .disablePlugins(SonarPlugin, ScoverageSbtPlugin)
+//    .disablePlugins(SonarPlugin, ScalaJsTypingsPlugin, ScoverageSbtPlugin)
 
 /** ********************************************** AMF CLI *********************************************
   */
@@ -256,10 +256,10 @@ lazy val cli = crossProject(JSPlatform, JVMPlatform)
   .in(file("./amf-cli"))
   .settings(commonSettings)
   .settings(
-    libraryDependencies += "com.github.scopt" %%% "scopt" % "3.7.0"
+    libraryDependencies += "com.github.scopt" %%% "scopt" % "4.0.0"
   )
   .jvmSettings(
-    libraryDependencies += "org.scala-js"   %% "scalajs-stubs" % scalaJSVersion % "provided",
+    libraryDependencies += "org.scala-js"   %% "scalajs-stubs" % "1.1.0" % "provided",
     libraryDependencies += "org.reflections" % "reflections"   % "0.10.2",
     Compile / mainClass                     := Some("amf.cli.client.Main"),
     Compile / packageBin / packageOptions += Package.ManifestAttributes("Automatic-Module-Name" → "org.mule.amf"),
@@ -285,11 +285,12 @@ lazy val cli = crossProject(JSPlatform, JVMPlatform)
     addArtifact(assembly / artifact, assembly)
   )
   .jsSettings(
-    scalaJSModuleKind                  := ModuleKind.CommonJSModule,
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
     Compile / fullOptJS / artifactPath := baseDirectory.value / "amf.js",
-    npmDependencies ++= npmDeps
+    npmDependencies ++= npmDeps,
+    jsDependencies += rdfLibJS / "shacl.js" % "test"
   )
-  .jsSettings(TypingGenerationSettings.settings: _*)
+//  .jsSettings(TypingGenerationSettings.settings: _*)
 
 lazy val cliJVM = cli.jvm.in(file("./amf-cli/jvm")).sourceDependency(rdfJVMRef % "test", rdfLibJVM % "test")
 
@@ -297,6 +298,7 @@ lazy val cliJS = cli.js
   .in(file("./amf-cli/js"))
   .sourceDependency(rdfJSRef % "test", rdfLibJS % "test")
   .disablePlugins(SonarPlugin, ScoverageSbtPlugin)
+  .enablePlugins(JSDependenciesPlugin)
 
 /** ********************************************** AD-HOC CLI *********************************************
   */
@@ -308,7 +310,7 @@ lazy val adhocCli = (project in file("adhoc-cli"))
     libraryDependencies += "com.github.amlorg" %% "amf-validation-profile-dialect" % versions("amf.validation.profile.dialect"),
     libraryDependencies += "com.github.amlorg" %% "amf-validation-report-dialect"  % versions("amf.validation.report.dialect"),
     libraryDependencies += "commons-io"         % "commons-io"                     % "2.11.0",
-    libraryDependencies += "org.mule.common"  %%% "scala-common-test"              % "0.0.10" % Test
+    libraryDependencies += "org.mule.common"  %%% "scala-common-test"              % "0.1.13" % Test
   )
   .settings(
     assembly / aggregate          := true,

--- a/project/NpmOpsPlugin.scala
+++ b/project/NpmOpsPlugin.scala
@@ -1,5 +1,5 @@
 import org.scalajs.sbtplugin.ScalaJSPlugin
-import org.scalajs.sbtplugin.ScalaJSPlugin.AutoImport.{fastOptJS, fullOptJS}
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.{fastLinkJS, fullLinkJS}
 import sbt.Keys.{baseDirectory, sLog}
 import sbt.util.Logger
 import sbt.{AutoPlugin, Compile, Def, Test, settingKey, taskKey}
@@ -15,9 +15,9 @@ object NpmOpsPlugin extends AutoPlugin {
 
   object autoImport {
     val npmLinkDependencies = settingKey[List[String]]("List of npm dependencies to link")
-    val npmDependencies = settingKey[List[(String, String)]]("List of npm dependencies name and version")
-    val npmInstallDeps  = taskKey[Unit]("Install NPM dependencies if not installed")
-    val npmPackageLoc   = settingKey[File]("Path to the location of the packages' 'package.json'")
+    val npmDependencies     = settingKey[List[(String, String)]]("List of npm dependencies name and version")
+    val npmInstallDeps      = taskKey[Unit]("Install NPM dependencies if not installed")
+    val npmPackageLoc       = settingKey[File]("Path to the location of the packages' 'package.json'")
   }
 
   import autoImport._
@@ -59,13 +59,13 @@ object NpmOpsPlugin extends AutoPlugin {
     deps.map(tuple => s"${tuple._1}@${tuple._2}")
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    npmInstallDeps      := npmInstallDepsTask.value,
-    npmDependencies     := Nil,
-    npmLinkDependencies := Nil,
-    npmPackageLoc       := baseDirectory.value,
-    Compile / fastOptJS := (Compile / fastOptJS).dependsOn(npmInstallDepsTask).value,
-    Compile / fullOptJS := (Compile / fullOptJS).dependsOn(npmInstallDepsTask).value,
-    Test / fastOptJS    := (Test / fastOptJS).dependsOn(npmInstallDepsTask).value,
-    Test / fullOptJS    := (Test / fullOptJS).dependsOn(npmInstallDepsTask).value
+    npmInstallDeps       := npmInstallDepsTask.value,
+    npmDependencies      := Nil,
+    npmLinkDependencies  := Nil,
+    npmPackageLoc        := baseDirectory.value,
+    Compile / fastLinkJS := (Compile / fastLinkJS).dependsOn(npmInstallDepsTask).value,
+    Compile / fullLinkJS := (Compile / fullLinkJS).dependsOn(npmInstallDepsTask).value,
+    Test / fastLinkJS    := (Test / fastLinkJS).dependsOn(npmInstallDepsTask).value,
+    Test / fullLinkJS    := (Test / fullLinkJS).dependsOn(npmInstallDepsTask).value
   )
 }

--- a/project/TypingGenerationSettings.scala
+++ b/project/TypingGenerationSettings.scala
@@ -1,72 +1,72 @@
-import org.mulesoft.typings.generation.ScalaClassFilterBuilder
-import org.mulesoft.typings.plugin.ScalaJsTypingsPlugin.autoImport.{
-  customMappings,
-  namespaceReplacer,
-  namespaceTopLevelExports,
-  scalaFilteredClasses,
-  typingModuleName,
-  formattingCmd
-}
-import org.mulesoft.typings.resolution.BuiltInMappings.{dictionary, option, overwrite}
-import org.mulesoft.typings.resolution.MappingFactory
-import org.mulesoft.typings.resolution.namespace.PrefixNamespaceReplacer
+//import org.mulesoft.typings.generation.ScalaClassFilterBuilder
+//import org.mulesoft.typings.plugin.ScalaJsTypingsPlugin.autoImport.{
+//  customMappings,
+//  namespaceReplacer,
+//  namespaceTopLevelExports,
+//  scalaFilteredClasses,
+//  typingModuleName,
+//  formattingCmd
+//}
+//import org.mulesoft.typings.resolution.BuiltInMappings.{dictionary, option, overwrite}
+//import org.mulesoft.typings.resolution.MappingFactory
+//import org.mulesoft.typings.resolution.namespace.PrefixNamespaceReplacer
 import sbt.SettingsDefinition
 
 object TypingGenerationSettings {
 
   val settings: Seq[SettingsDefinition] = Seq(
-    typingModuleName         := typingsModuleName,
-    customMappings           := typingsCustomMappings,
-    namespaceReplacer        := typingsNamespaceReplacer,
-    scalaFilteredClasses     := typingsFilters,
-    formattingCmd            := Some("npx prettier --write amf-cli/js/@types/amf.d.ts"),
-    namespaceTopLevelExports := false
+//    typingModuleName         := typingsModuleName,
+//    customMappings           := typingsCustomMappings,
+//    namespaceReplacer        := typingsNamespaceReplacer,
+//    scalaFilteredClasses     := typingsFilters,
+//    formattingCmd            := Some("npx prettier --write amf-cli/js/@types/amf.d.ts"),
+//    namespaceTopLevelExports := false
   )
 
-  def typingsModuleName: String = "amf-client-js"
-
-  def typingsCustomMappings: MappingFactory =
-    MappingFactory()
-      .map("ClientList")
-      .to("Array")
-      .map("ClientFuture")
-      .to("Promise")
-      .map("AmfCustomClass")
-      .to("AnotherCustomClass")
-      .map("ClientOption")
-      .to(option())
-      .map("ClientMap")
-      .to(dictionary())
-      .map("AnyVal")
-      .to("any")
-      .map("DocBuilder")
-      .to(overwrite("JsOutputBuilder"))
-      .map("Unit")
-      .to("void")
-
-  def typingsNamespaceReplacer: PrefixNamespaceReplacer = PrefixNamespaceReplacer("amf\\.client\\.", "")
-
-  def typingsFilters: ScalaClassFilterBuilder =
-    ScalaClassFilterBuilder()
-      .withClassFilter("^.*\\.JsFs$")
-      .withClassFilter("^.*\\.SysError$")
-      .withClassFilter("^.*\\.Main.*$")
-      .withClassFilter("^.*\\.Https$")
-      .withClassFilter("^.*\\.Http$")
-      .withClassFilter("^.*\\.LimitedStringBuffer$")
-      .withClassFilter("^.*\\..*Platform.*$")
-      .withClassFilter("^amf\\.graphql\\..*")
-      .withClassFilter("^amf\\.grpc\\..*")
-      .withClassFilter("^amf\\.antlr\\..*")
-      .withClassFilter("^amf\\.rdf\\..*")
-      .withClassFilter("^org\\.mulesoft\\.antlrast\\..*")
-      .withTypeFilter("^.*$", "Option")
-      .withTypeFilter("^.*$", "BaseExecutionEnvironment")
-      .withTypeFilter("^.*$", "InputRange")
-      .withTypeFilter("^.*$", "Seq")
-      .withTypeFilter("^.*$", "ExecutionContext")
-      .withTypeFilter("^.*$", "AmfObjectWrapper")
-      .withTypeFilter("^.*$", "StringBuffer")
-      .withMethodFilter("^.*\\.ValidationReport$", "toString")
-      .withMethodFilter("^.*$", "+")
+//  def typingsModuleName: String = "amf-client-js"
+//
+//  def typingsCustomMappings: MappingFactory =
+//    MappingFactory()
+//      .map("ClientList")
+//      .to("Array")
+//      .map("ClientFuture")
+//      .to("Promise")
+//      .map("AmfCustomClass")
+//      .to("AnotherCustomClass")
+//      .map("ClientOption")
+//      .to(option())
+//      .map("ClientMap")
+//      .to(dictionary())
+//      .map("AnyVal")
+//      .to("any")
+//      .map("DocBuilder")
+//      .to(overwrite("JsOutputBuilder"))
+//      .map("Unit")
+//      .to("void")
+//
+//  def typingsNamespaceReplacer: PrefixNamespaceReplacer = PrefixNamespaceReplacer("amf\\.client\\.", "")
+//
+//  def typingsFilters: ScalaClassFilterBuilder =
+//    ScalaClassFilterBuilder()
+//      .withClassFilter("^.*\\.JsFs$")
+//      .withClassFilter("^.*\\.SysError$")
+//      .withClassFilter("^.*\\.Main.*$")
+//      .withClassFilter("^.*\\.Https$")
+//      .withClassFilter("^.*\\.Http$")
+//      .withClassFilter("^.*\\.LimitedStringBuffer$")
+//      .withClassFilter("^.*\\..*Platform.*$")
+//      .withClassFilter("^amf\\.graphql\\..*")
+//      .withClassFilter("^amf\\.grpc\\..*")
+//      .withClassFilter("^amf\\.antlr\\..*")
+//      .withClassFilter("^amf\\.rdf\\..*")
+//      .withClassFilter("^org\\.mulesoft\\.antlrast\\..*")
+//      .withTypeFilter("^.*$", "Option")
+//      .withTypeFilter("^.*$", "BaseExecutionEnvironment")
+//      .withTypeFilter("^.*$", "InputRange")
+//      .withTypeFilter("^.*$", "Seq")
+//      .withTypeFilter("^.*$", "ExecutionContext")
+//      .withTypeFilter("^.*$", "AmfObjectWrapper")
+//      .withTypeFilter("^.*$", "StringBuffer")
+//      .withMethodFilter("^.*\\.ValidationReport$", "toString")
+//      .withMethodFilter("^.*$", "+")
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,17 +1,18 @@
 import metabuild.Common
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.33")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.6.0")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"            % "2.0.4")
 addSbtPlugin("com.sonar-scala"    % "sbt-sonar"                % "2.3.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-sriracha"             % "0.1.0")
 addSbtPlugin("net.virtual-void"   % "sbt-dependency-graph"     % "0.10.0-RC1")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.10.0")
+addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.2")
 
 resolvers ++= List(Common.releases, Common.snapshots, Resolver.mavenLocal, Resolver.mavenCentral)
 credentials ++= Common.credentials()
 
-addSbtPlugin("com.github.amlorg" % "scala-js-typings" % "0.0.18")
+//addSbtPlugin("com.github.amlorg" % "scala-js-typings" % "0.0.18")
 
 ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
- bump sbt version to 1.7.3
- bump amf-ci-tools to 1.3.2
- W-13139981 - Added TypeUtil to allow to identify types from JS
- W-13139981 - Add typings
- W-13139981 - Fix typings
- adopt amf-antlr version 0.7.24
- fix TypeUtil classes
- bump ScalaJS to 1.6.0, disable typings plugin
- bump scala version to 2.12.15
