### PR TITLE
'any' can't override bugs

### DIFF
--- a/amf-cli/shared/src/test/resources/upanddown/raml10/array-override/api.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/array-override/api.jsonld
@@ -1,0 +1,737 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#17",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "Invoice API"
+          }
+        ],
+        "apiContract:accepts": [
+          {
+            "@value": "application/json"
+          }
+        ],
+        "apiContract:contentType": [
+          {
+            "@value": "application/json"
+          }
+        ],
+        "smaps": {
+          "single-value-array": {
+            "apiContract:contentType": "",
+            "apiContract:accepts": ""
+          },
+          "lexical": {
+            "apiContract:contentType": "[(3,0)-(5,0)]",
+            "core:name": "[(2,0)-(3,0)]",
+            "#17": "[(2,0)-(22,0)]",
+            "apiContract:accepts": "[(3,0)-(5,0)]"
+          }
+        }
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#16",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.2"
+          }
+        ],
+        "doc:transformed": [
+          {
+            "@value": true
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "RAML 1.0"
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#1",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:closed": [
+          {
+            "@value": false
+          }
+        ],
+        "shacl:property": [
+          {
+            "@id": "#2",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#grandParentProp"
+              }
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#3",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "grandParentProp"
+                  }
+                ],
+                "smaps": {
+                  "lexical": {
+                    "shacl:datatype": "[(8,23)-(8,29)]",
+                    "#3": "[(8,6)-(10,0)]"
+                  }
+                }
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "grandParentProp"
+              }
+            ],
+            "smaps": {
+              "synthesized-field": {
+                "shacl:minCount": "true",
+                "shacl:path": "true"
+              },
+              "lexical": {
+                "raml-shapes:range": "[(8,23)-(8,29)]",
+                "#2": "[(8,6)-(10,0)]"
+              },
+              "inheritance-provenance": {
+                "#2": "amf://id#1"
+              }
+            }
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "GrandParent"
+          }
+        ],
+        "smaps": {
+          "synthesized-field": {
+            "shacl:closed": "true"
+          },
+          "resolved-link": {
+            "#1": "amf://id#4"
+          },
+          "lexical": {
+            "shacl:name": "[(6,2)-(6,13)]",
+            "#1": "[(6,2)-(10,0)]"
+          },
+          "declared-element": {
+            "#1": ""
+          },
+          "resolved-link-target": {
+            "#1": "amf://id#1"
+          }
+        }
+      },
+      {
+        "@id": "#5",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:closed": [
+          {
+            "@value": false
+          }
+        ],
+        "shacl:property": [
+          {
+            "@id": "#6",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#parentProp"
+              }
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#7",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "parentProp"
+                  }
+                ],
+                "smaps": {
+                  "lexical": {
+                    "shacl:datatype": "[(13,18)-(13,24)]",
+                    "#7": "[(13,6)-(15,0)]"
+                  }
+                }
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "parentProp"
+              }
+            ],
+            "smaps": {
+              "synthesized-field": {
+                "shacl:minCount": "true",
+                "shacl:path": "true"
+              },
+              "lexical": {
+                "raml-shapes:range": "[(13,18)-(13,24)]",
+                "#6": "[(13,6)-(15,0)]"
+              },
+              "inheritance-provenance": {
+                "#6": "amf://id#5"
+              }
+            }
+          },
+          {
+            "@id": "#2",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#grandParentProp"
+              }
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#3",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "grandParentProp"
+                  }
+                ],
+                "smaps": {
+                  "lexical": {
+                    "shacl:datatype": "[(8,23)-(8,29)]",
+                    "#3": "[(8,6)-(10,0)]"
+                  }
+                }
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "grandParentProp"
+              }
+            ],
+            "smaps": {
+              "synthesized-field": {
+                "shacl:minCount": "true",
+                "shacl:path": "true"
+              },
+              "lexical": {
+                "raml-shapes:range": "[(8,23)-(8,29)]",
+                "#2": "[(8,6)-(10,0)]"
+              },
+              "inheritance-provenance": {
+                "#2": "amf://id#1"
+              }
+            }
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Parent"
+          }
+        ],
+        "smaps": {
+          "synthesized-field": {
+            "shacl:closed": "true"
+          },
+          "resolved-link-target": {
+            "#5": "amf://id#5"
+          },
+          "declared-element": {
+            "#5": ""
+          },
+          "lexical": {
+            "shacl:name": "[(10,2)-(10,8)]",
+            "#5": "[(10,2)-(15,0)]"
+          },
+          "type-property-lexical-info": {
+            "#5": "[(11,4)-(11,8)]"
+          },
+          "resolved-link": {
+            "#5": "amf://id#8"
+          },
+          "inherited-shapes": {
+            "#5": "amf://id#1"
+          }
+        }
+      },
+      {
+        "@id": "#9",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:closed": [
+          {
+            "@value": false
+          }
+        ],
+        "shacl:property": [
+          {
+            "@id": "#10",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#anotherProp"
+              }
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#11",
+                "@type": [
+                  "raml-shapes:ScalarShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:datatype": [
+                  {
+                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "anotherProp"
+                  }
+                ],
+                "smaps": {
+                  "lexical": {
+                    "shacl:datatype": "[(17,19)-(17,25)]",
+                    "#11": "[(17,6)-(19,0)]"
+                  }
+                }
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "anotherProp"
+              }
+            ],
+            "smaps": {
+              "synthesized-field": {
+                "shacl:minCount": "true",
+                "shacl:path": "true"
+              },
+              "lexical": {
+                "raml-shapes:range": "[(17,19)-(17,25)]",
+                "#10": "[(17,6)-(19,0)]"
+              }
+            }
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Another"
+          }
+        ],
+        "smaps": {
+          "synthesized-field": {
+            "shacl:closed": "true"
+          },
+          "resolved-link": {
+            "#9": "amf://id#12"
+          },
+          "lexical": {
+            "shacl:name": "[(15,2)-(15,9)]",
+            "#9": "[(15,2)-(19,0)]"
+          },
+          "declared-element": {
+            "#9": ""
+          },
+          "resolved-link-target": {
+            "#9": "amf://id#9"
+          }
+        }
+      },
+      {
+        "@id": "#13",
+        "@type": [
+          "raml-shapes:ArrayShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "raml-shapes:items": [
+          {
+            "@id": "#14",
+            "@type": [
+              "shacl:NodeShape",
+              "raml-shapes:AnyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:closed": [
+              {
+                "@value": false
+              }
+            ],
+            "shacl:property": [
+              {
+                "@id": "#10",
+                "@type": [
+                  "shacl:PropertyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#anotherProp"
+                  }
+                ],
+                "raml-shapes:range": [
+                  {
+                    "@id": "#11",
+                    "@type": [
+                      "raml-shapes:ScalarShape",
+                      "raml-shapes:AnyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "shacl:datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "anotherProp"
+                      }
+                    ],
+                    "smaps": {
+                      "lexical": {
+                        "shacl:datatype": "[(17,19)-(17,25)]",
+                        "#11": "[(17,6)-(19,0)]"
+                      }
+                    }
+                  }
+                ],
+                "shacl:minCount": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "anotherProp"
+                  }
+                ],
+                "smaps": {
+                  "synthesized-field": {
+                    "shacl:minCount": "true",
+                    "shacl:path": "true"
+                  },
+                  "lexical": {
+                    "raml-shapes:range": "[(17,19)-(17,25)]",
+                    "#10": "[(17,6)-(19,0)]"
+                  }
+                }
+              },
+              {
+                "@id": "#6",
+                "@type": [
+                  "shacl:PropertyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#parentProp"
+                  }
+                ],
+                "raml-shapes:range": [
+                  {
+                    "@id": "#7",
+                    "@type": [
+                      "raml-shapes:ScalarShape",
+                      "raml-shapes:AnyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "shacl:datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "parentProp"
+                      }
+                    ],
+                    "smaps": {
+                      "lexical": {
+                        "shacl:datatype": "[(13,18)-(13,24)]",
+                        "#7": "[(13,6)-(15,0)]"
+                      }
+                    }
+                  }
+                ],
+                "shacl:minCount": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "parentProp"
+                  }
+                ],
+                "smaps": {
+                  "synthesized-field": {
+                    "shacl:minCount": "true",
+                    "shacl:path": "true"
+                  },
+                  "lexical": {
+                    "raml-shapes:range": "[(13,18)-(13,24)]",
+                    "#6": "[(13,6)-(15,0)]"
+                  },
+                  "inheritance-provenance": {
+                    "#6": "amf://id#5"
+                  }
+                }
+              },
+              {
+                "@id": "#2",
+                "@type": [
+                  "shacl:PropertyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#grandParentProp"
+                  }
+                ],
+                "raml-shapes:range": [
+                  {
+                    "@id": "#3",
+                    "@type": [
+                      "raml-shapes:ScalarShape",
+                      "raml-shapes:AnyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "shacl:datatype": [
+                      {
+                        "@id": "http://www.w3.org/2001/XMLSchema#string"
+                      }
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "grandParentProp"
+                      }
+                    ],
+                    "smaps": {
+                      "lexical": {
+                        "shacl:datatype": "[(8,23)-(8,29)]",
+                        "#3": "[(8,6)-(10,0)]"
+                      }
+                    }
+                  }
+                ],
+                "shacl:minCount": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "grandParentProp"
+                  }
+                ],
+                "smaps": {
+                  "synthesized-field": {
+                    "shacl:minCount": "true",
+                    "shacl:path": "true"
+                  },
+                  "lexical": {
+                    "raml-shapes:range": "[(8,23)-(8,29)]",
+                    "#2": "[(8,6)-(10,0)]"
+                  },
+                  "inheritance-provenance": {
+                    "#2": "amf://id#1"
+                  }
+                }
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "Another"
+              }
+            ],
+            "smaps": {
+              "synthesized-field": {
+                "shacl:closed": "true"
+              },
+              "resolved-link-target": {
+                "#14": "amf://id#9"
+              },
+              "declared-element": {
+                "#14": ""
+              },
+              "lexical": {
+                "shacl:name": "[(15,2)-(15,9)]",
+                "#14": "[(15,2)-(19,0)]"
+              },
+              "resolved-link": {
+                "#14": "amf://id#12"
+              },
+              "inherited-shapes": {
+                "#14": "amf://id#5"
+              }
+            }
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "MyArray"
+          }
+        ],
+        "smaps": {
+          "inherited-shapes": {
+            "#13": "amf://id#15"
+          },
+          "type-property-lexical-info": {
+            "#13": "[(20,4)-(20,8)]"
+          },
+          "lexical": {
+            "shacl:name": "[(19,2)-(19,9)]",
+            "#13": "[(19,2)-(22,0)]"
+          },
+          "declared-element": {
+            "#13": ""
+          }
+        }
+      }
+    ],
+    "@context": {
+      "@base": "amf://id",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/array-override/api.raml
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/array-override/api.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0
+title: Invoice API
+mediaType: application/json
+
+types:
+  GrandParent:
+    properties:
+      grandParentProp: string
+
+  Parent:
+    type: GrandParent
+    properties:
+      parentProp: string
+
+  Another:
+    properties:
+      anotherProp: string
+
+  MyArray:
+    type: Parent[]
+    items: Another

--- a/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/A.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/A.raml
@@ -1,0 +1,6 @@
+#%RAML 1.0 DataType
+type: !include B.raml
+properties:
+  data:
+    type: array
+    items: object

--- a/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/B.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/B.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 DataType
+type: !include C.raml
+properties:
+  data:
+    type: array
+    items: any
+

--- a/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/C.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/C.raml
@@ -1,0 +1,4 @@
+#%RAML 1.0 DataType
+properties:
+  data:
+    type: any

--- a/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/api.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/api.jsonld
@@ -1,0 +1,677 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:encodes": [
+      {
+        "@id": "#22",
+        "@type": [
+          "apiContract:WebAPI",
+          "apiContract:API",
+          "doc:RootDomainElement",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "API"
+          }
+        ],
+        "core:version": [
+          {
+            "@value": "1.0.0"
+          }
+        ],
+        "smaps": {
+          "lexical": {
+            "core:version": "[(3,0)-(5,0)]",
+            "#22": "[(2,0)-(7,0)]",
+            "core:name": "[(2,0)-(3,0)]"
+          }
+        }
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#21",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.2"
+          }
+        ],
+        "doc:transformed": [
+          {
+            "@value": true
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "RAML 1.0"
+          }
+        ]
+      }
+    ],
+    "doc:references": [
+      {
+        "@id": "#1",
+        "@type": [
+          "raml-shapes:DataTypeFragment",
+          "doc:Fragment",
+          "doc:Unit"
+        ],
+        "doc:encodes": [
+          {
+            "@id": "#16",
+            "@type": [
+              "shacl:NodeShape",
+              "raml-shapes:AnyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:closed": [
+              {
+                "@value": false
+              }
+            ],
+            "shacl:property": [
+              {
+                "@id": "#17",
+                "@type": [
+                  "shacl:PropertyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:path": [
+                  {
+                    "@id": "http://a.ml/vocabularies/data#data"
+                  }
+                ],
+                "raml-shapes:range": [
+                  {
+                    "@id": "#18",
+                    "@type": [
+                      "raml-shapes:ArrayShape",
+                      "raml-shapes:AnyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "raml-shapes:items": [
+                      {
+                        "@id": "#19",
+                        "@type": [
+                          "shacl:NodeShape",
+                          "raml-shapes:AnyShape",
+                          "shacl:Shape",
+                          "raml-shapes:Shape",
+                          "doc:DomainElement"
+                        ],
+                        "shacl:name": [
+                          {
+                            "@value": "items"
+                          }
+                        ],
+                        "smaps": {
+                          "lexical": {
+                            "#19": "[(6,4)-(7,0)]"
+                          }
+                        }
+                      }
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "data"
+                      }
+                    ],
+                    "smaps": {
+                      "inherited-shapes": {
+                        "#18": "amf://id#12,amf://id#12"
+                      },
+                      "lexical": {
+                        "#18": "[(4,2)-(7,0)]"
+                      },
+                      "type-property-lexical-info": {
+                        "#18": "[(5,4)-(5,8)]"
+                      }
+                    }
+                  }
+                ],
+                "shacl:minCount": [
+                  {
+                    "@value": 1
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "data"
+                  }
+                ],
+                "smaps": {
+                  "synthesized-field": {
+                    "shacl:minCount": "true",
+                    "shacl:path": "true"
+                  },
+                  "lexical": {
+                    "raml-shapes:range": "[(4,7)-(7,0)]",
+                    "#17": "[(4,2)-(7,0)]"
+                  },
+                  "inherited-shapes": {
+                    "#17": "amf://id#11,amf://id#11"
+                  }
+                }
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "type"
+              }
+            ],
+            "smaps": {
+              "synthesized-field": {
+                "shacl:closed": "true"
+              },
+              "type-property-lexical-info": {
+                "#16": "[(2,0)-(2,4)]"
+              },
+              "lexical": {
+                "#16": "[(2,0)-(7,0)]"
+              },
+              "inherited-shapes": {
+                "#16": "amf://id#10"
+              }
+            }
+          }
+        ],
+        "doc:references": [
+          {
+            "@id": "#2",
+            "@type": [
+              "raml-shapes:DataTypeFragment",
+              "doc:Fragment",
+              "doc:Unit"
+            ],
+            "doc:encodes": [
+              {
+                "@id": "#10",
+                "@type": [
+                  "shacl:NodeShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "shacl:closed": [
+                  {
+                    "@value": false
+                  }
+                ],
+                "shacl:property": [
+                  {
+                    "@id": "#11",
+                    "@type": [
+                      "shacl:PropertyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "shacl:path": [
+                      {
+                        "@id": "http://a.ml/vocabularies/data#data"
+                      }
+                    ],
+                    "raml-shapes:range": [
+                      {
+                        "@id": "#12",
+                        "@type": [
+                          "raml-shapes:ArrayShape",
+                          "raml-shapes:AnyShape",
+                          "shacl:Shape",
+                          "raml-shapes:Shape",
+                          "doc:DomainElement"
+                        ],
+                        "raml-shapes:items": [
+                          {
+                            "@id": "#13",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "shacl:name": [
+                              {
+                                "@value": "items"
+                              }
+                            ],
+                            "smaps": {
+                              "lexical": {
+                                "#13": "[(6,4)-(8,0)]"
+                              }
+                            }
+                          }
+                        ],
+                        "shacl:name": [
+                          {
+                            "@value": "data"
+                          }
+                        ],
+                        "smaps": {
+                          "type-property-lexical-info": {
+                            "#12": "[(5,4)-(5,8)]"
+                          },
+                          "lexical": {
+                            "#12": "[(4,2)-(8,0)]"
+                          }
+                        }
+                      }
+                    ],
+                    "shacl:minCount": [
+                      {
+                        "@value": 1
+                      }
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "data"
+                      }
+                    ],
+                    "smaps": {
+                      "synthesized-field": {
+                        "shacl:minCount": "true",
+                        "shacl:path": "true"
+                      },
+                      "lexical": {
+                        "raml-shapes:range": "[(4,7)-(8,0)]",
+                        "#11": "[(4,2)-(8,0)]"
+                      },
+                      "inherited-shapes": {
+                        "#11": "amf://id#6"
+                      }
+                    }
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "type"
+                  }
+                ],
+                "smaps": {
+                  "synthesized-field": {
+                    "shacl:closed": "true"
+                  },
+                  "resolved-link-target": {
+                    "#10": "amf://id#10"
+                  },
+                  "auto-generated-name": {
+                    "#10": ""
+                  },
+                  "lexical": {
+                    "#10": "[(2,0)-(8,0)]"
+                  },
+                  "type-property-lexical-info": {
+                    "#10": "[(2,0)-(2,4)]"
+                  },
+                  "resolved-link": {
+                    "#10": "amf://id#14"
+                  },
+                  "inherited-shapes": {
+                    "#10": "amf://id#5"
+                  }
+                }
+              }
+            ],
+            "doc:references": [
+              {
+                "@id": "#3",
+                "@type": [
+                  "raml-shapes:DataTypeFragment",
+                  "doc:Fragment",
+                  "doc:Unit"
+                ],
+                "doc:encodes": [
+                  {
+                    "@id": "#5",
+                    "@type": [
+                      "shacl:NodeShape",
+                      "raml-shapes:AnyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "shacl:closed": [
+                      {
+                        "@value": false
+                      }
+                    ],
+                    "shacl:property": [
+                      {
+                        "@id": "#6",
+                        "@type": [
+                          "shacl:PropertyShape",
+                          "shacl:Shape",
+                          "raml-shapes:Shape",
+                          "doc:DomainElement"
+                        ],
+                        "shacl:path": [
+                          {
+                            "@id": "http://a.ml/vocabularies/data#data"
+                          }
+                        ],
+                        "raml-shapes:range": [
+                          {
+                            "@id": "#7",
+                            "@type": [
+                              "raml-shapes:AnyShape",
+                              "shacl:Shape",
+                              "raml-shapes:Shape",
+                              "doc:DomainElement"
+                            ],
+                            "shacl:name": [
+                              {
+                                "@value": "data"
+                              }
+                            ],
+                            "smaps": {
+                              "type-property-lexical-info": {
+                                "#7": "[(4,4)-(4,8)]"
+                              },
+                              "lexical": {
+                                "#7": "[(3,2)-(5,0)]"
+                              }
+                            }
+                          }
+                        ],
+                        "shacl:minCount": [
+                          {
+                            "@value": 1
+                          }
+                        ],
+                        "shacl:name": [
+                          {
+                            "@value": "data"
+                          }
+                        ],
+                        "smaps": {
+                          "synthesized-field": {
+                            "shacl:minCount": "true",
+                            "shacl:path": "true"
+                          },
+                          "lexical": {
+                            "raml-shapes:range": "[(3,7)-(5,0)]",
+                            "#6": "[(3,2)-(5,0)]"
+                          }
+                        }
+                      }
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "type"
+                      }
+                    ],
+                    "smaps": {
+                      "synthesized-field": {
+                        "shacl:closed": "true"
+                      },
+                      "resolved-link": {
+                        "#5": "amf://id#8"
+                      },
+                      "lexical": {
+                        "#5": "[(2,0)-(5,0)]"
+                      },
+                      "auto-generated-name": {
+                        "#5": ""
+                      },
+                      "resolved-link-target": {
+                        "#5": "amf://id#5"
+                      }
+                    }
+                  }
+                ],
+                "doc:root": [
+                  {
+                    "@value": false
+                  }
+                ],
+                "doc:processingData": [
+                  {
+                    "@id": "#4",
+                    "@type": [
+                      "doc:APIContractProcessingData"
+                    ],
+                    "apiContract:modelVersion": [
+                      {
+                        "@value": "3.8.2"
+                      }
+                    ],
+                    "doc:sourceSpec": [
+                      {
+                        "@value": "RAML 1.0"
+                      }
+                    ]
+                  }
+                ],
+                "smaps": {
+                  "lexical": {
+                    "#3": "[(1,0)-(5,0)]"
+                  }
+                }
+              }
+            ],
+            "doc:root": [
+              {
+                "@value": false
+              }
+            ],
+            "doc:processingData": [
+              {
+                "@id": "#9",
+                "@type": [
+                  "doc:APIContractProcessingData"
+                ],
+                "apiContract:modelVersion": [
+                  {
+                    "@value": "3.8.2"
+                  }
+                ],
+                "doc:sourceSpec": [
+                  {
+                    "@value": "RAML 1.0"
+                  }
+                ]
+              }
+            ],
+            "smaps": {
+              "lexical": {
+                "#2": "[(1,0)-(8,0)]"
+              }
+            }
+          }
+        ],
+        "doc:root": [
+          {
+            "@value": false
+          }
+        ],
+        "doc:processingData": [
+          {
+            "@id": "#15",
+            "@type": [
+              "doc:APIContractProcessingData"
+            ],
+            "apiContract:modelVersion": [
+              {
+                "@value": "3.8.2"
+              }
+            ],
+            "doc:sourceSpec": [
+              {
+                "@value": "RAML 1.0"
+              }
+            ]
+          }
+        ],
+        "smaps": {
+          "lexical": {
+            "#1": "[(1,0)-(7,0)]"
+          }
+        }
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#20",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:closed": [
+          {
+            "@value": false
+          }
+        ],
+        "shacl:property": [
+          {
+            "@id": "#17",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#data"
+              }
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#18",
+                "@type": [
+                  "raml-shapes:ArrayShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "raml-shapes:items": [
+                  {
+                    "@id": "#19",
+                    "@type": [
+                      "shacl:NodeShape",
+                      "raml-shapes:AnyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "items"
+                      }
+                    ],
+                    "smaps": {
+                      "lexical": {
+                        "#19": "[(6,4)-(7,0)]"
+                      }
+                    }
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "data"
+                  }
+                ],
+                "smaps": {
+                  "inherited-shapes": {
+                    "#18": "amf://id#12,amf://id#12"
+                  },
+                  "lexical": {
+                    "#18": "[(4,2)-(7,0)]"
+                  },
+                  "type-property-lexical-info": {
+                    "#18": "[(5,4)-(5,8)]"
+                  }
+                }
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "data"
+              }
+            ],
+            "smaps": {
+              "synthesized-field": {
+                "shacl:minCount": "true",
+                "shacl:path": "true"
+              },
+              "lexical": {
+                "raml-shapes:range": "[(4,7)-(7,0)]",
+                "#17": "[(4,2)-(7,0)]"
+              },
+              "inherited-shapes": {
+                "#17": "amf://id#11,amf://id#11"
+              }
+            }
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "A"
+          }
+        ],
+        "smaps": {
+          "synthesized-field": {
+            "shacl:closed": "true"
+          },
+          "declared-element": {
+            "#20": ""
+          },
+          "resolved-link": {
+            "#20": "amf://id#20"
+          },
+          "lexical": {
+            "#20": "[(2,0)-(7,0)]"
+          },
+          "type-property-lexical-info": {
+            "#20": "[(2,0)-(2,4)]"
+          },
+          "resolved-link-target": {
+            "#20": "amf://id#16"
+          },
+          "inherited-shapes": {
+            "#20": "amf://id#10"
+          }
+        }
+      }
+    ],
+    "@context": {
+      "@base": "amf://id",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#",
+      "core": "http://a.ml/vocabularies/core#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/api.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/api.raml
@@ -1,0 +1,6 @@
+#%RAML 1.0
+title: API
+version: 1.0.0
+
+types:
+  A: !include A.raml

--- a/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case2/api.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case2/api.jsonld
@@ -1,0 +1,419 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#13",
+        "@type": [
+          "doc:APIContractProcessingData"
+        ],
+        "apiContract:modelVersion": [
+          {
+            "@value": "3.8.2"
+          }
+        ],
+        "doc:transformed": [
+          {
+            "@value": true
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "RAML 1.0"
+          }
+        ]
+      }
+    ],
+    "smaps": {
+      "lexical": {
+        "": "[(1,0)-(22,0)]"
+      }
+    },
+    "doc:declares": [
+      {
+        "@id": "#1",
+        "@type": [
+          "raml-shapes:ArrayShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "raml-shapes:items": [
+          {
+            "@id": "#2",
+            "@type": [
+              "shacl:NodeShape",
+              "raml-shapes:AnyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:name": [
+              {
+                "@value": "items"
+              }
+            ],
+            "smaps": {
+              "lexical": {
+                "#2": "[(5,4)-(7,0)]"
+              }
+            }
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "ObjectArray"
+          }
+        ],
+        "smaps": {
+          "resolved-link-target": {
+            "#1": "amf://id#1"
+          },
+          "declared-element": {
+            "#1": ""
+          },
+          "lexical": {
+            "shacl:name": "[(3,2)-(3,13)]",
+            "#1": "[(3,2)-(7,0)]"
+          },
+          "type-property-lexical-info": {
+            "#1": "[(4,4)-(4,8)]"
+          },
+          "resolved-link": {
+            "#1": "amf://id#3"
+          }
+        }
+      },
+      {
+        "@id": "#4",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:closed": [
+          {
+            "@value": false
+          }
+        ],
+        "shacl:property": [
+          {
+            "@id": "#5",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#myProperty"
+              }
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#1",
+                "@type": [
+                  "raml-shapes:ArrayShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "raml-shapes:items": [
+                  {
+                    "@id": "#2",
+                    "@type": [
+                      "shacl:NodeShape",
+                      "raml-shapes:AnyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "items"
+                      }
+                    ],
+                    "smaps": {
+                      "lexical": {
+                        "#2": "[(5,4)-(7,0)]"
+                      }
+                    }
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "ObjectArray"
+                  }
+                ],
+                "smaps": {
+                  "resolved-link-target": {
+                    "#1": "amf://id#1"
+                  },
+                  "declared-element": {
+                    "#1": ""
+                  },
+                  "lexical": {
+                    "shacl:name": "[(3,2)-(3,13)]",
+                    "#1": "[(3,2)-(7,0)]"
+                  },
+                  "type-property-lexical-info": {
+                    "#1": "[(4,4)-(4,8)]"
+                  },
+                  "resolved-link": {
+                    "#1": "amf://id#3"
+                  }
+                }
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "myProperty"
+              }
+            ],
+            "smaps": {
+              "synthesized-field": {
+                "shacl:minCount": "true",
+                "shacl:path": "true"
+              },
+              "lexical": {
+                "raml-shapes:range": "[(9,17)-(12,0)]",
+                "#5": "[(9,6)-(12,0)]"
+              }
+            }
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Parent"
+          }
+        ],
+        "smaps": {
+          "synthesized-field": {
+            "shacl:closed": "true"
+          },
+          "resolved-link": {
+            "#4": "amf://id#6"
+          },
+          "lexical": {
+            "shacl:name": "[(7,2)-(7,8)]",
+            "#4": "[(7,2)-(12,0)]"
+          },
+          "declared-element": {
+            "#4": ""
+          },
+          "resolved-link-target": {
+            "#4": "amf://id#4"
+          }
+        }
+      },
+      {
+        "@id": "#7",
+        "@type": [
+          "shacl:NodeShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "shacl:closed": [
+          {
+            "@value": false
+          }
+        ],
+        "shacl:property": [
+          {
+            "@id": "#8",
+            "@type": [
+              "shacl:PropertyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#myProperty"
+              }
+            ],
+            "raml-shapes:range": [
+              {
+                "@id": "#9",
+                "@type": [
+                  "raml-shapes:ArrayShape",
+                  "raml-shapes:AnyShape",
+                  "shacl:Shape",
+                  "raml-shapes:Shape",
+                  "doc:DomainElement"
+                ],
+                "raml-shapes:items": [
+                  {
+                    "@id": "#2",
+                    "@type": [
+                      "shacl:NodeShape",
+                      "raml-shapes:AnyShape",
+                      "shacl:Shape",
+                      "raml-shapes:Shape",
+                      "doc:DomainElement"
+                    ],
+                    "shacl:name": [
+                      {
+                        "@value": "items"
+                      }
+                    ],
+                    "smaps": {
+                      "lexical": {
+                        "#2": "[(5,4)-(7,0)]"
+                      }
+                    }
+                  }
+                ],
+                "shacl:name": [
+                  {
+                    "@value": "myProperty"
+                  }
+                ],
+                "smaps": {
+                  "inherited-shapes": {
+                    "#9": "amf://id#10,amf://id#1"
+                  },
+                  "lexical": {
+                    "#9": "[(15,6)-(18,0)]"
+                  },
+                  "type-property-lexical-info": {
+                    "#9": "[(16,8)-(16,12)]"
+                  }
+                }
+              }
+            ],
+            "shacl:minCount": [
+              {
+                "@value": 1
+              }
+            ],
+            "shacl:name": [
+              {
+                "@value": "myProperty"
+              }
+            ],
+            "smaps": {
+              "synthesized-field": {
+                "shacl:minCount": "true",
+                "shacl:path": "true"
+              },
+              "lexical": {
+                "raml-shapes:range": "[(15,17)-(18,0)]",
+                "#8": "[(15,6)-(18,0)]"
+              },
+              "inherited-shapes": {
+                "#8": "amf://id#5"
+              }
+            }
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "Child"
+          }
+        ],
+        "smaps": {
+          "synthesized-field": {
+            "shacl:closed": "true"
+          },
+          "declared-element": {
+            "#7": ""
+          },
+          "lexical": {
+            "shacl:name": "[(12,2)-(12,7)]",
+            "#7": "[(12,2)-(18,0)]"
+          },
+          "type-property-lexical-info": {
+            "#7": "[(13,4)-(13,8)]"
+          },
+          "inherited-shapes": {
+            "#7": "amf://id#4"
+          }
+        }
+      },
+      {
+        "@id": "#10",
+        "@type": [
+          "raml-shapes:ArrayShape",
+          "raml-shapes:AnyShape",
+          "shacl:Shape",
+          "raml-shapes:Shape",
+          "doc:DomainElement"
+        ],
+        "raml-shapes:items": [
+          {
+            "@id": "#11",
+            "@type": [
+              "shacl:NodeShape",
+              "raml-shapes:AnyShape",
+              "shacl:Shape",
+              "raml-shapes:Shape",
+              "doc:DomainElement"
+            ],
+            "shacl:name": [
+              {
+                "@value": "items"
+              }
+            ],
+            "smaps": {
+              "lexical": {
+                "#11": "[(20,4)-(22,0)]"
+              }
+            }
+          }
+        ],
+        "shacl:name": [
+          {
+            "@value": "AnotherObjectArray"
+          }
+        ],
+        "smaps": {
+          "resolved-link-target": {
+            "#10": "amf://id#10"
+          },
+          "declared-element": {
+            "#10": ""
+          },
+          "lexical": {
+            "shacl:name": "[(18,2)-(18,20)]",
+            "#10": "[(18,2)-(22,0)]"
+          },
+          "type-property-lexical-info": {
+            "#10": "[(19,4)-(19,8)]"
+          },
+          "resolved-link": {
+            "#10": "amf://id#12"
+          }
+        }
+      }
+    ],
+    "@context": {
+      "@base": "amf://id",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "raml-shapes": "http://a.ml/vocabularies/shapes#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "apiContract": "http://a.ml/vocabularies/apiContract#"
+    }
+  }
+]

