### PR TITLE
(hf): publish 5.4.1-1. Previous commit failed because I hadn't changed the version

### DIFF
--- a/amf-apicontract.versions
+++ b/amf-apicontract.versions
@@ -1,4 +1,4 @@
-amf.apicontract=5.4.1-0
+amf.apicontract=5.4.1-1
 amf.aml=6.4.1-0
 amf.model=3.8.2
 antlr4Version=0.7.25


### PR DESCRIPTION
- W-11460908: update ruleset dialect version
- W-13841580 (feat): parse string values with date and date-time formats as dates so they are emitted in the json-ld correctly
- W-13813016 (feat): added interfaces for 'withProperty' for date-time values
- W-13813016: avoid re adopt web api at examplesresolution stage (#1842)
- (hf): publish 5.4.1-1. Previous commit failed because I hadn't changed the version