--- a/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case2/api.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case2/api.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0 Library
+types:
+  ObjectArray:
+    type: array
+    items: object
+
+  Parent:
+    properties:
+      myProperty:
+        type: ObjectArray
+
+  Child:
+    type: Parent
+    properties:
+      myProperty:
+        type: AnotherObjectArray
+
+  AnotherObjectArray:
+    type: array
+    items: object
+

--- a/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case3/api.raml
+++ b/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case3/api.raml
@@ -1,0 +1,20 @@
+#%RAML 1.0 Library
+types:
+  ObjectArray:
+    type: array
+    items: object
+
+  Parent:
+    properties:
+      myProperty:
+        type: ObjectArray
+
+  Child:
+    type: Parent
+    properties:
+      myProperty:
+        type: AnyDeclaration
+
+  AnyDeclaration:
+    type: any
+

--- a/amf-cli/shared/src/test/resources/validations/reports/model/property-overwriting-2.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/model/property-overwriting-2.report
@@ -6,7 +6,7 @@ Number of results: 1
 Level: Violation
 
 - Constraint: http://a.ml/vocabularies/amf/resolution#invalid-type-inheritance
-  Message: Resolution error: Invalid scalar inheritance base type 'any' can't override
+  Message: Invalid inheritance: property 'file://amf-cli/shared/src/test/resources/validations/types/property-overwriting-2.raml#/declares/shape/Father/property/property/age' of type 'any' can't override parent property 'file://amf-cli/shared/src/test/resources/validations/types/property-overwriting-2.raml#/declares/shape/Grandfather/property/property/age' of type 'http://www.w3.org/2001/XMLSchema#integer'
   Severity: Violation
   Target: file://amf-cli/shared/src/test/resources/validations/types/property-overwriting-2.raml#/declares/shape/Father/property/property/age
   Property: http://a.ml/vocabularies/shapes#inherits

--- a/amf-cli/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
@@ -1402,5 +1402,18 @@ class EditingResolutionTest extends ResolutionTest {
     )
   }
 
+  test("Any can't override case 1") {
+    val directory = s"$validationsPath/raml/any-cant-override/case1/"
+    cycle(
+      "api.raml",
+      "api.jsonld",
+      Raml10YamlHint,
+      target = AmfJsonHint,
+      transformWith = Some(Raml10),
+      directory = directory
+    )
+
+  }
+
   override val basePath: String = ""
 }

--- a/amf-cli/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
@@ -1412,7 +1412,18 @@ class EditingResolutionTest extends ResolutionTest {
       transformWith = Some(Raml10),
       directory = directory
     )
+  }
 
+  test("Any can't override case 2") {
+    val directory = s"$validationsPath/raml/any-cant-override/case2/"
+    cycle(
+      "api.raml",
+      "api.jsonld",
+      Raml10YamlHint,
+      target = AmfJsonHint,
+      transformWith = Some(Raml10),
+      directory = directory
+    )
   }
 
   override val basePath: String = ""

--- a/amf-cli/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/resolution/EditingResolutionTest.scala
@@ -1388,7 +1388,19 @@ class EditingResolutionTest extends ResolutionTest {
       eh = Some(UnhandledErrorHandler),
       transformWith = Some(Raml10)
     )
+  }
 
+  test("Array override") {
+    cycle(
+      "api.raml",
+      "api.jsonld",
+      Raml10YamlHint,
+      AmfJsonHint,
+      renderOptions = Some(renderOptions().withPrettyPrint),
+      directory = s"${cyclePath}raml10/array-override/",
+      eh = Some(UnhandledErrorHandler),
+      transformWith = Some(Raml10)
+    )
   }
 
   test("Object with property that inherits from union of objects") {

--- a/amf-cli/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
@@ -316,4 +316,8 @@ class ValidRamlModelParserTest extends ValidModelTest {
     checkValid("/raml/any-cant-override/case1/api.raml")
   }
 
+  test("Any can't override case 2") {
+    checkValid("/raml/any-cant-override/case2/api.raml")
+  }
+
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
@@ -320,4 +320,8 @@ class ValidRamlModelParserTest extends ValidModelTest {
     checkValid("/raml/any-cant-override/case2/api.raml")
   }
 
+  test("Any can't override case 3") {
+    checkValid("/raml/any-cant-override/case3/api.raml") // TODO this test should fail!
+  }
+
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/ValidRamlModelParserTest.scala
@@ -312,4 +312,8 @@ class ValidRamlModelParserTest extends ValidModelTest {
     checkValid("/raml/complex-case-with-unions-and-proxy-types.raml")
   }
 
+  test("Any can't override case 1") {
+    checkValid("/raml/any-cant-override/case1/api.raml")
+  }
+
 }


### PR DESCRIPTION
- Improve "'any' can't override" error message + formatting
- W-14171345: skip computing nested inheritance when parent is 'any'
- W-13741083: do not throw 'any' cant override violation when child has not been resolved
- WIP - due to the previous commit this test should fail but doesn't
- W-13104880: added test
