### PR TITLE
W-16888404: change parameter description parsing and bump model

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/emitter/ServerEmitters.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/emitter/ServerEmitters.scala
@@ -2,14 +2,13 @@ package amf.apicontract.internal.spec.common.emitter
 
 import amf.apicontract.client.scala.model.domain.api.Api
 import amf.apicontract.client.scala.model.domain.{EndPoint, Operation, Parameter, Server}
-import amf.apicontract.internal.metamodel.domain.ServerModel
 import amf.apicontract.internal.metamodel.domain.api.BaseApiModel
+import amf.apicontract.internal.metamodel.domain.{ParameterModel, ServerModel}
 import amf.apicontract.internal.spec.oas.emitter.context.{Oas3SpecEmitterFactory, OasSpecEmitterContext}
 import amf.apicontract.internal.spec.oas.emitter.domain.OasTagToReferenceEmitter
 import amf.apicontract.internal.spec.oas.parser.domain.BaseUriSplitter
 import amf.apicontract.internal.spec.raml.emitter.context.RamlSpecEmitterContext
 import amf.apicontract.internal.spec.spec.toRaml
-import org.mulesoft.common.client.lexical.Position
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.{AmfArray, AmfScalar, DomainElement}
 import amf.core.internal.annotations.{BasePathLexicalInformation, HostLexicalInformation, VirtualElement}
@@ -25,6 +24,7 @@ import amf.shapes.internal.domain.metamodel.ScalarShapeModel
 import amf.shapes.internal.spec.common.emitter.annotations.AnnotationsEmitter
 import amf.shapes.internal.spec.common.emitter.{EnumValuesEmitter, ShapeEmitterContext}
 import amf.shapes.internal.spec.contexts.emitter.raml.RamlScalarEmitter
+import org.mulesoft.common.client.lexical.Position
 import org.yaml.model.YDocument
 import org.yaml.model.YDocument.{EntryBuilder, PartBuilder}
 
@@ -280,7 +280,7 @@ case class OasServerVariableEmitter(variable: Parameter, ordering: SpecOrdering)
     val shape  = variable.schema
     val fs     = shape.fields
 
-    variable.fields.entry(ShapeModel.Description).map(f => result += ValueEmitter("description", f))
+    variable.fields.entry(ParameterModel.Description).map(f => result += ValueEmitter("description", f))
 
     fs.entry(ShapeModel.Values).map(f => result += EnumValuesEmitter("enum", f.value, ordering))
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/emitter/ServerEmitters.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/emitter/ServerEmitters.scala
@@ -280,7 +280,7 @@ case class OasServerVariableEmitter(variable: Parameter, ordering: SpecOrdering)
     val shape  = variable.schema
     val fs     = shape.fields
 
-    fs.entry(ShapeModel.Description).map(f => result += ValueEmitter("description", f))
+    variable.fields.entry(ShapeModel.Description).map(f => result += ValueEmitter("description", f))
 
     fs.entry(ShapeModel.Values).map(f => result += EnumValuesEmitter("enum", f.value, ordering))
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasLikeServerParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasLikeServerParser.scala
@@ -63,6 +63,7 @@ class OasLikeServerVariableParser(entry: YMapEntryLike, parent: String)(implicit
     variable.setWithoutId(ParameterModel.Required, AmfScalar(true), Annotations.synthesized())
 
     val map = entry.value.as[YMap]
+    map.key("description", ParameterModel.Description in variable)
     parseMap(variable, map)
 
     variable
@@ -83,8 +84,6 @@ class OasLikeServerVariableParser(entry: YMapEntryLike, parent: String)(implicit
         schema.withDefault(DataNodeParser(entry.value).parse(), Annotations(entry))
       }
     )
-    map.key("description", ShapeModel.Description in schema)
-
     AnnotationParser(schema, map).parse()
   }
 }

--- a/amf-apicontract.versions
+++ b/amf-apicontract.versions
@@ -1,6 +1,6 @@
 amf.apicontract=5.7.0-SNAPSHOT
 amf.aml=6.7.0-SNAPSHOT
-amf.model=3.9.0
+amf.model=3.10.0
 antlr4Version=0.7.25
 amf.validation.profile.dialect=1.6.0
 amf.validation.report.dialect=1.2.0

--- a/amf-cli/js/package.json
+++ b/amf-cli/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amf-client-js",
-  "version": "5.4.0-SNAPSHOT",
+  "version": "5.7.0-SNAPSHOT",
   "description": "AMF Library",
   "main": "amf.js",
   "author": "amf team",

--- a/amf-cli/shared/src/test/resources/avro/doc/cycled/async-basic-avsc.yaml.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/doc/cycled/async-basic-avsc.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/avro/doc/cycled/async-basic-json.yaml.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/doc/cycled/async-basic-json.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/invalid/avro-invalid-ref.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/invalid/avro-invalid-ref.jsonld
@@ -107,7 +107,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/invalid/avro-invalid.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/invalid/avro-invalid.jsonld
@@ -91,7 +91,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/invalid/avro-ref-broken-schema.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/invalid/avro-ref-broken-schema.jsonld
@@ -107,7 +107,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/async-2.4-avro-valid.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/async-2.4-avro-valid.jsonld
@@ -91,7 +91,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/async-avro-component-ref.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/async-avro-component-ref.jsonld
@@ -107,7 +107,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/async-avro-external-ref.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/async-avro-external-ref.jsonld
@@ -743,7 +743,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.dumped.yaml
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.dumped.yaml
@@ -1,0 +1,43 @@
+asyncapi: 2.6.0
+info:
+  title: Market Data API
+  version: 1.0.0
+  description: This API provides real-time market data updates.
+components:
+  messages:
+    m1:
+      payload:
+        type: record
+        name: Person
+        fields:
+          -
+            name: name
+            type: string
+          -
+            name: age
+            type:
+              - "null"
+              - int
+            default: null
+          -
+            name: favoriteProgrammingLanguage
+            type:
+              type: enum
+              name: ProgrammingLanguage
+              symbols:
+                - JS
+                - Java
+                - Go
+                - Rust
+                - C
+          -
+            name: address
+            type:
+              type: record
+              name: Address
+              fields:
+                -
+                  name: zipcode
+                  type: int
+      schemaFormat: application/vnd.apache.avro;version=1.9.0
+channels: {}

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.jsonld
@@ -1,0 +1,783 @@
+[
+  {
+    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml",
+    "@type": [
+      "http://a.ml/vocabularies/document#Document",
+      "http://a.ml/vocabularies/document#Fragment",
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/document#encodes": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/async-api",
+        "@type": [
+          "http://a.ml/vocabularies/apiContract#AsyncAPI",
+          "http://a.ml/vocabularies/apiContract#API",
+          "http://a.ml/vocabularies/document#RootDomainElement",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "Market Data API"
+          }
+        ],
+        "http://a.ml/vocabularies/core#description": [
+          {
+            "@value": "This API provides real-time market data updates."
+          }
+        ],
+        "http://a.ml/vocabularies/core#version": [
+          {
+            "@value": "1.0.0"
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document#processingData": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/BaseUnitProcessingData",
+        "@type": [
+          "http://a.ml/vocabularies/document#APIContractProcessingData"
+        ],
+        "http://a.ml/vocabularies/apiContract#modelVersion": [
+          {
+            "@value": "3.9.0"
+          }
+        ],
+        "http://a.ml/vocabularies/document#sourceSpec": [
+          {
+            "@value": "ASYNC 2.6"
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#references": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/references/0",
+        "@type": [
+          "http://a.ml/vocabularies/document#ExternalFragment",
+          "http://a.ml/vocabularies/document#Fragment",
+          "http://a.ml/vocabularies/document#Unit"
+        ],
+        "http://a.ml/vocabularies/document#encodes": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/references/0/external",
+            "@type": [
+              "http://a.ml/vocabularies/document#ExternalDomainElement",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/document#raw": [
+              {
+                "@value": "{\n  \"type\": \"record\",\n  \"name\": \"Person\",\n  \"fields\": [\n    {\"name\": \"name\", \"type\": \"string\", \"example\": \"Donkey\"},\n    {\"name\": \"age\", \"type\": [\"null\", \"int\"], \"default\": null},\n    {\n      \"name\": \"favoriteProgrammingLanguage\",\n      \"type\": {\"name\": \"ProgrammingLanguage\", \"type\": \"enum\", \"symbols\": [\"JS\", \"Java\", \"Go\", \"Rust\", \"C\"]}\n    },\n    {\n      \"name\": \"address\",\n      \"type\": {\n        \"name\": \"Address\",\n        \"type\": \"record\",\n        \"fields\": [{\"name\": \"zipcode\", \"type\": \"int\"}]\n      }\n    }\n  ]\n}\n"
+              }
+            ],
+            "http://a.ml/vocabularies/core#mediaType": [
+              {
+                "@value": "application/json"
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document#root": [
+          {
+            "@value": false
+          }
+        ],
+        "http://a.ml/vocabularies/document#processingData": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/references/0/BaseUnitProcessingData",
+            "@type": [
+              "http://a.ml/vocabularies/document#BaseUnitProcessingData"
+            ],
+            "http://a.ml/vocabularies/document#transformed": [
+              {
+                "@value": false
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#declares": [
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1",
+        "@type": [
+          "http://a.ml/vocabularies/apiContract#Message",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "m1"
+          }
+        ],
+        "http://a.ml/vocabularies/apiContract#payload": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Payload",
+              "http://a.ml/vocabularies/core#Payload",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/apiContract#schemaMediaType": [
+              {
+                "@value": "application/vnd.apache.avro;version=1.9.0"
+              }
+            ],
+            "http://a.ml/vocabularies/shapes#schema": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person",
+                "@type": [
+                  "http://www.w3.org/ns/shacl#NodeShape",
+                  "http://a.ml/vocabularies/shapes#AnyShape",
+                  "http://www.w3.org/ns/shacl#Shape",
+                  "http://a.ml/vocabularies/shapes#Shape",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://www.w3.org/ns/shacl#property": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/name",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/name/scalar/default-scalar",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/name/scalar/default-scalar/source-map",
+                            "@type": [
+                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#avro-schema": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/name/scalar/default-scalar/source-map/avro-schema/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/name/scalar/default-scalar"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "string"
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#avro-raw-schema": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/name/scalar/default-scalar/source-map/avro-raw-schema/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/name/scalar/default-scalar"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "{\n  \"name\": \"name\",\n  \"type\": \"string\",\n  \"example\": \"Donkey\"\n}"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "name"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#UnionShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://a.ml/vocabularies/shapes#anyOf": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/nil/null",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#NilShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "null"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#sources": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/nil/null/source-map",
+                                "@type": [
+                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#avro-schema": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/nil/null/source-map/avro-schema/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/nil/null"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "null"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#avro-raw-schema": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/nil/null/source-map/avro-raw-schema/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/nil/null"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "\"null\""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/scalar/default-scalar",
+                            "@type": [
+                              "http://a.ml/vocabularies/shapes#ScalarShape",
+                              "http://a.ml/vocabularies/shapes#AnyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#sources": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/scalar/default-scalar/source-map",
+                                "@type": [
+                                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#avro-schema": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/scalar/default-scalar/source-map/avro-schema/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/scalar/default-scalar"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "int"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#avro-raw-schema": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/scalar/default-scalar/source-map/avro-raw-schema/element_0",
+                                    "http://a.ml/vocabularies/document-source-maps#element": [
+                                      {
+                                        "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/anyOf/scalar/default-scalar"
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#value": [
+                                      {
+                                        "@value": "\"int\""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "age"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#defaultValue": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/scalar_1",
+                            "@type": [
+                              "http://a.ml/vocabularies/data#Scalar",
+                              "http://a.ml/vocabularies/data#Node",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/data#value": [
+                              {
+                                "@value": "null"
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#datatype": [
+                              {
+                                "@id": "http://www.w3.org/2001/XMLSchema#nil"
+                              }
+                            ],
+                            "http://a.ml/vocabularies/core#name": [
+                              {
+                                "@value": "scalar_1"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/source-map",
+                            "@type": [
+                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#avro-schema": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/source-map/avro-schema/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "union"
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#avro-raw-schema": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age/source-map/avro-raw-schema/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/age/union/age"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "{\n  \"name\": \"age\",\n  \"type\": [\n    \"null\",\n    \"int\"\n  ],\n  \"default\": null\n}"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "age"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "ProgrammingLanguage"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#in": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage/list",
+                            "@type": "http://www.w3.org/2000/01/rdf-schema#Seq",
+                            "http://www.w3.org/2000/01/rdf-schema#_1": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage/in/data-node",
+                                "@type": [
+                                  "http://a.ml/vocabularies/data#Scalar",
+                                  "http://a.ml/vocabularies/data#Node",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/data#value": [
+                                  {
+                                    "@value": "JS"
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://www.w3.org/2000/01/rdf-schema#_2": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage/in/data-node_1",
+                                "@type": [
+                                  "http://a.ml/vocabularies/data#Scalar",
+                                  "http://a.ml/vocabularies/data#Node",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/data#value": [
+                                  {
+                                    "@value": "Java"
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://www.w3.org/2000/01/rdf-schema#_3": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage/in/data-node_2",
+                                "@type": [
+                                  "http://a.ml/vocabularies/data#Scalar",
+                                  "http://a.ml/vocabularies/data#Node",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/data#value": [
+                                  {
+                                    "@value": "Go"
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://www.w3.org/2000/01/rdf-schema#_4": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage/in/data-node_3",
+                                "@type": [
+                                  "http://a.ml/vocabularies/data#Scalar",
+                                  "http://a.ml/vocabularies/data#Node",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/data#value": [
+                                  {
+                                    "@value": "Rust"
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://www.w3.org/2000/01/rdf-schema#_5": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage/in/data-node_4",
+                                "@type": [
+                                  "http://a.ml/vocabularies/data#Scalar",
+                                  "http://a.ml/vocabularies/data#Node",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://a.ml/vocabularies/data#value": [
+                                  {
+                                    "@value": "C"
+                                  }
+                                ],
+                                "http://www.w3.org/ns/shacl#datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage/source-map",
+                            "@type": [
+                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#avro-schema": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage/source-map/avro-schema/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "enum"
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#avro-raw-schema": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage/source-map/avro-raw-schema/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/favoriteProgrammingLanguage/scalar/ProgrammingLanguage"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "{\n  \"name\": \"ProgrammingLanguage\",\n  \"type\": \"enum\",\n  \"symbols\": [\n    \"JS\",\n    \"Java\",\n    \"Go\",\n    \"Rust\",\n    \"C\"\n  ]\n}"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "favoriteProgrammingLanguage"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address",
+                    "@type": [
+                      "http://www.w3.org/ns/shacl#PropertyShape",
+                      "http://www.w3.org/ns/shacl#Shape",
+                      "http://a.ml/vocabularies/shapes#Shape",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/shapes#range": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address",
+                        "@type": [
+                          "http://www.w3.org/ns/shacl#NodeShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#property": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address/property/property/zipcode",
+                            "@type": [
+                              "http://www.w3.org/ns/shacl#PropertyShape",
+                              "http://www.w3.org/ns/shacl#Shape",
+                              "http://a.ml/vocabularies/shapes#Shape",
+                              "http://a.ml/vocabularies/document#DomainElement"
+                            ],
+                            "http://a.ml/vocabularies/shapes#range": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address/property/property/zipcode/scalar/default-scalar",
+                                "@type": [
+                                  "http://a.ml/vocabularies/shapes#ScalarShape",
+                                  "http://a.ml/vocabularies/shapes#AnyShape",
+                                  "http://www.w3.org/ns/shacl#Shape",
+                                  "http://a.ml/vocabularies/shapes#Shape",
+                                  "http://a.ml/vocabularies/document#DomainElement"
+                                ],
+                                "http://www.w3.org/ns/shacl#datatype": [
+                                  {
+                                    "@id": "http://www.w3.org/2001/XMLSchema#integer"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#sources": [
+                                  {
+                                    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address/property/property/zipcode/scalar/default-scalar/source-map",
+                                    "@type": [
+                                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#avro-schema": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address/property/property/zipcode/scalar/default-scalar/source-map/avro-schema/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address/property/property/zipcode/scalar/default-scalar"
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "int"
+                                          }
+                                        ]
+                                      }
+                                    ],
+                                    "http://a.ml/vocabularies/document-source-maps#avro-raw-schema": [
+                                      {
+                                        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address/property/property/zipcode/scalar/default-scalar/source-map/avro-raw-schema/element_0",
+                                        "http://a.ml/vocabularies/document-source-maps#element": [
+                                          {
+                                            "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address/property/property/zipcode/scalar/default-scalar"
+                                          }
+                                        ],
+                                        "http://a.ml/vocabularies/document-source-maps#value": [
+                                          {
+                                            "@value": "{\n  \"name\": \"zipcode\",\n  \"type\": \"int\"\n}"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://www.w3.org/ns/shacl#name": [
+                              {
+                                "@value": "zipcode"
+                              }
+                            ]
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "Address"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#sources": [
+                          {
+                            "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address/source-map",
+                            "@type": [
+                              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#avro-schema": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address/source-map/avro-schema/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "record"
+                                  }
+                                ]
+                              }
+                            ],
+                            "http://a.ml/vocabularies/document-source-maps#avro-raw-schema": [
+                              {
+                                "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address/source-map/avro-raw-schema/element_0",
+                                "http://a.ml/vocabularies/document-source-maps#element": [
+                                  {
+                                    "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/property/property/address/shape/Address"
+                                  }
+                                ],
+                                "http://a.ml/vocabularies/document-source-maps#value": [
+                                  {
+                                    "@value": "{\n  \"name\": \"Address\",\n  \"type\": \"record\",\n  \"fields\": [\n    {\n      \"name\": \"zipcode\",\n      \"type\": \"int\"\n    }\n  ]\n}"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "http://www.w3.org/ns/shacl#name": [
+                      {
+                        "@value": "address"
+                      }
+                    ]
+                  }
+                ],
+                "http://www.w3.org/ns/shacl#name": [
+                  {
+                    "@value": "Person"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#sources": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/source-map",
+                    "@type": [
+                      "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#avro-schema": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/source-map/avro-schema/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "record"
+                          }
+                        ]
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#avro-raw-schema": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person/source-map/avro-raw-schema/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "file://amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml#/declares/msg/m1/payload/default/shape/Person"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "{\n  \"type\": \"record\",\n  \"name\": \"Person\",\n  \"fields\": [\n    {\n      \"name\": \"name\",\n      \"type\": \"string\",\n      \"example\": \"Donkey\"\n    },\n    {\n      \"name\": \"age\",\n      \"type\": [\n        \"null\",\n        \"int\"\n      ],\n      \"default\": null\n    },\n    {\n      \"name\": \"favoriteProgrammingLanguage\",\n      \"type\": {\n        \"name\": \"ProgrammingLanguage\",\n        \"type\": \"enum\",\n        \"symbols\": [\n          \"JS\",\n          \"Java\",\n          \"Go\",\n          \"Rust\",\n          \"C\"\n        ]\n      }\n    },\n    {\n      \"name\": \"address\",\n      \"type\": {\n        \"name\": \"Address\",\n        \"type\": \"record\",\n        \"fields\": [\n          {\n            \"name\": \"zipcode\",\n            \"type\": \"int\"\n          }\n        ]\n      }\n    }\n  ]\n}"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.jsonld
@@ -46,7 +46,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components-external.yaml
@@ -1,0 +1,12 @@
+asyncapi: 2.6.0
+info:
+  title: Market Data API
+  version: 1.0.0
+  description: This API provides real-time market data updates.
+
+components:
+  messages:
+    m1:
+      schemaFormat: application/vnd.apache.avro;version=1.9.0
+      payload:
+        $ref: schema-1.9.0.avsc

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-components.jsonld
@@ -91,7 +91,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-inline.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-inline.jsonld
@@ -2042,7 +2042,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-map-values-union.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-map-values-union.jsonld
@@ -268,7 +268,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-ref-1.9.0.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-ref-1.9.0.jsonld
@@ -770,7 +770,7 @@
             ],
             "http://a.ml/vocabularies/document#raw": [
               {
-                "@value": "{\n  \"type\": \"record\",\n  \"name\": \"Person\",\n  \"fields\": [\n    {\"name\": \"name\", \"type\": \"string\", \"example\": \"Donkey\"},\n    {\"name\": \"age\", \"type\": [\"null\", \"int\"], \"default\": null},\n    {\n      \"name\": \"favoriteProgrammingLanguage\",\n      \"type\": {\"name\": \"ProgrammingLanguage\", \"type\": \"enum\", \"symbols\": [\"JS\", \"Java\", \"Go\", \"Rust\", \"C\"]}\n    },\n    {\n      \"name\": \"address\",\n      \"type\": {\n        \"name\": \"Address\",\n        \"type\": \"record\",\n        \"fields\": [{\"name\": \"zipcode\", \"type\": \"int\"}]\n      }\n    }\n  ],\n}\n"
+                "@value": "{\n  \"type\": \"record\",\n  \"name\": \"Person\",\n  \"fields\": [\n    {\"name\": \"name\", \"type\": \"string\", \"example\": \"Donkey\"},\n    {\"name\": \"age\", \"type\": [\"null\", \"int\"], \"default\": null},\n    {\n      \"name\": \"favoriteProgrammingLanguage\",\n      \"type\": {\"name\": \"ProgrammingLanguage\", \"type\": \"enum\", \"symbols\": [\"JS\", \"Java\", \"Go\", \"Rust\", \"C\"]}\n    },\n    {\n      \"name\": \"address\",\n      \"type\": {\n        \"name\": \"Address\",\n        \"type\": \"record\",\n        \"fields\": [{\"name\": \"zipcode\", \"type\": \"int\"}]\n      }\n    }\n  ]\n}\n"
               }
             ],
             "http://a.ml/vocabularies/core#mediaType": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-ref-1.9.0.jsonld
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/avro-ref-1.9.0.jsonld
@@ -743,7 +743,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/avro/tck/apis/valid/schema-1.9.0.avsc
+++ b/amf-cli/shared/src/test/resources/avro/tck/apis/valid/schema-1.9.0.avsc
@@ -16,5 +16,5 @@
         "fields": [{"name": "zipcode", "type": "int"}]
       }
     }
-  ],
+  ]
 }

--- a/amf-cli/shared/src/test/resources/configuration/async-model.jsonld
+++ b/amf-cli/shared/src/test/resources/configuration/async-model.jsonld
@@ -5,7 +5,7 @@
 "@type": [
 "http://a.ml/vocabularies/document#APIContractProcessingData"
 ],
-"http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+"http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
 },
 {
 "@id": "root/async-api",

--- a/amf-cli/shared/src/test/resources/configuration/webapi-model.jsonld
+++ b/amf-cli/shared/src/test/resources/configuration/webapi-model.jsonld
@@ -5,7 +5,7 @@
 "@type": [
 "http://a.ml/vocabularies/document#APIContractProcessingData"
 ],
-"http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+"http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
 },
 {
 "@id": "root/web-api",

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-types.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/transformation/introspected-types.jsonld
@@ -23,7 +23,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "GraphQLFederation"
     },

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/directive-with-directives.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-extend-type.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/external-type.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/federation-directives.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/graphql-directives.jsonld
@@ -300,7 +300,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-argument.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum-value.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-enum.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field-with-argument.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-field.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-field.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-input-object.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-interface.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-object.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-scalar.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/inaccessible-union.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-interface.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-complex.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type-resolvable.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-extend-type.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-interface.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-complex.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-multi-resolvable.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type-resolvable.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/key-type.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/link.jsonld
@@ -178,7 +178,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/override.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/provides.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/requires.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/root-field-directives.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/root-field-directives.jsonld
@@ -905,7 +905,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/root-innacessible-arg.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/root-innacessible-arg.jsonld
@@ -405,7 +405,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-field.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql-federation/tck/apis/valid/shareable-object.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/corner-cases/recursion-with-query.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/corner-cases/recursion-with-query.jsonld
@@ -144,7 +144,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/corner-cases/recursion-with-unions.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/corner-cases/recursion-with-unions.jsonld
@@ -160,7 +160,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-!-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-!-token.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-"-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-"-token.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-&-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-&-token.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-*-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-*-token.jsonld
@@ -160,7 +160,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous---token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous---token.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-:-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-:-token.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-;-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-;-token.jsonld
@@ -160,7 +160,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-@-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-@-token.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-tokens.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-tokens.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-|-token.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/extraneous-|-token.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-colon.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-colon.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-0.jsonld
@@ -133,7 +133,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-1.jsonld
@@ -133,7 +133,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-2.jsonld
@@ -255,7 +255,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-3.jsonld
@@ -160,7 +160,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-4.jsonld
@@ -160,7 +160,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-5.jsonld
@@ -160,7 +160,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-6.jsonld
@@ -297,7 +297,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-7.jsonld
@@ -323,7 +323,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-field-type-8.jsonld
@@ -160,7 +160,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket-and-lparen.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket-and-lparen.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-lbracket.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket-and-rparen.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket-and-rparen.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rbracket.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rparen.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-rparen.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-slbracket.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-slbracket.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-srbracket.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-srbracket.jsonld
@@ -193,7 +193,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member-remixed.jsonld
@@ -160,7 +160,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/missing-union-member.jsonld
@@ -160,7 +160,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/misspelling-type.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/misspelling-type.jsonld
@@ -160,7 +160,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/replace-{-with-[.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/replace-{-with-[.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/scalar-inside-type.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/scalar-inside-type.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/syntax-recovery/type-inside-type.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/syntax-recovery/type-inside-type.jsonld
@@ -37,7 +37,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-enum-values.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-enum-values.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-enum-values.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-enum-values.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-input-object-values.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-input-object-values.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-input-object-values.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-input-object-values.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-scalar-values.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-scalar-values.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-scalar-values.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/argument-scalar-values.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/covariance.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/covariance.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/covariance.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/covariance.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/custom-scalar.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/custom-scalar.api.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/custom-scalar.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/custom-scalar.api.resolved.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/deprecated.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/deprecated.api.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/deprecated.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/deprecated.api.resolved.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/descriptions-enum.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/descriptions-enum.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/descriptions-enum.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/descriptions-enum.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/descriptions.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/descriptions.api.jsonld
@@ -217,7 +217,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/descriptions.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/descriptions.api.resolved.jsonld
@@ -217,7 +217,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-applications.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-applications.api.jsonld
@@ -246,7 +246,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-applications.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-applications.api.resolved.jsonld
@@ -246,7 +246,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-arguments.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-arguments.api.jsonld
@@ -203,7 +203,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-arguments.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-arguments.api.resolved.jsonld
@@ -203,7 +203,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-locations.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-locations.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-locations.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-locations.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-multitarget.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-multitarget.api.jsonld
@@ -178,7 +178,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-multitarget.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-multitarget.api.resolved.jsonld
@@ -178,7 +178,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.flattened.jsonld
@@ -15,7 +15,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "GraphQL"
     },
     {

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-repeatable.resolved.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-simple.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-simple.api.jsonld
@@ -178,7 +178,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-simple.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/directive-simple.api.resolved.jsonld
@@ -178,7 +178,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-enum.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-enum.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-enum.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-enum.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-input-type.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-input-type.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-input-type.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-input-type.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-interface.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-interface.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-interface.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-interface.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-objects.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-objects.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-objects.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-objects.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-scalars.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-scalars.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-scalars.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-scalars.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-union.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-union.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-union.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/extension-union.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-chain-covariant.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-chain-covariant.jsonld
@@ -139,7 +139,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-chain-covariant.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-chain-covariant.resolved.jsonld
@@ -139,7 +139,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-double.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-double.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-double.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-double.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-simple.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-simple.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-simple.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-simple.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-with-interface.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-with-interface.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-with-interface.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/interface-with-interface.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-directive-arguments.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-directive-arguments.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-directive-arguments.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-directive-arguments.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-fields.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-fields.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-interface-arguments.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-interface-arguments.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-interface-arguments.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-interface-arguments.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-object-arguments.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-object-arguments.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-object-arguments.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-input-type-object-arguments.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-output-type-interface-fields.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-output-type-interface-fields.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-output-type-interface-fields.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-output-type-interface-fields.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-output-type-object-fields.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-output-type-object-fields.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-output-type-object-fields.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/is-output-type-object-fields.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/nested-interfaces.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/nested-interfaces.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/nested-interfaces.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/nested-interfaces.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/no-schema.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/no-schema.api.jsonld
@@ -324,7 +324,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/no-schema.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/no-schema.api.resolved.jsonld
@@ -324,7 +324,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/recursion.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/recursion.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-extends.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-extends.jsonld
@@ -404,7 +404,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-extends.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-extends.resolved.jsonld
@@ -404,7 +404,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-in-schema-extends.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-in-schema-extends.jsonld
@@ -404,7 +404,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-in-schema-extends.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-in-schema-extends.resolved.jsonld
@@ -404,7 +404,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-in-schema.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-in-schema.jsonld
@@ -404,7 +404,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-in-schema.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types-in-schema.resolved.jsonld
@@ -404,7 +404,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types.jsonld
@@ -404,7 +404,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/root-types.resolved.jsonld
@@ -404,7 +404,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/specified-by.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/specified-by.api.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/specified-by.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/specified-by.api.resolved.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-arguments.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-arguments.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-arguments.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-arguments.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-enum.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-enum.api.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-enum.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-enum.api.resolved.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-input-type.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-input-type.api.jsonld
@@ -334,7 +334,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-input-type.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-input-type.api.resolved.jsonld
@@ -334,7 +334,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-list.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-list.api.jsonld
@@ -193,7 +193,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-list.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-list.api.resolved.jsonld
@@ -193,7 +193,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-matrix.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-matrix.api.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-matrix.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-matrix.api.resolved.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-non-null.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-non-null.api.jsonld
@@ -386,7 +386,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-non-null.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-non-null.api.resolved.jsonld
@@ -386,7 +386,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-object.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-object.api.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-object.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-object.api.resolved.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-scalars.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-scalars.api.jsonld
@@ -653,7 +653,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-scalars.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-scalars.api.resolved.jsonld
@@ -653,7 +653,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-union.api.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-union.api.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-union.api.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/graphql/tck/apis/valid/types-union.api.resolved.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/jsonschema/cycled/api-2019.raml.jsonld
+++ b/amf-cli/shared/src/test/resources/jsonschema/cycled/api-2019.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/jsonschema/cycled/api.raml.jsonld
+++ b/amf-cli/shared/src/test/resources/jsonschema/cycled/api.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/jsonschema/cycled/oas20-2019.yaml.jsonld
+++ b/amf-cli/shared/src/test/resources/jsonschema/cycled/oas20-2019.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/jsonschema/cycled/oas20.yaml.jsonld
+++ b/amf-cli/shared/src/test/resources/jsonschema/cycled/oas20.yaml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/parser/array-type-expressions/base-type-array.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/array-type-expressions/base-type-array.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/parser/array-type-expressions/base-type-array.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/array-type-expressions/base-type-array.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/parser/array-type-expressions/matrix-type-array.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/array-type-expressions/matrix-type-array.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/parser/array-type-expressions/matrix-type-array.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/array-type-expressions/matrix-type-array.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/parser/array-type-expressions/type-expression-with-inheritance.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/array-type-expressions/type-expression-with-inheritance.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/parser/array-type-expressions/type-expression-with-inheritance.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/array-type-expressions/type-expression-with-inheritance.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/parser/array-type-expressions/union-type-array.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/array-type-expressions/union-type-array.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/parser/array-type-expressions/union-type-array.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/array-type-expressions/union-type-array.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/parser/union-expressions/child-declaration-links.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/union-expressions/child-declaration-links.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/parser/union-expressions/child-declaration-links.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/union-expressions/child-declaration-links.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/parser/union-expressions/union-right-declaration.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/union-expressions/union-right-declaration.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/parser/union-expressions/union-right-declaration.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/union-expressions/union-right-declaration.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/parser/union-with-lib/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/union-with-lib/api.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -370,7 +370,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/parser/union-with-lib/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/parser/union-with-lib/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -187,7 +187,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/poc/inheritance-item.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/inheritance-item.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/inheritance-nested-object.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/inheritance-nested-object.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-in-inherited-property.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-in-inherited-property.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-inheritance-cycle.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-inheritance-cycle.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-invalid-mandatory-property.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-invalid-mandatory-property.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-invalid-mandatory-type.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-invalid-mandatory-type.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-invalid-minitems-no-zero.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-invalid-minitems-no-zero.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-invalid-optional-property-complex.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-invalid-optional-property-complex.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-invalid-union-nested.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-invalid-union-nested.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-invalid-union.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-invalid-union.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-valid-additionalproperties.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-valid-additionalproperties.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-valid-minitems-zero.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-valid-minitems-zero.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-valid-optional-property.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-valid-optional-property.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-valid-optional-type.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-valid-optional-type.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-valid-union-nested-exit-at-first.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-valid-union-nested-exit-at-first.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-valid-union-nested-exit-at-second.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-valid-union-nested-exit-at-second.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/poc/recursion-valid-union.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/poc/recursion-valid-union.resolved.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/enum-id-with-applied-trait/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/enum-id-with-applied-trait/golden.expanded.jsonld
@@ -726,7 +726,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/enum-id-with-applied-trait/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/enum-id-with-applied-trait/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/event-api/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/event-api/api.expanded.jsonld
@@ -830,7 +830,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/production/event-api/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/event-api/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/example-in-union.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/example-in-union.raml.expanded.jsonld
@@ -952,7 +952,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/example-in-union.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/example-in-union.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.expanded.jsonld
@@ -21622,7 +21622,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/googleapis.compredictionv1.2swagger.raml.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/inherits-resolution-declares/add-facet.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/inherits-resolution-declares/add-facet.raml.expanded.jsonld
@@ -506,7 +506,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/inherits-resolution-declares/add-facet.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/inherits-resolution-declares/add-facet.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/inherits-resolution-declares/test-ramlfragment.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/inherits-resolution-declares/test-ramlfragment.raml.expanded.jsonld
@@ -517,7 +517,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/inherits-resolution-declares/test-ramlfragment.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/inherits-resolution-declares/test-ramlfragment.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/knowledge-graph-reduced/api.jsonld
+++ b/amf-cli/shared/src/test/resources/production/knowledge-graph-reduced/api.jsonld
@@ -2486,7 +2486,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/production/lib-trait-location/api.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/lib-trait-location/api.resolved.expanded.jsonld
@@ -325,7 +325,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -502,7 +502,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/lib-trait-location/api.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/lib-trait-location/api.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -328,7 +328,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/production/lib-types/lib.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/lib-types/lib.expanded.jsonld
@@ -18,7 +18,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/production/lib-types/lib.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/lib-types/lib.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/microsoft_azure_blob_service.raml.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/microsoft_azure_blob_service.raml.resolved.expanded.jsonld
@@ -443,7 +443,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/microsoft_azure_blob_service.raml.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/microsoft_azure_blob_service.raml.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/oas-complex-example/api.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas-complex-example/api.resolved.expanded.jsonld
@@ -3448,7 +3448,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/oas-complex-example/api.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas-complex-example/api.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/production/oas-example.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas-example.json.expanded.jsonld
@@ -4276,7 +4276,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/oas-example.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas-example.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/production/oas-multiple-example.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas-multiple-example.json.expanded.jsonld
@@ -2408,7 +2408,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/oas-multiple-example.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas-multiple-example.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/production/oas-multiple-example.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas-multiple-example.resolved.expanded.jsonld
@@ -1108,7 +1108,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/production/oas-multiple-example.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas-multiple-example.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/production/oas20/xml-payload.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas20/xml-payload.json.expanded.jsonld
@@ -488,7 +488,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/oas20/xml-payload.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/oas20/xml-payload.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/production/raml08/definitions-loops-crossfiles/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml08/definitions-loops-crossfiles/api.raml.expanded.jsonld
@@ -219,7 +219,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml08/definitions-loops-crossfiles/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml08/definitions-loops-crossfiles/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml08/definitions-loops-crossfiles2/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml08/definitions-loops-crossfiles2/api.raml.expanded.jsonld
@@ -493,7 +493,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml08/definitions-loops-crossfiles2/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml08/definitions-loops-crossfiles2/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml08/definitions-loops/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml08/definitions-loops/api.raml.expanded.jsonld
@@ -219,7 +219,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml08/definitions-loops/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml08/definitions-loops/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml.expanded.jsonld
@@ -3495,7 +3495,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml08/lock-unlock/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml.expanded.jsonld
@@ -8444,7 +8444,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -10057,7 +10057,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -10130,7 +10130,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -10203,7 +10203,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -10276,7 +10276,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/american-flights-api/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -6529,7 +6529,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -6557,7 +6557,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -6585,7 +6585,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -6613,7 +6613,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml10/banking-api/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/banking-api/api.raml.expanded.jsonld
@@ -10432,7 +10432,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -35562,7 +35562,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -37505,7 +37505,7 @@
                 ],
                 "http://a.ml/vocabularies/apiContract#modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "http://a.ml/vocabularies/document#sourceSpec": [
@@ -37986,7 +37986,7 @@
                 ],
                 "http://a.ml/vocabularies/apiContract#modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "http://a.ml/vocabularies/document#sourceSpec": [
@@ -40040,7 +40040,7 @@
                 ],
                 "http://a.ml/vocabularies/apiContract#modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "http://a.ml/vocabularies/document#sourceSpec": [
@@ -40610,7 +40610,7 @@
                 ],
                 "http://a.ml/vocabularies/apiContract#modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "http://a.ml/vocabularies/document#sourceSpec": [
@@ -40676,7 +40676,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -41514,7 +41514,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -43555,7 +43555,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml10/banking-api/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/banking-api/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -9171,7 +9171,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -9341,7 +9341,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -9408,7 +9408,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -9443,7 +9443,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -13214,7 +13214,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -13252,7 +13252,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -13290,7 +13290,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml.expanded.jsonld
@@ -12165,7 +12165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/demo-api/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml10/jsonchema-apiexternalexample/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/jsonchema-apiexternalexample/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml10/jsonchema-apiexternalexample/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/jsonchema-apiexternalexample/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml10/jsonschema-apiwithfragmentref/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/jsonschema-apiwithfragmentref/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml10/jsonschema-apiwithfragmentref/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/jsonschema-apiwithfragmentref/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml10/jsonschema/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/jsonschema/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml10/jsonschema/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/jsonschema/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml10/locations-api/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/locations-api/api.raml.expanded.jsonld
@@ -3737,7 +3737,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -6256,7 +6256,7 @@
                 ],
                 "http://a.ml/vocabularies/apiContract#modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "http://a.ml/vocabularies/document#sourceSpec": [
@@ -6337,7 +6337,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -6468,7 +6468,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml10/locations-api/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/locations-api/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -3095,7 +3095,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -3141,7 +3141,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -3532,7 +3532,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml10/xsdexample/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/xsdexample/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml10/xsdexample/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/xsdexample/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml10/xsdschema-withfragmentref/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/xsdschema-withfragmentref/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml10/xsdschema-withfragmentref/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/xsdschema-withfragmentref/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/raml10/xsdschema/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/xsdschema/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/raml10/xsdschema/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/raml10/xsdschema/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/recursive-union.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/recursive-union.raml.expanded.jsonld
@@ -269,7 +269,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/recursive-union.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/recursive-union.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/recursive3.editing.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/recursive3.editing.expanded.jsonld
@@ -48,7 +48,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/production/recursive3.editing.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/recursive3.editing.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/recursive4.editing.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/recursive4.editing.expanded.jsonld
@@ -48,7 +48,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/production/recursive4.editing.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/recursive4.editing.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/resolution-dumpjsonld/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/resolution-dumpjsonld/api.raml.expanded.jsonld
@@ -556,7 +556,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/production/resolution-dumpjsonld/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/resolution-dumpjsonld/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/production/resolution-dumpjsonld/api.resolved.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/resolution-dumpjsonld/api.resolved.raml.expanded.jsonld
@@ -414,7 +414,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/resolution-dumpjsonld/api.resolved.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/resolution-dumpjsonld/api.resolved.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/union-type-with-composing-closed-type/additional-prop-and-defined-after.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/union-type-with-composing-closed-type/additional-prop-and-defined-after.expanded.jsonld
@@ -150,7 +150,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/production/union-type-with-composing-closed-type/additional-prop-and-defined-after.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/union-type-with-composing-closed-type/additional-prop-and-defined-after.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/union-type-with-composing-closed-type/additional-prop-and-defined-before.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/union-type-with-composing-closed-type/additional-prop-and-defined-before.expanded.jsonld
@@ -150,7 +150,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/production/union-type-with-composing-closed-type/additional-prop-and-defined-before.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/union-type-with-composing-closed-type/additional-prop-and-defined-before.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/production/union-type/api.raml.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/production/union-type/api.raml.resolved.jsonld
@@ -290,7 +290,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/unions-example.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/production/unions-example.raml.expanded.jsonld
@@ -4852,7 +4852,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/production/unions-example.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/production/unions-example.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/rdf/apis/banking.jsonld
+++ b/amf-cli/shared/src/test/resources/rdf/apis/banking.jsonld
@@ -41,7 +41,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/references/data-type-fragment.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/references/data-type-fragment.json.expanded.jsonld
@@ -104,7 +104,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -358,7 +358,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/references/data-type-fragment.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/references/data-type-fragment.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {
@@ -161,7 +161,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/references/data-type-fragment.reference.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/references/data-type-fragment.reference.resolved.expanded.jsonld
@@ -48,7 +48,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -181,7 +181,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/references/data-type-fragment.reference.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/references/data-type-fragment.reference.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -137,7 +137,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/references/lib/lib.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/references/lib/lib.json.expanded.jsonld
@@ -23,7 +23,7 @@
 ],
 "http://a.ml/vocabularies/apiContract#modelVersion": [
 {
-"@value": "3.9.0"
+"@value": "3.10.0"
 }
 ],
 "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/references/lib/lib.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/references/lib/lib.json.flattened.jsonld
@@ -5,7 +5,7 @@
 "@type": [
 "http://a.ml/vocabularies/document#APIContractProcessingData"
 ],
-"http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+"http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
 "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
 },
 {

--- a/amf-cli/shared/src/test/resources/references/lib/lib.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/references/lib/lib.raml.expanded.jsonld
@@ -23,7 +23,7 @@
 ],
 "http://a.ml/vocabularies/apiContract#modelVersion": [
 {
-"@value": "3.9.0"
+"@value": "3.10.0"
 }
 ],
 "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/references/lib/lib.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/references/lib/lib.raml.flattened.jsonld
@@ -5,7 +5,7 @@
 "@type": [
 "http://a.ml/vocabularies/document#APIContractProcessingData"
 ],
-"http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+"http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
 "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
 },
 {

--- a/amf-cli/shared/src/test/resources/references/libraries.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/references/libraries.json.expanded.jsonld
@@ -104,7 +104,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -550,7 +550,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/references/libraries.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/references/libraries.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {
@@ -154,7 +154,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/references/oas/oas-references/oas-2-root.jsonld
+++ b/amf-cli/shared/src/test/resources/references/oas/oas-references/oas-2-root.jsonld
@@ -104,7 +104,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/references/oas/oas-references/oas-3-root.jsonld
+++ b/amf-cli/shared/src/test/resources/references/oas/oas-references/oas-3-root.jsonld
@@ -104,7 +104,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/render/governance-mode/async/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/render/governance-mode/async/api.expanded.jsonld
@@ -164,7 +164,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/render/governance-mode/async/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/render/governance-mode/async/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/render/governance-mode/oas/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/render/governance-mode/oas/api.expanded.jsonld
@@ -192,7 +192,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/render/governance-mode/oas/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/render/governance-mode/oas/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/render/governance-mode/raml/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/render/governance-mode/raml/api.expanded.jsonld
@@ -151,7 +151,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/render/governance-mode/raml/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/render/governance-mode/raml/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/render/recursion.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/render/recursion.expanded.jsonld
@@ -282,7 +282,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/render/recursion.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/render/recursion.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/render/types.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/render/types.expanded.jsonld
@@ -282,7 +282,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/render/types.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/render/types.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/render/union.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/render/union.expanded.jsonld
@@ -282,7 +282,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/render/union.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/render/union.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/08/included-schema-and-example/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/08/included-schema-and-example/api.expanded.jsonld
@@ -405,7 +405,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/08/included-schema-and-example/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/08/included-schema-and-example/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/async-2.3-components.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/async-2.3-components.expanded.jsonld
@@ -167,7 +167,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/async-2.3-components.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/async-2.3-components.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.3"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.4.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.4.expanded.jsonld
@@ -278,7 +278,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.4.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.4.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.4"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.5.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.5.expanded.jsonld
@@ -278,7 +278,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.5.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.5.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.5"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.6.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.6.expanded.jsonld
@@ -278,7 +278,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.6.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-2.6.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.6"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-23.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-23.expanded.jsonld
@@ -278,7 +278,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-23.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-23.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.3"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-implicit.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-implicit.expanded.jsonld
@@ -436,7 +436,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-implicit.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers-implicit.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers.expanded.jsonld
@@ -278,7 +278,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/channel-servers.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/channel-servers.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.2"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/content-type-override.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/content-type-override.expanded.jsonld
@@ -745,7 +745,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/content-type-override.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/content-type-override.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/message-example-propagation.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/message-example-propagation.expanded.jsonld
@@ -884,7 +884,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/message-example-propagation.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/message-example-propagation.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/message-references.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/message-references.expanded.jsonld
@@ -541,7 +541,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/message-references.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/message-references.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/message-trait-merging-and-removed.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/message-trait-merging-and-removed.expanded.jsonld
@@ -154,7 +154,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/message-trait-merging-and-removed.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/message-trait-merging-and-removed.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/message-trait-merging.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/message-trait-merging.expanded.jsonld
@@ -251,7 +251,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/message-trait-merging.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/message-trait-merging.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/named-parameter-with-ref.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/named-parameter-with-ref.expanded.jsonld
@@ -146,7 +146,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/named-parameter-with-ref.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/named-parameter-with-ref.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/operation-trait-merging-and-removed.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/operation-trait-merging-and-removed.expanded.jsonld
@@ -111,7 +111,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/operation-trait-merging-and-removed.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/operation-trait-merging-and-removed.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/operation-trait-merging.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/operation-trait-merging.expanded.jsonld
@@ -214,7 +214,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/operation-trait-merging.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/operation-trait-merging.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/async20/type-forward-referencing.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/type-forward-referencing.expanded.jsonld
@@ -50,7 +50,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/async20/type-forward-referencing.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/async20/type-forward-referencing.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/binary-fragment/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/binary-fragment/api.expanded.jsonld
@@ -388,7 +388,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/binary-fragment/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/binary-fragment/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/declared-from-library/api.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/declared-from-library/api.resolved.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -180,7 +180,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/resolution/declared-from-library/api.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/declared-from-library/api.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -148,7 +148,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/resolution/double-declare-type/api.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/double-declare-type/api.resolved.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -172,7 +172,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/resolution/double-declare-type/api.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/double-declare-type/api.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -172,7 +172,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/resolution/double-union-inheritance/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/double-union-inheritance/api.expanded.jsonld
@@ -48,7 +48,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/double-union-inheritance/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/double-union-inheritance/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/encoded-uris-in-properties/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/encoded-uris-in-properties/api.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/encoded-uris-in-properties/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/encoded-uris-in-properties/api.flattened.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/example-in-resource-type/examples-defined-in-rt.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/example-in-resource-type/examples-defined-in-rt.expanded.jsonld
@@ -471,7 +471,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/example-in-resource-type/examples-defined-in-rt.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/example-in-resource-type/examples-defined-in-rt.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/example-in-trait/example-in-trait.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/example-in-trait/example-in-trait.expanded.jsonld
@@ -716,7 +716,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/example-in-trait/example-in-trait.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/example-in-trait/example-in-trait.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/examples-shortener.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/examples-shortener.resolved.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/examples-shortener.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/examples-shortener.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/examples/response-declarations-with-multiple-media-types.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/examples/response-declarations-with-multiple-media-types.expanded.jsonld
@@ -579,7 +579,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/examples/response-declarations-with-multiple-media-types.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/examples/response-declarations-with-multiple-media-types.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/examples/response-examples.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/examples/response-examples.json.expanded.jsonld
@@ -5285,7 +5285,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/examples/response-examples.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/examples/response-examples.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/examples/response-examples.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/examples/response-examples.raml.expanded.jsonld
@@ -888,7 +888,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/examples/response-examples.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/examples/response-examples.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/08/trait-with-quoted-value.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/08/trait-with-quoted-value.resolved.expanded.jsonld
@@ -574,7 +574,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/08/trait-with-quoted-value.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/08/trait-with-quoted-value.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/api-with-complex-rt-trait-file-structure/api.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/api-with-complex-rt-trait-file-structure/api.jsonld
@@ -534,7 +534,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [
@@ -1192,7 +1192,7 @@
                         ],
                         "http://a.ml/vocabularies/apiContract#modelVersion": [
                           {
-                            "@value": "3.9.0"
+                            "@value": "3.10.0"
                           }
                         ],
                         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1303,7 +1303,7 @@
                         ],
                         "http://a.ml/vocabularies/apiContract#modelVersion": [
                           {
-                            "@value": "3.9.0"
+                            "@value": "3.10.0"
                           }
                         ],
                         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1333,7 +1333,7 @@
                     ],
                     "http://a.ml/vocabularies/apiContract#modelVersion": [
                       {
-                        "@value": "3.9.0"
+                        "@value": "3.10.0"
                       }
                     ],
                     "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1358,7 +1358,7 @@
                 ],
                 "http://a.ml/vocabularies/apiContract#modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1388,7 +1388,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1689,7 +1689,7 @@
                 ],
                 "http://a.ml/vocabularies/apiContract#modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1800,7 +1800,7 @@
                 ],
                 "http://a.ml/vocabularies/apiContract#modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1830,7 +1830,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/complex-traits-resource-types.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/complex-traits-resource-types.raml.expanded.jsonld
@@ -4111,7 +4111,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/complex-traits-resource-types.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/complex-traits-resource-types.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/data.editing.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/data.editing.expanded.jsonld
@@ -612,7 +612,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/data.editing.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/data.editing.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/merging/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/merging/api.expanded.jsonld
@@ -218,7 +218,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/merging/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/merging/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/resource-type/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/resource-type/api.expanded.jsonld
@@ -308,7 +308,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/resource-type/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/resource-type/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/trait/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/trait/api.expanded.jsonld
@@ -280,7 +280,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/trait/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/extends-with-references-to-declares/trait/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/optional-method.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/optional-method.raml.expanded.jsonld
@@ -490,7 +490,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/optional-method.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/optional-method.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/parameters.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/parameters.raml.expanded.jsonld
@@ -929,7 +929,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/parameters.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/parameters.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/simple-merge.editing.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/simple-merge.editing.expanded.jsonld
@@ -438,7 +438,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/simple-merge.editing.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/simple-merge.editing.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/simple-merge.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/simple-merge.raml.expanded.jsonld
@@ -515,7 +515,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/simple-merge.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/simple-merge.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extends/to-jsonld-and-back/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/to-jsonld-and-back/api.expanded.jsonld
@@ -46,7 +46,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extends/to-jsonld-and-back/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extends/to-jsonld-and-back/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extension/operation/output.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extension/operation/output.expanded.jsonld
@@ -645,7 +645,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extension/operation/output.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extension/operation/output.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extension/traits/input.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extension/traits/input.resolved.expanded.jsonld
@@ -309,7 +309,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extension/traits/input.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extension/traits/input.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/extension/traits/output.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extension/traits/output.expanded.jsonld
@@ -144,7 +144,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/extension/traits/output.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/extension/traits/output.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/externalfragment/jsonexample.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/externalfragment/jsonexample.raml.expanded.jsonld
@@ -960,7 +960,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/externalfragment/jsonexample.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/externalfragment/jsonexample.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/externalfragment/jsonschema.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/externalfragment/jsonschema.raml.expanded.jsonld
@@ -485,7 +485,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/externalfragment/jsonschema.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/externalfragment/jsonschema.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/externalfragment/test-links-with-references/api.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/externalfragment/test-links-with-references/api.resolved.expanded.jsonld
@@ -240,7 +240,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/externalfragment/test-links-with-references/api.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/externalfragment/test-links-with-references/api.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/externalfragment/xmlexample.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/externalfragment/xmlexample.raml.expanded.jsonld
@@ -404,7 +404,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/externalfragment/xmlexample.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/externalfragment/xmlexample.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/externalfragment/xmlschema.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/externalfragment/xmlschema.raml.expanded.jsonld
@@ -345,7 +345,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/externalfragment/xmlschema.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/externalfragment/xmlschema.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/jsonld-example/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/jsonld-example/api.expanded.jsonld
@@ -301,7 +301,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/jsonld-example/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/jsonld-example/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/link-of-link/in-api/link-of-link-in-api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/link-of-link/in-api/link-of-link-in-api.expanded.jsonld
@@ -152,7 +152,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -448,7 +448,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/resolution/link-of-link/in-api/link-of-link-in-api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/link-of-link/in-api/link-of-link-in-api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -329,7 +329,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/resolution/link-of-link/link-of-link-of-link.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/link-of-link/link-of-link-of-link.expanded.jsonld
@@ -18,7 +18,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/link-of-link/link-of-link-of-link.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/link-of-link/link-of-link-of-link.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/link-of-link/link-of-link.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/link-of-link/link-of-link.expanded.jsonld
@@ -18,7 +18,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/link-of-link/link-of-link.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/link-of-link/link-of-link.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/link-of-link/middle-link-in-api/link-of-link-in-api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/link-of-link/middle-link-in-api/link-of-link-in-api.expanded.jsonld
@@ -152,7 +152,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -558,7 +558,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/resolution/link-of-link/middle-link-in-api/link-of-link-in-api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/link-of-link/middle-link-in-api/link-of-link-in-api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -372,7 +372,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/avoid-extract-to-declares.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/avoid-extract-to-declares.expanded.jsonld
@@ -246,7 +246,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/avoid-extract-to-declares.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/avoid-extract-to-declares.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/link-to-declares-and-refs-default.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/link-to-declares-and-refs-default.expanded.jsonld
@@ -1625,7 +1625,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/link-to-declares-and-refs-default.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/link-to-declares-and-refs-default.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/link-to-declares-and-refs-editing.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/link-to-declares-and-refs-editing.expanded.jsonld
@@ -766,7 +766,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -910,7 +910,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [
@@ -1187,7 +1187,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [
@@ -1446,7 +1446,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/link-to-declares-and-refs-editing.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/links-to-declares-and-references/link-to-declares-and-refs-editing.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -1034,7 +1034,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -1078,7 +1078,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -1086,7 +1086,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override-oas-target.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override-oas-target.json.expanded.jsonld
@@ -828,7 +828,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override-oas-target.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override-oas-target.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override.json.expanded.jsonld
@@ -818,7 +818,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override.raml.expanded.jsonld
@@ -847,7 +847,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-type-override.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-type.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-type.json.expanded.jsonld
@@ -818,7 +818,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-type.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-type.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-type.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-type.raml.expanded.jsonld
@@ -847,7 +847,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-type.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-type.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-types.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-types.json.expanded.jsonld
@@ -1373,7 +1373,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-types.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-types.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-types.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-types.raml.expanded.jsonld
@@ -1376,7 +1376,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/media-type/media-types.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/media-types.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/media-type/security-scheme-use-global-mediatype.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/security-scheme-use-global-mediatype.raml.expanded.jsonld
@@ -807,7 +807,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/media-type/security-scheme-use-global-mediatype.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/media-type/security-scheme-use-global-mediatype.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/merge-inherits-json-schema-fragments/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge-inherits-json-schema-fragments/api.expanded.jsonld
@@ -1000,7 +1000,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/merge-inherits-json-schema-fragments/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge-inherits-json-schema-fragments/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/merge-inherits/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge-inherits/api.expanded.jsonld
@@ -1243,7 +1243,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/merge-inherits/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge-inherits/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/merge-recursive-inherits/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge-recursive-inherits/api.expanded.jsonld
@@ -745,7 +745,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/merge-recursive-inherits/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge-recursive-inherits/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/merge-recursive-json-schemas-raml08/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge-recursive-json-schemas-raml08/api.expanded.jsonld
@@ -1079,7 +1079,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/merge-recursive-json-schemas-raml08/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge-recursive-json-schemas-raml08/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 0.8"
     },

--- a/amf-cli/shared/src/test/resources/resolution/merge-recursive-json-schemas-raml10/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge-recursive-json-schemas-raml10/api.expanded.jsonld
@@ -1097,7 +1097,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/merge-recursive-json-schemas-raml10/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge-recursive-json-schemas-raml10/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-different-binding/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-different-binding/golden.expanded.jsonld
@@ -115,7 +115,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-different-binding/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-different-binding/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/resp/message",

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-different-examples/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-different-examples/golden.expanded.jsonld
@@ -148,7 +148,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-different-examples/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-different-examples/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/resp/message",

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-documentation/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-documentation/golden.expanded.jsonld
@@ -55,7 +55,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-documentation/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-documentation/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/resp/message",

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-same-binding/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-same-binding/golden.expanded.jsonld
@@ -118,7 +118,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-same-binding/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-same-binding/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/resp/message",

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-same-example-names/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-same-example-names/golden.expanded.jsonld
@@ -148,7 +148,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-same-example-names/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-same-example-names/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/resp/message",

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-simple/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-simple/golden.expanded.jsonld
@@ -98,7 +98,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-simple/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-simple/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/resp/message",

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-tags/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-tags/golden.expanded.jsonld
@@ -55,7 +55,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/message-tags/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/message-tags/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/resp/message",

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-binding-nested-schema/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-binding-nested-schema/golden.expanded.jsonld
@@ -144,7 +144,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-binding-nested-schema/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-binding-nested-schema/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/subscribe/traitOperationId",

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-different-binding/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-different-binding/golden.expanded.jsonld
@@ -207,7 +207,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-different-binding/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-different-binding/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/subscribe/traitOperationId",

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-documentation/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-documentation/golden.expanded.jsonld
@@ -59,7 +59,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-documentation/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-documentation/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/subscribe/traitOperationId",

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-same-binding/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-same-binding/golden.expanded.jsonld
@@ -144,7 +144,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-same-binding/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-same-binding/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/subscribe/traitOperationId",

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-simple/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-simple/golden.expanded.jsonld
@@ -50,7 +50,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-simple/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-simple/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/subscribe/traitOperationId",

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-tags/golden.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-tags/golden.expanded.jsonld
@@ -59,7 +59,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ]
       }

--- a/amf-cli/shared/src/test/resources/resolution/merge/operation-tags/golden.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/merge/operation-tags/golden.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0"
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0"
     },
     {
       "@id": "testId/subscribe/traitOperationId",

--- a/amf-cli/shared/src/test/resources/resolution/multiple-ref-to-external-schema/result.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/multiple-ref-to-external-schema/result.expanded.jsonld
@@ -843,7 +843,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/multiple-ref-to-external-schema/result.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/multiple-ref-to-external-schema/result.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/nested-parameters.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/nested-parameters.raml.expanded.jsonld
@@ -1849,7 +1849,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/nested-parameters.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/nested-parameters.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas-declared-link-of-scalar.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-declared-link-of-scalar.expanded.jsonld
@@ -56,7 +56,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/oas-declared-link-of-scalar.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-declared-link-of-scalar.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas-internal-json-schema-link/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-internal-json-schema-link/api.expanded.jsonld
@@ -332,7 +332,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/oas-internal-json-schema-link/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-internal-json-schema-link/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/all-objects-case.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/all-objects-case.expanded.jsonld
@@ -321,7 +321,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/all-objects-case.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/all-objects-case.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/array-in-the-middle.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/array-in-the-middle.expanded.jsonld
@@ -321,7 +321,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/array-in-the-middle.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/array-in-the-middle.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/array-with-child-recursion.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/array-with-child-recursion.expanded.jsonld
@@ -321,7 +321,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/array-with-child-recursion.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-link-of-link/array-with-child-recursion.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas-recursion.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-recursion.expanded.jsonld
@@ -50,7 +50,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/oas-recursion.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-recursion.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas3-cookie-propagation/oas3-cookie-parameter-propagation.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas3-cookie-propagation/oas3-cookie-parameter-propagation.expanded.jsonld
@@ -417,7 +417,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/oas3-cookie-propagation/oas3-cookie-parameter-propagation.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas3-cookie-propagation/oas3-cookie-parameter-propagation.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas3-inlined-shapes.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas3-inlined-shapes.expanded.jsonld
@@ -360,7 +360,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/oas3-inlined-shapes.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas3-inlined-shapes.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas30-discriminator-invalid-mapping/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas30-discriminator-invalid-mapping/api.expanded.jsonld
@@ -50,7 +50,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/oas30-discriminator-invalid-mapping/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas30-discriminator-invalid-mapping/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas30-discriminator/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas30-discriminator/api.expanded.jsonld
@@ -166,7 +166,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/oas30-discriminator/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas30-discriminator/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/operation-path-parameters/result.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/operation-path-parameters/result.expanded.jsonld
@@ -597,7 +597,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/operation-path-parameters/result.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/operation-path-parameters/result.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.expanded.jsonld
@@ -1057,7 +1057,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/overrided-baseUriParams.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },

--- a/amf-cli/shared/src/test/resources/resolution/parameter-without-type/parameter-without-type.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/parameter-without-type/parameter-without-type.expanded.jsonld
@@ -197,7 +197,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/parameter-without-type/parameter-without-type.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/parameter-without-type/parameter-without-type.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/parameters.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/parameters.json.expanded.jsonld
@@ -935,7 +935,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/parameters.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/parameters.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/parameters.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/parameters.raml.expanded.jsonld
@@ -692,7 +692,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/parameters.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/parameters.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/payloads-examples-resolution.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/payloads-examples-resolution.resolved.expanded.jsonld
@@ -224,7 +224,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/payloads-examples-resolution.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/payloads-examples-resolution.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/queryString/query-string.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/queryString/query-string.json.expanded.jsonld
@@ -1374,7 +1374,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/queryString/query-string.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/queryString/query-string.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/queryString/query-string.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/queryString/query-string.raml.expanded.jsonld
@@ -1524,7 +1524,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/queryString/query-string.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/queryString/query-string.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/queryString/security-with-query-string.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/queryString/security-with-query-string.json.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/queryString/security-with-query-string.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/queryString/security-with-query-string.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/queryString/security-with-query-string.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/queryString/security-with-query-string.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/queryString/security-with-query-string.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/queryString/security-with-query-string.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/raml-multiple-fragments/output.source-info.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/raml-multiple-fragments/output.source-info.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -364,7 +364,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -430,7 +430,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -465,7 +465,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/resolution/raml-query-and-header-params/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/raml-query-and-header-params/api.expanded.jsonld
@@ -383,7 +383,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/raml-query-and-header-params/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/raml-query-and-header-params/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/recursive-additional-properties/recursive-additional-properties-2.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/recursive-additional-properties/recursive-additional-properties-2.expanded.jsonld
@@ -50,7 +50,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/recursive-additional-properties/recursive-additional-properties-2.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/recursive-additional-properties/recursive-additional-properties-2.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/recursive-additional-properties/recursive-additional-properties.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/recursive-additional-properties/recursive-additional-properties.expanded.jsonld
@@ -240,7 +240,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/recursive-additional-properties/recursive-additional-properties.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/recursive-additional-properties/recursive-additional-properties.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/recursive-extension-provenance/api.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/recursive-extension-provenance/api.resolved.expanded.jsonld
@@ -331,7 +331,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/recursive-extension-provenance/api.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/recursive-extension-provenance/api.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/recursive-tuple/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/recursive-tuple/api.expanded.jsonld
@@ -1136,7 +1136,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/recursive-tuple/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/recursive-tuple/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 0.8"
     },

--- a/amf-cli/shared/src/test/resources/resolution/request-link-parameters/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/request-link-parameters/api.expanded.jsonld
@@ -621,7 +621,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/request-link-parameters/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/request-link-parameters/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/security-requirements/security-requirements.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/security-requirements/security-requirements.expanded.jsonld
@@ -942,7 +942,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -1478,7 +1478,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [
@@ -1782,7 +1782,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/resolution/security-requirements/security-requirements.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/security-requirements/security-requirements.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -851,7 +851,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -897,7 +897,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/resolution/security/security.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/security/security.json.expanded.jsonld
@@ -2935,7 +2935,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/security/security.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/security/security.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/security/security.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/security/security.raml.expanded.jsonld
@@ -3114,7 +3114,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/security/security.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/security/security.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/shape-normalization/cyclic-inheritance/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shape-normalization/cyclic-inheritance/api.expanded.jsonld
@@ -55,7 +55,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/shape-normalization/cyclic-inheritance/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shape-normalization/cyclic-inheritance/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/shape-normalization/cyclic-union-members/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shape-normalization/cyclic-union-members/api.expanded.jsonld
@@ -55,7 +55,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/shape-normalization/cyclic-union-members/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shape-normalization/cyclic-union-members/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/shared-oas-30-examples/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shared-oas-30-examples/api.expanded.jsonld
@@ -1379,7 +1379,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/shared-oas-30-examples/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shared-oas-30-examples/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/shared-request-body-reference/oas30/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shared-request-body-reference/oas30/api.expanded.jsonld
@@ -359,7 +359,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/shared-request-body-reference/oas30/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shared-request-body-reference/oas30/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/shared-response-reference/oas20/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shared-response-reference/oas20/api.expanded.jsonld
@@ -315,7 +315,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/shared-response-reference/oas20/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shared-response-reference/oas20/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/shared-response-reference/oas30/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shared-response-reference/oas30/api.expanded.jsonld
@@ -297,7 +297,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/shared-response-reference/oas30/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/shared-response-reference/oas30/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/trait-with-link.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/trait-with-link.expanded.jsonld
@@ -851,7 +851,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/trait-with-link.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/trait-with-link.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/union-of-arrays/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/union-of-arrays/api.expanded.jsonld
@@ -144,7 +144,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/union-of-arrays/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/union-of-arrays/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/union-of-declarations/api.raml.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/union-of-declarations/api.raml.resolved.expanded.jsonld
@@ -346,7 +346,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/union-of-declarations/api.raml.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/union-of-declarations/api.raml.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/unresolved-shape.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/unresolved-shape.raml.expanded.jsonld
@@ -36,7 +36,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/resolution/unresolved-shape.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/unresolved-shape.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/uri-params/api-operation.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/uri-params/api-operation.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/resolution/uri-params/api.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/uri-params/api.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/any-method.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/any-method.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/api-key-source.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/api-key-source.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/auth-type.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/auth-type.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/auth.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/auth.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/authorizer.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/authorizer.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/binary-media-types.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/binary-media-types.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/cors.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/cors.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/documentation.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/documentation.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/endpoint-configuration.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/endpoint-configuration.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/gateway-responses.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/gateway-responses.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/importexport-version.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/importexport-version.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/integration-any-method.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/integration-any-method.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/integration-declaration.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/integration-declaration.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/integration-inline.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/integration-inline.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/minimum-compression-size.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/minimum-compression-size.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/policy.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/policy.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/request-validators.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/request-validators.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/aws/apis/tag.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/aws/apis/tag.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "raml-doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "raml-doc:transformed": true,
       "raml-doc:sourceSpec": "AWS OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/instance-nested-object.raml.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance-nested-object.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/instance-scalar.async.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance-scalar.async.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/instance-scalar.oas20.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance-scalar.oas20.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/instance-scalar.oas30.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance-scalar.oas30.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/instance-scalar.parsed.async.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance-scalar.parsed.async.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/semantic/instance-scalar.parsed.oas20.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance-scalar.parsed.oas20.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/semantic/instance-scalar.parsed.oas30.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance-scalar.parsed.oas30.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "OAS 3.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/semantic/instance-scalar.parsed.raml.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance-scalar.parsed.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/semantic/instance-scalar.raml.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance-scalar.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/instance.async.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.async.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/instance.oas20.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.oas20.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/instance.oas30.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.oas30.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/semantic/instance.parsed.async.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.parsed.async.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/semantic/instance.parsed.oas20.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.parsed.oas20.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/semantic/instance.parsed.oas30.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.parsed.oas30.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "OAS 3.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/semantic/instance.parsed.raml.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.parsed.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/semantic/instance.raml.jsonld
+++ b/amf-cli/shared/src/test/resources/semantic/instance.raml.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/additional-properties.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/additional-properties.expanded.jsonld
@@ -104,7 +104,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/additional-properties.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/additional-properties.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/annotations.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/annotations.json.expanded.jsonld
@@ -538,7 +538,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/annotations.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/annotations.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/basic.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/basic.json.expanded.jsonld
@@ -279,7 +279,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/basic.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/basic.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/collection-format.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/collection-format.expanded.jsonld
@@ -878,7 +878,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/collection-format.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/collection-format.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/complete.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/complete.json.expanded.jsonld
@@ -560,7 +560,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/complete.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/complete.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/default-arguments/default-arguments.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/default-arguments/default-arguments.jsonld
@@ -532,7 +532,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/default-arguments/invalid-default-arguments.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/default-arguments/invalid-default-arguments.jsonld
@@ -532,7 +532,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/descriptions/block.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/descriptions/block.jsonld
@@ -812,7 +812,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/descriptions/simple.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/descriptions/simple.jsonld
@@ -812,7 +812,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/directive-with-directives/api.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/directive-with-directives/api.jsonld
@@ -59,7 +59,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/directives/arguments.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/directives/arguments.jsonld
@@ -246,7 +246,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/directives/default.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/directives/default.jsonld
@@ -203,7 +203,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/directives/multiple.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/directives/multiple.jsonld
@@ -228,7 +228,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/directives/simple.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/directives/simple.jsonld
@@ -196,7 +196,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/fragment-reserved-name/api.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/fragment-reserved-name/api.jsonld
@@ -287,7 +287,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/keyword-enum-values/api.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/keyword-enum-values/api.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/keyword-names/api.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/keyword-names/api.jsonld
@@ -165,7 +165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/non-root-optional-array/api.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/non-root-optional-array/api.jsonld
@@ -410,7 +410,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/arguments-array.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/arguments-array.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/arguments.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/arguments.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/directives.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/directives.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/input-objects-array.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/input-objects-array.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/input-objects.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/input-objects.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/mix-input-output-objects.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/mix-input-output-objects.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/self.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/invalid/self.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/inheritance.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/inheritance.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/interfaces-array.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/interfaces-array.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/interfaces.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/interfaces.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/mix-interface-objects.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/mix-interface-objects.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/objects-array.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/objects-array.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/objects.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/objects.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/self.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/self.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/union.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursion/valid/union.jsonld
@@ -36,7 +36,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursive-inheritance/simple.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/recursive-inheritance/simple.resolved.jsonld
@@ -438,7 +438,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/root-type/non-root-type.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/root-type/non-root-type.jsonld
@@ -160,7 +160,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/root-type/root-type.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/root-type/root-type.jsonld
@@ -245,7 +245,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/simple/api.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/simple/api.jsonld
@@ -693,7 +693,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/swapi/api.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/graphql/swapi/api.jsonld
@@ -3300,7 +3300,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas-component/simple.jsonld
@@ -5,7 +5,7 @@
 "@type": [
 "http://a.ml/vocabularies/document#APIContractProcessingData"
 ],
-"http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+"http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
 "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
 },
 {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/json/pathitem-fragment/api.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/json/pathitem-fragment/api.json.expanded.jsonld
@@ -402,7 +402,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/json/pathitem-fragment/api.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/json/pathitem-fragment/api.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/json/type-definitions-with-refs.source-info.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/json/type-definitions-with-refs.source-info.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/invalid-param-ref/api.yaml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/invalid-param-ref/api.yaml.expanded.jsonld
@@ -329,7 +329,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/invalid-param-ref/api.yaml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/invalid-param-ref/api.yaml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/multiple-form-data/api.yaml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/multiple-form-data/api.yaml.expanded.jsonld
@@ -733,7 +733,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/multiple-form-data/api.yaml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/multiple-form-data/api.yaml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/param-in-body-link/api.yaml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/param-in-body-link/api.yaml.expanded.jsonld
@@ -329,7 +329,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/param-in-body-link/api.yaml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/oas20/yaml/param-in-body-link/api.yaml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml.expanded.jsonld
@@ -7917,7 +7917,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/americanflightapi/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/base-uri-params-implicit/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/base-uri-params-implicit/api.raml.expanded.jsonld
@@ -776,7 +776,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/base-uri-params-implicit/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/base-uri-params-implicit/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/default_value/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/default_value/api.raml.expanded.jsonld
@@ -1047,7 +1047,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/default_value/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/default_value/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/define-uri-parameters/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/define-uri-parameters/api.raml.expanded.jsonld
@@ -568,7 +568,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/define-uri-parameters/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/define-uri-parameters/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/empty_payload/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/empty_payload/api.raml.expanded.jsonld
@@ -278,7 +278,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/empty_payload/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/empty_payload/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/file-array/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/file-array/api.raml.expanded.jsonld
@@ -481,7 +481,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/file-array/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/file-array/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/json_schema_array/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/json_schema_array/api.raml.expanded.jsonld
@@ -155,7 +155,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/json_schema_array/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/json_schema_array/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/missing_payload/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/missing_payload/api.raml.expanded.jsonld
@@ -299,7 +299,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/missing_payload/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/missing_payload/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/schema-position/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/schema-position/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/schema-position/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml08/schema-position/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/all-type-types/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/all-type-types/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/all-type-types/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/all-type-types/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml.expanded.jsonld
@@ -3095,7 +3095,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-full/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml.expanded.jsonld
@@ -2136,7 +2136,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-scalars/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-type-expressions/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-type-expressions/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-type-expressions/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations-type-expressions/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.expanded.jsonld
@@ -506,7 +506,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/annotations/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/api-with-multi-line-schema/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/api-with-multi-line-schema/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/api-with-multi-line-schema/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/api-with-multi-line-schema/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/array-example/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/array-example/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/array-example/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/array-example/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/banking-api/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/banking-api/api.raml.expanded.jsonld
@@ -2156,7 +2156,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/banking-api/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/banking-api/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/basic/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/basic/api.raml.expanded.jsonld
@@ -276,7 +276,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/basic/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/basic/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/basic_with_xsd/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/basic_with_xsd/api.raml.expanded.jsonld
@@ -600,7 +600,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/basic_with_xsd/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/basic_with_xsd/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/bells with spaces/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/bells with spaces/api.raml.expanded.jsonld
@@ -780,7 +780,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/bells with spaces/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/bells with spaces/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/boolean-value-in-example/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/boolean-value-in-example/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/boolean-value-in-example/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/boolean-value-in-example/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/boolean_in_key/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/boolean_in_key/api.raml.expanded.jsonld
@@ -924,7 +924,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/boolean_in_key/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/boolean_in_key/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/chars[]infilespaths/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/chars[]infilespaths/api.raml.expanded.jsonld
@@ -529,7 +529,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/chars[]infilespaths/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/chars[]infilespaths/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-crossed-props/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-crossed-props/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-crossed-props/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-crossed-props/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-full-valid/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-full-valid/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-full-valid/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-full-valid/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-inheritance/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-inheritance/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-inheritance/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/closures-inheritance/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/complete-with-operations/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/complete-with-operations/api.raml.expanded.jsonld
@@ -1633,7 +1633,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/complete-with-operations/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/complete-with-operations/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/complete/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/complete/api.raml.expanded.jsonld
@@ -527,7 +527,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/complete/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/complete/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/data-type-fragment/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/data-type-fragment/api.raml.expanded.jsonld
@@ -54,7 +54,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -321,7 +321,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/data-type-fragment/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/data-type-fragment/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -133,7 +133,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/declarations-small/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/declarations-small/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/declarations-small/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/declarations-small/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/declared-security-schemes/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/declared-security-schemes/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/declared-security-schemes/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/declared-security-schemes/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml.expanded.jsonld
@@ -1546,7 +1546,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/default-types/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-external-fragment/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-external-fragment/api.raml.expanded.jsonld
@@ -482,7 +482,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-external-fragment/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-external-fragment/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-library/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-library/api.raml.expanded.jsonld
@@ -18,7 +18,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-library/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-library/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-resesponse-securityscheme/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-resesponse-securityscheme/api.raml.expanded.jsonld
@@ -543,7 +543,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-resesponse-securityscheme/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty-resesponse-securityscheme/api.raml.flattened.jsonld
@@ -33,7 +33,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty_union/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty_union/api.raml.expanded.jsonld
@@ -481,7 +481,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty_union/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/empty_union/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/endpoints/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/endpoints/api.raml.expanded.jsonld
@@ -823,7 +823,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/endpoints/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/endpoints/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/enum-inheritance/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/enum-inheritance/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/enum-inheritance/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/enum-inheritance/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/enums/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/enums/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/enums/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/enums/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/example-key-map-without-value/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/example-key-map-without-value/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/example-key-map-without-value/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/example-key-map-without-value/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/examples/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/examples/api.raml.expanded.jsonld
@@ -3181,7 +3181,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/examples/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/examples/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/explicit-&-implicit-type-object/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/explicit-&-implicit-type-object/api.raml.expanded.jsonld
@@ -959,7 +959,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/explicit-&-implicit-type-object/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/explicit-&-implicit-type-object/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/extensions/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/extensions/api.raml.expanded.jsonld
@@ -133,7 +133,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -2352,7 +2352,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/extensions/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/extensions/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -206,7 +206,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/externals/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/externals/api.raml.expanded.jsonld
@@ -1315,7 +1315,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/externals/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/externals/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file-detection/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file-detection/api.raml.expanded.jsonld
@@ -348,7 +348,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file-detection/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file-detection/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file_type_expression/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file_type_expression/api.raml.expanded.jsonld
@@ -697,7 +697,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file_type_expression/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file_type_expression/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file_types/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file_types/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file_types/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/file_types/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-inherits-reference/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-inherits-reference/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-inherits-reference/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-inherits-reference/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-references-types/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-references-types/api.raml.expanded.jsonld
@@ -646,7 +646,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-references-types/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-references-types/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-shape-custom-properties/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-shape-custom-properties/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-shape-custom-properties/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/forward-shape-custom-properties/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/fragment_usage/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/fragment_usage/api.raml.expanded.jsonld
@@ -1473,7 +1473,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/fragment_usage/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/fragment_usage/api.raml.flattened.jsonld
@@ -32,7 +32,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/full-example/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/full-example/api.raml.expanded.jsonld
@@ -3069,7 +3069,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/full-example/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/full-example/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/implicitly-defined-object/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/implicitly-defined-object/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/implicitly-defined-object/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/implicitly-defined-object/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/include-repeated/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/include-repeated/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/include-repeated/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/include-repeated/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/inline-named-examples/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/inline-named-examples/api.raml.expanded.jsonld
@@ -3710,7 +3710,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -4860,7 +4860,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -4933,7 +4933,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -5006,7 +5006,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/inline-named-examples/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/inline-named-examples/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -2964,7 +2964,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -2992,7 +2992,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -3020,7 +3020,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml.expanded.jsonld
@@ -1210,7 +1210,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/int_uri_param/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/jukebox-api/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/jukebox-api/api.raml.expanded.jsonld
@@ -1078,7 +1078,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/jukebox-api/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/jukebox-api/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml.expanded.jsonld
@@ -836,7 +836,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/konst1/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/lib-alias-reference/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/lib-alias-reference/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -394,7 +394,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/lib-alias-reference/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/lib-alias-reference/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -160,7 +160,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/libraries-3-alias/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/libraries-3-alias/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -394,7 +394,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/libraries-3-alias/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/libraries-3-alias/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -210,7 +210,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/libraries/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/libraries/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -555,7 +555,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/libraries/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/libraries/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -136,7 +136,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.expanded.jsonld
@@ -18,7 +18,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/library-annotations/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/matrix-id/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/matrix-id/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/matrix-id/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/matrix-id/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/matrix/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/matrix/api.raml.expanded.jsonld
@@ -191,7 +191,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/matrix/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/matrix/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/missing_example/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/missing_example/api.raml.expanded.jsonld
@@ -1121,7 +1121,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/missing_example/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/missing_example/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-inheritance-2/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-inheritance-2/api.raml.expanded.jsonld
@@ -218,7 +218,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-inheritance-2/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-inheritance-2/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-inheritance/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-inheritance/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-inheritance/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-inheritance/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-media-types/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-media-types/api.raml.expanded.jsonld
@@ -1151,7 +1151,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-media-types/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/multiple-media-types/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/named-example/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/named-example/api.raml.expanded.jsonld
@@ -54,7 +54,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -104,7 +104,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/named-example/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/named-example/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -128,7 +128,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/null-secured-by/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/null-secured-by/api.raml.expanded.jsonld
@@ -272,7 +272,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/null-secured-by/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/null-secured-by/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/number_title/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/number_title/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/number_title/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/number_title/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/numeric-facets/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/numeric-facets/api.raml.expanded.jsonld
@@ -572,7 +572,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/numeric-facets/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/numeric-facets/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/oauth_security_scheme/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/oauth_security_scheme/api.raml.expanded.jsonld
@@ -90,7 +90,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/oauth_security_scheme/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/oauth_security_scheme/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/operation-response/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/operation-response/api.raml.expanded.jsonld
@@ -771,7 +771,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/operation-response/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/operation-response/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/overlay/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/overlay/api.raml.expanded.jsonld
@@ -133,7 +133,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -2352,7 +2352,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/overlay/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/overlay/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -206,7 +206,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/parameters/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/parameters/api.raml.expanded.jsonld
@@ -231,7 +231,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/parameters/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/parameters/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/payloads/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/payloads/api.raml.expanded.jsonld
@@ -999,7 +999,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/payloads/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/payloads/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/query-string/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/query-string/api.raml.expanded.jsonld
@@ -485,7 +485,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/query-string/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/query-string/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/raml-security/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/raml-security/api.raml.expanded.jsonld
@@ -631,7 +631,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/raml-security/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/raml-security/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/referenced-example/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/referenced-example/api.raml.expanded.jsonld
@@ -980,7 +980,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1030,7 +1030,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/referenced-example/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/referenced-example/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -814,7 +814,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-complex-variables/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-complex-variables/api.raml.expanded.jsonld
@@ -1191,7 +1191,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-complex-variables/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-complex-variables/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-fragment/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-fragment/api.raml.expanded.jsonld
@@ -54,7 +54,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -650,7 +650,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-fragment/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-fragment/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -130,7 +130,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-multi-transformation/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-multi-transformation/api.raml.expanded.jsonld
@@ -686,7 +686,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-multi-transformation/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/resource-type-multi-transformation/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/sapi-customer/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/sapi-customer/api.raml.expanded.jsonld
@@ -5505,7 +5505,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -5555,7 +5555,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -5628,7 +5628,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/sapi-customer/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/sapi-customer/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -4281,7 +4281,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -4309,7 +4309,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml.expanded.jsonld
@@ -2296,7 +2296,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -3034,7 +3034,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/secured-by/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -1680,7 +1680,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/security-with-query-string/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/security-with-query-string/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/security-with-query-string/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/security-with-query-string/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/security/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/security/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/security/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/security/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/simple_example_type/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/simple_example_type/api.raml.expanded.jsonld
@@ -537,7 +537,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1029,7 +1029,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/simple_example_type/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/simple_example_type/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -511,7 +511,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/simple_xml_schema/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/simple_xml_schema/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/simple_xml_schema/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/simple_xml_schema/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/single-array-value/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/single-array-value/api.raml.expanded.jsonld
@@ -2388,7 +2388,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/single-array-value/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/single-array-value/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/spec_examples_example/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/spec_examples_example/api.raml.expanded.jsonld
@@ -2100,7 +2100,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/spec_examples_example/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/spec_examples_example/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/trait-fragment/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/trait-fragment/api.raml.expanded.jsonld
@@ -54,7 +54,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -423,7 +423,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/trait-fragment/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/trait-fragment/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -128,7 +128,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/trait-string-quoted-node/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/trait-string-quoted-node/api.raml.expanded.jsonld
@@ -739,7 +739,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/trait-string-quoted-node/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/trait-string-quoted-node/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/traits-resource-types/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/traits-resource-types/api.raml.expanded.jsonld
@@ -2327,7 +2327,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/traits-resource-types/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/traits-resource-types/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-chain-with-examples/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-chain-with-examples/api.raml.expanded.jsonld
@@ -90,7 +90,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-chain-with-examples/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-chain-with-examples/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-closed-true/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-closed-true/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-closed-true/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-closed-true/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-declared-with-square-bracket/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-declared-with-square-bracket/api.raml.expanded.jsonld
@@ -574,7 +574,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-declared-with-square-bracket/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-declared-with-square-bracket/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-facets/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-facets/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-facets/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type-facets/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml.expanded.jsonld
@@ -137,7 +137,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/type_nil_shortcut/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types-dependency/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types-dependency/api.raml.expanded.jsonld
@@ -3151,7 +3151,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types-dependency/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types-dependency/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types-facet/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types-facet/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types-facet/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types-facet/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types/api.raml.expanded.jsonld
@@ -3304,7 +3304,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml.expanded.jsonld
@@ -993,7 +993,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/types_problems2/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/unresolved-shape/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/unresolved-shape/api.raml.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/unresolved-shape/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/unresolved-shape/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml.expanded.jsonld
@@ -1429,7 +1429,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/users_accounts/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml.expanded.jsonld
@@ -1388,7 +1388,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1492,7 +1492,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1670,7 +1670,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1912,7 +1912,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -2673,7 +2673,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/cycle/raml10/with_references/api.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -1358,7 +1358,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -1394,7 +1394,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -1429,7 +1429,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {
@@ -1479,7 +1479,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/declared-responses.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/declared-responses.json.expanded.jsonld
@@ -363,7 +363,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/declared-responses.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/declared-responses.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/endpoints.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/endpoints.json.expanded.jsonld
@@ -773,7 +773,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/endpoints.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/endpoints.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/enums/enums.raml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/enums/enums.raml.expanded.jsonld
@@ -104,7 +104,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/enums/enums.raml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/enums/enums.raml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/examples.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/examples.json.expanded.jsonld
@@ -3558,7 +3558,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/examples.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/examples.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/externals.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/externals.json.expanded.jsonld
@@ -1507,7 +1507,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/externals.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/externals.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/file-type.json
+++ b/amf-cli/shared/src/test/resources/upanddown/file-type.json
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/form-data-params.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/form-data-params.expanded.jsonld
@@ -570,7 +570,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/form-data-params.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/form-data-params.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/formDataParameters.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/formDataParameters.expanded.jsonld
@@ -505,7 +505,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/formDataParameters.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/formDataParameters.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/formdata-parameters-multiple.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/formdata-parameters-multiple.expanded.jsonld
@@ -952,7 +952,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/formdata-parameters-multiple.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/formdata-parameters-multiple.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/full-example.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/full-example.json.expanded.jsonld
@@ -3316,7 +3316,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/full-example.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/full-example.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/any.proto.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/any.proto.expanded.jsonld
@@ -338,7 +338,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/any.proto.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/any.proto.flattened.jsonld
@@ -54,7 +54,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/api.proto.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/api.proto.expanded.jsonld
@@ -338,7 +338,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -833,7 +833,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -7167,7 +7167,7 @@
                 ],
                 "http://a.ml/vocabularies/apiContract#modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "http://a.ml/vocabularies/document#sourceSpec": [
@@ -7662,7 +7662,7 @@
                 ],
                 "http://a.ml/vocabularies/apiContract#modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "http://a.ml/vocabularies/document#sourceSpec": [
@@ -7692,7 +7692,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/api.proto.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/api.proto.flattened.jsonld
@@ -54,7 +54,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {
@@ -564,7 +564,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {
@@ -892,7 +892,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {
@@ -2216,7 +2216,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/duration.proto.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/duration.proto.expanded.jsonld
@@ -387,7 +387,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/duration.proto.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/duration.proto.flattened.jsonld
@@ -60,7 +60,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/empty.proto.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/empty.proto.expanded.jsonld
@@ -387,7 +387,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/empty.proto.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/empty.proto.flattened.jsonld
@@ -60,7 +60,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/field_mask.proto.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/field_mask.proto.expanded.jsonld
@@ -387,7 +387,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/field_mask.proto.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/field_mask.proto.flattened.jsonld
@@ -60,7 +60,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/source_context.proto.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/source_context.proto.expanded.jsonld
@@ -338,7 +338,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/source_context.proto.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/source_context.proto.flattened.jsonld
@@ -54,7 +54,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/struct.proto.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/struct.proto.expanded.jsonld
@@ -387,7 +387,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/struct.proto.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/struct.proto.flattened.jsonld
@@ -60,7 +60,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/timestamp.proto.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/timestamp.proto.expanded.jsonld
@@ -387,7 +387,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/timestamp.proto.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/timestamp.proto.flattened.jsonld
@@ -60,7 +60,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/type.proto.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/type.proto.expanded.jsonld
@@ -387,7 +387,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -964,7 +964,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1459,7 +1459,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/type.proto.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/type.proto.flattened.jsonld
@@ -60,7 +60,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {
@@ -733,7 +733,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {
@@ -812,7 +812,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/wrappers.proto.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/wrappers.proto.expanded.jsonld
@@ -387,7 +387,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/google/wrappers.proto.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/google/wrappers.proto.flattened.jsonld
@@ -60,7 +60,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/simple.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/simple.expanded.jsonld
@@ -1230,7 +1230,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [
@@ -1464,7 +1464,7 @@
             ],
             "http://a.ml/vocabularies/apiContract#modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/grpc/simple.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/grpc/simple.flattened.jsonld
@@ -46,7 +46,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {
@@ -1320,7 +1320,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "Grpc"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/oas-fragment-ref/api.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas-fragment-ref/api.resolved.expanded.jsonld
@@ -388,7 +388,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/oas-fragment-ref/api.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas-fragment-ref/api.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/oas3/parameter-payload-resolution/parameter-payload-examples.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas3/parameter-payload-resolution/parameter-payload-examples.expanded.jsonld
@@ -250,7 +250,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/oas3/parameter-payload-resolution/parameter-payload-examples.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas3/parameter-payload-resolution/parameter-payload-examples.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/oas3/summary-description-in-path/description-applied-to-operations-resolution.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas3/summary-description-in-path/description-applied-to-operations-resolution.expanded.jsonld
@@ -1236,7 +1236,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/oas3/summary-description-in-path/description-applied-to-operations-resolution.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas3/summary-description-in-path/description-applied-to-operations-resolution.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/oas_foward_definitions.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas_foward_definitions.resolved.expanded.jsonld
@@ -190,7 +190,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/oas_foward_definitions.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas_foward_definitions.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/oas_response_declaration.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas_response_declaration.expanded.jsonld
@@ -291,7 +291,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/oas_response_declaration.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas_response_declaration.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/oas_response_declaration.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas_response_declaration.resolved.expanded.jsonld
@@ -424,7 +424,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/oas_response_declaration.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas_response_declaration.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.expanded.jsonld
@@ -621,7 +621,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/orphan_extensions.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/parameters.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/parameters.json.expanded.jsonld
@@ -234,7 +234,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/parameters.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/parameters.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/petstore/petstore.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/petstore/petstore.expanded.jsonld
@@ -627,7 +627,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/petstore/petstore.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/petstore/petstore.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/query-string.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/query-string.json.expanded.jsonld
@@ -530,7 +530,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/query-string.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/query-string.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/raml08/schemas-lexical-info.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml08/schemas-lexical-info.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml08/schemas-lexical-info.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml08/schemas-lexical-info.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 0.8"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/annotations/api.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/annotations/api.jsonld
@@ -376,7 +376,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/array-override/api.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/array-override/api.jsonld
@@ -58,7 +58,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/duplicate-id-in-param-types/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/duplicate-id-in-param-types/api.expanded.jsonld
@@ -1428,7 +1428,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/duplicate-id-in-param-types/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/duplicate-id-in-param-types/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions-in-resource-types/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions-in-resource-types/api.expanded.jsonld
@@ -496,7 +496,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions-in-resource-types/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions-in-resource-types/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions-in-traits/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions-in-traits/api.expanded.jsonld
@@ -472,7 +472,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions-in-traits/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions-in-traits/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions/api.expanded.jsonld
@@ -192,7 +192,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/multiple-non-nested-unions/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/nillable-type-in-parameter/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/nillable-type-in-parameter/api.expanded.jsonld
@@ -2405,7 +2405,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/nillable-type-in-parameter/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/nillable-type-in-parameter/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/raml-default-schema-version.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/raml-default-schema-version.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/raml-default-schema-version.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/raml-default-schema-version.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/raml-reference-draft-7.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/raml-reference-draft-7.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/raml-reference-draft-7.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/raml-reference-draft-7.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/type-with-json-schema-in-type-facet.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/type-with-json-schema-in-type-facet.expanded.jsonld
@@ -72,7 +72,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/type-with-json-schema-in-type-facet.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/type-with-json-schema-in-type-facet.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/union-combinatorial/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/union-combinatorial/api.expanded.jsonld
@@ -58,7 +58,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/union-combinatorial/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/union-combinatorial/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/unions/triple-unions.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/unions/triple-unions.resolved.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/raml10/unions/triple-unions.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/raml10/unions/triple-unions.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/security-with-query-string.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/security-with-query-string.json.expanded.jsonld
@@ -104,7 +104,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/security-with-query-string.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/security-with-query-string.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/security.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/security.json.expanded.jsonld
@@ -104,7 +104,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/security.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/security.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/shapes-with-items.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/shapes-with-items.expanded.jsonld
@@ -774,7 +774,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/shapes-with-items.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/shapes-with-items.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/simple_example_type.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/simple_example_type.resolved.expanded.jsonld
@@ -191,7 +191,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -411,7 +411,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/simple_example_type.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/simple_example_type.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -385,7 +385,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/upanddown/tags.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/tags.expanded.jsonld
@@ -537,7 +537,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/tags.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/tags.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/traits-resource-types.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/traits-resource-types.json.expanded.jsonld
@@ -2318,7 +2318,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/traits-resource-types.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/traits-resource-types.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/type-facets.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/type-facets.json.expanded.jsonld
@@ -104,7 +104,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/type-facets.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/type-facets.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/types-dependency.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/types-dependency.json.expanded.jsonld
@@ -2915,7 +2915,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/types-dependency.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/types-dependency.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/types-facet.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/types-facet.json.expanded.jsonld
@@ -104,7 +104,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/upanddown/types-facet.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/types-facet.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/upanddown/union_arrays.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/union_arrays.resolved.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/union_arrays.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/union_arrays.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/upanddown/with_references_resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/with_references_resolved.expanded.jsonld
@@ -1610,7 +1610,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/upanddown/with_references_resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/with_references_resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/api-with-xml-examples/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/api-with-xml-examples/api.expanded.jsonld
@@ -762,7 +762,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/api-with-xml-examples/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/api-with-xml-examples/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 0.8"
     },

--- a/amf-cli/shared/src/test/resources/validations/async20/amqp-channel-binding-010.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/amqp-channel-binding-010.expanded.jsonld
@@ -521,7 +521,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/amqp-channel-binding-010.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/amqp-channel-binding-010.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/amqp-channel-binding-020.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/amqp-channel-binding-020.expanded.jsonld
@@ -557,7 +557,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/amqp-channel-binding-020.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/amqp-channel-binding-020.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/amqp-message-binding.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/amqp-message-binding.expanded.jsonld
@@ -403,7 +403,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/amqp-message-binding.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/amqp-message-binding.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/amqp-operation-binding.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/amqp-operation-binding.expanded.jsonld
@@ -665,7 +665,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/amqp-operation-binding.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/amqp-operation-binding.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.1-all.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.1-all.expanded.jsonld
@@ -2723,7 +2723,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.1-all.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.1-all.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.1"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.2-all.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.2-all.expanded.jsonld
@@ -3628,7 +3628,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.2-all.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.2-all.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.2"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.3-all.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.3-all.expanded.jsonld
@@ -3987,7 +3987,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.3-all.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.3-all.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.3"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.expanded.jsonld
@@ -61,6 +61,11 @@
                     "@value": "environment"
                   }
                 ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "API environment"
+                  }
+                ],
                 "http://a.ml/vocabularies/apiContract#required": [
                   {
                     "@value": true
@@ -89,11 +94,6 @@
                     "http://www.w3.org/ns/shacl#name": [
                       {
                         "@value": "environment"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/core#description": [
-                      {
-                        "@value": "API environment"
                       }
                     ],
                     "http://www.w3.org/ns/shacl#defaultValue": [
@@ -200,7 +200,7 @@
                         ],
                         "http://a.ml/vocabularies/document-source-maps#lexical": [
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -209,19 +209,6 @@
                             "http://a.ml/vocabularies/document-source-maps#value": [
                               {
                                 "@value": "[(24,8)-(25,0)]"
-                              }
-                            ]
-                          },
-                          {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "http://a.ml/vocabularies/core#description"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(25,8)-(26,0)]"
                               }
                             ]
                           },
@@ -239,7 +226,7 @@
                             ]
                           },
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment"
@@ -318,6 +305,32 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#lexical": [
                       {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_2",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(23,6)-(23,17)]"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#description"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(25,8)-(26,0)]"
+                          }
+                        ]
+                      },
+                      {
                         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1",
                         "http://a.ml/vocabularies/document-source-maps#element": [
                           {
@@ -327,19 +340,6 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "[(23,6)-(26,0)]"
-                          }
-                        ]
-                      },
-                      {
-                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "http://a.ml/vocabularies/core#name"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(23,6)-(23,17)]"
                           }
                         ]
                       }
@@ -362,6 +362,11 @@
                 "http://a.ml/vocabularies/apiContract#paramName": [
                   {
                     "@value": "version"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "API version"
                   }
                 ],
                 "http://a.ml/vocabularies/apiContract#required": [
@@ -392,11 +397,6 @@
                     "http://www.w3.org/ns/shacl#name": [
                       {
                         "@value": "version"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/core#description": [
-                      {
-                        "@value": "API version"
                       }
                     ],
                     "http://www.w3.org/ns/shacl#defaultValue": [
@@ -503,7 +503,7 @@
                         ],
                         "http://a.ml/vocabularies/document-source-maps#lexical": [
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_3",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -512,19 +512,6 @@
                             "http://a.ml/vocabularies/document-source-maps#value": [
                               {
                                 "@value": "[(27,8)-(28,0)]"
-                              }
-                            ]
-                          },
-                          {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "http://a.ml/vocabularies/core#description"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(28,8)-(29,0)]"
                               }
                             ]
                           },
@@ -542,7 +529,7 @@
                             ]
                           },
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version"
@@ -621,6 +608,32 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#lexical": [
                       {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_2",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(26,6)-(26,13)]"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#description"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(28,8)-(29,0)]"
+                          }
+                        ]
+                      },
+                      {
                         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1",
                         "http://a.ml/vocabularies/document-source-maps#element": [
                           {
@@ -630,19 +643,6 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "[(26,6)-(29,0)]"
-                          }
-                        ]
-                      },
-                      {
-                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "http://a.ml/vocabularies/core#name"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(26,6)-(26,13)]"
                           }
                         ]
                       }
@@ -7480,6 +7480,11 @@
             "@value": "environment"
           }
         ],
+        "http://a.ml/vocabularies/core#description": [
+          {
+            "@value": "Development API environment"
+          }
+        ],
         "http://a.ml/vocabularies/apiContract#required": [
           {
             "@value": true
@@ -7508,11 +7513,6 @@
             "http://www.w3.org/ns/shacl#name": [
               {
                 "@value": "environment"
-              }
-            ],
-            "http://a.ml/vocabularies/core#description": [
-              {
-                "@value": "Development API environment"
               }
             ],
             "http://www.w3.org/ns/shacl#defaultValue": [
@@ -7619,7 +7619,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -7628,19 +7628,6 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(156,6)-(157,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://a.ml/vocabularies/core#description"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(157,6)-(158,0)]"
                       }
                     ]
                   },
@@ -7658,7 +7645,7 @@
                     ]
                   },
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment"
@@ -7767,6 +7754,32 @@
             ],
             "http://a.ml/vocabularies/document-source-maps#lexical": [
               {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(155,4)-(155,15)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#description"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(157,6)-(158,0)]"
+                  }
+                ]
+              },
+              {
                 "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1",
                 "http://a.ml/vocabularies/document-source-maps#element": [
                   {
@@ -7776,19 +7789,6 @@
                 "http://a.ml/vocabularies/document-source-maps#value": [
                   {
                     "@value": "[(155,4)-(158,0)]"
-                  }
-                ]
-              },
-              {
-                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0",
-                "http://a.ml/vocabularies/document-source-maps#element": [
-                  {
-                    "@value": "http://a.ml/vocabularies/core#name"
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#value": [
-                  {
-                    "@value": "[(155,4)-(155,15)]"
                   }
                 ]
               }
@@ -7811,6 +7811,11 @@
         "http://a.ml/vocabularies/apiContract#paramName": [
           {
             "@value": "version"
+          }
+        ],
+        "http://a.ml/vocabularies/core#description": [
+          {
+            "@value": "Development API version"
           }
         ],
         "http://a.ml/vocabularies/apiContract#required": [
@@ -7841,11 +7846,6 @@
             "http://www.w3.org/ns/shacl#name": [
               {
                 "@value": "version"
-              }
-            ],
-            "http://a.ml/vocabularies/core#description": [
-              {
-                "@value": "Development API version"
               }
             ],
             "http://www.w3.org/ns/shacl#defaultValue": [
@@ -7952,7 +7952,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_3",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -7961,19 +7961,6 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(159,6)-(160,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://a.ml/vocabularies/core#description"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(160,6)-(161,0)]"
                       }
                     ]
                   },
@@ -7991,7 +7978,7 @@
                     ]
                   },
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version"
@@ -8100,6 +8087,32 @@
             ],
             "http://a.ml/vocabularies/document-source-maps#lexical": [
               {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(158,4)-(158,11)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#description"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(160,6)-(161,0)]"
+                  }
+                ]
+              },
+              {
                 "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1",
                 "http://a.ml/vocabularies/document-source-maps#element": [
                   {
@@ -8109,19 +8122,6 @@
                 "http://a.ml/vocabularies/document-source-maps#value": [
                   {
                     "@value": "[(158,4)-(161,0)]"
-                  }
-                ]
-              },
-              {
-                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0",
-                "http://a.ml/vocabularies/document-source-maps#element": [
-                  {
-                    "@value": "http://a.ml/vocabularies/core#name"
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#value": [
-                  {
-                    "@value": "[(158,4)-(158,11)]"
                   }
                 ]
               }

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.expanded.jsonld
@@ -5945,7 +5945,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.flattened.jsonld
@@ -217,6 +217,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "environment",
       "http://a.ml/vocabularies/apiContract#paramName": "environment",
+      "http://a.ml/vocabularies/core#description": "API environment",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -237,6 +238,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "version",
       "http://a.ml/vocabularies/apiContract#paramName": "version",
+      "http://a.ml/vocabularies/core#description": "API version",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -612,7 +614,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "environment",
-      "http://a.ml/vocabularies/core#description": "API environment",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/scalar_1"
       },
@@ -644,10 +645,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -666,7 +670,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "version",
-      "http://a.ml/vocabularies/core#description": "API version",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/scalar_1"
       },
@@ -698,10 +701,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -1221,16 +1227,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -1255,14 +1258,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(26,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(23,17)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(23,17)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(25,8)-(26,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(26,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/scalar_1",
@@ -1296,16 +1304,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -1330,14 +1335,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(29,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(26,13)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(26,13)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(28,8)-(29,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(29,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/scheme/oauth2",
@@ -1931,14 +1941,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,8)-(25,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(25,8)-(26,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_0",
@@ -1946,7 +1951,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,8)-(25,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment",
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,0)-(26,0)]"
     },
@@ -1975,14 +1980,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,8)-(28,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(28,8)-(29,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_0",
@@ -1990,7 +1990,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,8)-(28,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,0)-(29,0)]"
     },
@@ -4255,6 +4255,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "environment",
       "http://a.ml/vocabularies/apiContract#paramName": "environment",
+      "http://a.ml/vocabularies/core#description": "Development API environment",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -4275,6 +4276,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "version",
       "http://a.ml/vocabularies/apiContract#paramName": "version",
+      "http://a.ml/vocabularies/core#description": "Development API version",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -4449,7 +4451,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "environment",
-      "http://a.ml/vocabularies/core#description": "Development API environment",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/scalar_1"
       },
@@ -4491,10 +4492,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -4513,7 +4517,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "version",
-      "http://a.ml/vocabularies/core#description": "Development API version",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/scalar_1"
       },
@@ -4555,10 +4558,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -4835,16 +4841,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -4879,14 +4882,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(155,4)-(158,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(155,4)-(155,15)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(155,4)-(155,15)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(157,6)-(158,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(155,4)-(158,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/scalar_1",
@@ -4920,16 +4928,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -4964,14 +4969,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(158,4)-(161,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(158,4)-(158,11)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(158,4)-(158,11)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(160,6)-(161,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(158,4)-(161,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/shape/market/property/property/type/scalar/type/source-map",
@@ -5220,14 +5230,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(156,6)-(157,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(157,6)-(158,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_0",
@@ -5235,7 +5240,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(156,6)-(157,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/environment/scalar/environment",
       "http://a.ml/vocabularies/document-source-maps#value": "[(156,0)-(158,0)]"
     },
@@ -5264,14 +5269,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(159,6)-(160,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(160,6)-(161,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_0",
@@ -5279,7 +5279,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(159,6)-(160,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.yaml#/declares/parameter/path/version/scalar/version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(159,0)-(161,0)]"
     },

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.4-all.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.4"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.expanded.jsonld
@@ -6572,7 +6572,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.expanded.jsonld
@@ -61,6 +61,11 @@
                     "@value": "environment"
                   }
                 ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "API environment"
+                  }
+                ],
                 "http://a.ml/vocabularies/apiContract#required": [
                   {
                     "@value": true
@@ -89,11 +94,6 @@
                     "http://www.w3.org/ns/shacl#name": [
                       {
                         "@value": "environment"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/core#description": [
-                      {
-                        "@value": "API environment"
                       }
                     ],
                     "http://www.w3.org/ns/shacl#defaultValue": [
@@ -200,7 +200,7 @@
                         ],
                         "http://a.ml/vocabularies/document-source-maps#lexical": [
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -209,19 +209,6 @@
                             "http://a.ml/vocabularies/document-source-maps#value": [
                               {
                                 "@value": "[(24,8)-(25,0)]"
-                              }
-                            ]
-                          },
-                          {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "http://a.ml/vocabularies/core#description"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(25,8)-(26,0)]"
                               }
                             ]
                           },
@@ -239,7 +226,7 @@
                             ]
                           },
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment"
@@ -318,6 +305,32 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#lexical": [
                       {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_2",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(23,6)-(23,17)]"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#description"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(25,8)-(26,0)]"
+                          }
+                        ]
+                      },
+                      {
                         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1",
                         "http://a.ml/vocabularies/document-source-maps#element": [
                           {
@@ -327,19 +340,6 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "[(23,6)-(26,0)]"
-                          }
-                        ]
-                      },
-                      {
-                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "http://a.ml/vocabularies/core#name"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(23,6)-(23,17)]"
                           }
                         ]
                       }
@@ -362,6 +362,11 @@
                 "http://a.ml/vocabularies/apiContract#paramName": [
                   {
                     "@value": "version"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "API version"
                   }
                 ],
                 "http://a.ml/vocabularies/apiContract#required": [
@@ -392,11 +397,6 @@
                     "http://www.w3.org/ns/shacl#name": [
                       {
                         "@value": "version"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/core#description": [
-                      {
-                        "@value": "API version"
                       }
                     ],
                     "http://www.w3.org/ns/shacl#defaultValue": [
@@ -503,7 +503,7 @@
                         ],
                         "http://a.ml/vocabularies/document-source-maps#lexical": [
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_3",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -512,19 +512,6 @@
                             "http://a.ml/vocabularies/document-source-maps#value": [
                               {
                                 "@value": "[(27,8)-(28,0)]"
-                              }
-                            ]
-                          },
-                          {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "http://a.ml/vocabularies/core#description"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(28,8)-(29,0)]"
                               }
                             ]
                           },
@@ -542,7 +529,7 @@
                             ]
                           },
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version"
@@ -621,6 +608,32 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#lexical": [
                       {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_2",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(26,6)-(26,13)]"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#description"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(28,8)-(29,0)]"
+                          }
+                        ]
+                      },
+                      {
                         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1",
                         "http://a.ml/vocabularies/document-source-maps#element": [
                           {
@@ -630,19 +643,6 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "[(26,6)-(29,0)]"
-                          }
-                        ]
-                      },
-                      {
-                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "http://a.ml/vocabularies/core#name"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(26,6)-(26,13)]"
                           }
                         ]
                       }
@@ -8551,6 +8551,11 @@
             "@value": "environment"
           }
         ],
+        "http://a.ml/vocabularies/core#description": [
+          {
+            "@value": "Development API environment"
+          }
+        ],
         "http://a.ml/vocabularies/apiContract#required": [
           {
             "@value": true
@@ -8579,11 +8584,6 @@
             "http://www.w3.org/ns/shacl#name": [
               {
                 "@value": "environment"
-              }
-            ],
-            "http://a.ml/vocabularies/core#description": [
-              {
-                "@value": "Development API environment"
               }
             ],
             "http://www.w3.org/ns/shacl#defaultValue": [
@@ -8690,7 +8690,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -8699,19 +8699,6 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(183,6)-(184,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://a.ml/vocabularies/core#description"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(184,6)-(185,0)]"
                       }
                     ]
                   },
@@ -8729,7 +8716,7 @@
                     ]
                   },
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment"
@@ -8838,6 +8825,32 @@
             ],
             "http://a.ml/vocabularies/document-source-maps#lexical": [
               {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(182,4)-(182,15)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#description"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(184,6)-(185,0)]"
+                  }
+                ]
+              },
+              {
                 "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1",
                 "http://a.ml/vocabularies/document-source-maps#element": [
                   {
@@ -8847,19 +8860,6 @@
                 "http://a.ml/vocabularies/document-source-maps#value": [
                   {
                     "@value": "[(182,4)-(185,0)]"
-                  }
-                ]
-              },
-              {
-                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0",
-                "http://a.ml/vocabularies/document-source-maps#element": [
-                  {
-                    "@value": "http://a.ml/vocabularies/core#name"
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#value": [
-                  {
-                    "@value": "[(182,4)-(182,15)]"
                   }
                 ]
               }
@@ -8882,6 +8882,11 @@
         "http://a.ml/vocabularies/apiContract#paramName": [
           {
             "@value": "version"
+          }
+        ],
+        "http://a.ml/vocabularies/core#description": [
+          {
+            "@value": "Development API version"
           }
         ],
         "http://a.ml/vocabularies/apiContract#required": [
@@ -8912,11 +8917,6 @@
             "http://www.w3.org/ns/shacl#name": [
               {
                 "@value": "version"
-              }
-            ],
-            "http://a.ml/vocabularies/core#description": [
-              {
-                "@value": "Development API version"
               }
             ],
             "http://www.w3.org/ns/shacl#defaultValue": [
@@ -9023,7 +9023,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_3",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -9032,19 +9032,6 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(186,6)-(187,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://a.ml/vocabularies/core#description"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(187,6)-(188,0)]"
                       }
                     ]
                   },
@@ -9062,7 +9049,7 @@
                     ]
                   },
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version"
@@ -9171,6 +9158,32 @@
             ],
             "http://a.ml/vocabularies/document-source-maps#lexical": [
               {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(185,4)-(185,11)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#description"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(187,6)-(188,0)]"
+                  }
+                ]
+              },
+              {
                 "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1",
                 "http://a.ml/vocabularies/document-source-maps#element": [
                   {
@@ -9180,19 +9193,6 @@
                 "http://a.ml/vocabularies/document-source-maps#value": [
                   {
                     "@value": "[(185,4)-(188,0)]"
-                  }
-                ]
-              },
-              {
-                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0",
-                "http://a.ml/vocabularies/document-source-maps#element": [
-                  {
-                    "@value": "http://a.ml/vocabularies/core#name"
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#value": [
-                  {
-                    "@value": "[(185,4)-(185,11)]"
                   }
                 ]
               }

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.5"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.flattened.jsonld
@@ -236,6 +236,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "environment",
       "http://a.ml/vocabularies/apiContract#paramName": "environment",
+      "http://a.ml/vocabularies/core#description": "API environment",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -256,6 +257,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "version",
       "http://a.ml/vocabularies/apiContract#paramName": "version",
+      "http://a.ml/vocabularies/core#description": "API version",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -662,7 +664,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "environment",
-      "http://a.ml/vocabularies/core#description": "API environment",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/scalar_1"
       },
@@ -694,10 +695,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -716,7 +720,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "version",
-      "http://a.ml/vocabularies/core#description": "API version",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/scalar_1"
       },
@@ -748,10 +751,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -1321,16 +1327,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -1355,14 +1358,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(26,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(23,17)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(23,17)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(25,8)-(26,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(26,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/scalar_1",
@@ -1396,16 +1404,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -1430,14 +1435,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(29,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(26,13)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(26,13)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(28,8)-(29,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(29,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/scheme/oauth2",
@@ -2127,14 +2137,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,8)-(25,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(25,8)-(26,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_0",
@@ -2142,7 +2147,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,8)-(25,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment",
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,0)-(26,0)]"
     },
@@ -2171,14 +2176,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,8)-(28,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(28,8)-(29,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_0",
@@ -2186,7 +2186,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,8)-(28,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,0)-(29,0)]"
     },
@@ -4732,6 +4732,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "environment",
       "http://a.ml/vocabularies/apiContract#paramName": "environment",
+      "http://a.ml/vocabularies/core#description": "Development API environment",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -4752,6 +4753,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "version",
       "http://a.ml/vocabularies/apiContract#paramName": "version",
+      "http://a.ml/vocabularies/core#description": "Development API version",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -4965,7 +4967,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "environment",
-      "http://a.ml/vocabularies/core#description": "Development API environment",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/scalar_1"
       },
@@ -5007,10 +5008,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -5029,7 +5033,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "version",
-      "http://a.ml/vocabularies/core#description": "Development API version",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/scalar_1"
       },
@@ -5071,10 +5074,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -5407,16 +5413,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -5451,14 +5454,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(182,4)-(185,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(182,4)-(182,15)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(182,4)-(182,15)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(184,6)-(185,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(182,4)-(185,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/scalar_1",
@@ -5492,16 +5500,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -5536,14 +5541,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(185,4)-(188,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(185,4)-(185,11)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(185,4)-(185,11)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(187,6)-(188,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(185,4)-(188,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/shape/market/property/property/type/scalar/type/source-map",
@@ -5859,14 +5869,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(183,6)-(184,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(184,6)-(185,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_0",
@@ -5874,7 +5879,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(183,6)-(184,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/environment/scalar/environment",
       "http://a.ml/vocabularies/document-source-maps#value": "[(183,0)-(185,0)]"
     },
@@ -5903,14 +5908,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(186,6)-(187,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(187,6)-(188,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_0",
@@ -5918,7 +5918,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(186,6)-(187,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.5-all.yaml#/declares/parameter/path/version/scalar/version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(186,0)-(188,0)]"
     },

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.expanded.jsonld
@@ -7163,7 +7163,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.expanded.jsonld
@@ -61,6 +61,11 @@
                     "@value": "environment"
                   }
                 ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "API environment"
+                  }
+                ],
                 "http://a.ml/vocabularies/apiContract#required": [
                   {
                     "@value": true
@@ -89,11 +94,6 @@
                     "http://www.w3.org/ns/shacl#name": [
                       {
                         "@value": "environment"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/core#description": [
-                      {
-                        "@value": "API environment"
                       }
                     ],
                     "http://www.w3.org/ns/shacl#defaultValue": [
@@ -200,7 +200,7 @@
                         ],
                         "http://a.ml/vocabularies/document-source-maps#lexical": [
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -209,19 +209,6 @@
                             "http://a.ml/vocabularies/document-source-maps#value": [
                               {
                                 "@value": "[(24,8)-(25,0)]"
-                              }
-                            ]
-                          },
-                          {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "http://a.ml/vocabularies/core#description"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(25,8)-(26,0)]"
                               }
                             ]
                           },
@@ -239,7 +226,7 @@
                             ]
                           },
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment"
@@ -318,6 +305,32 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#lexical": [
                       {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_2",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(23,6)-(23,17)]"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#description"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(25,8)-(26,0)]"
+                          }
+                        ]
+                      },
+                      {
                         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1",
                         "http://a.ml/vocabularies/document-source-maps#element": [
                           {
@@ -327,19 +340,6 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "[(23,6)-(26,0)]"
-                          }
-                        ]
-                      },
-                      {
-                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "http://a.ml/vocabularies/core#name"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(23,6)-(23,17)]"
                           }
                         ]
                       }
@@ -362,6 +362,11 @@
                 "http://a.ml/vocabularies/apiContract#paramName": [
                   {
                     "@value": "version"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "API version"
                   }
                 ],
                 "http://a.ml/vocabularies/apiContract#required": [
@@ -392,11 +397,6 @@
                     "http://www.w3.org/ns/shacl#name": [
                       {
                         "@value": "version"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/core#description": [
-                      {
-                        "@value": "API version"
                       }
                     ],
                     "http://www.w3.org/ns/shacl#defaultValue": [
@@ -503,7 +503,7 @@
                         ],
                         "http://a.ml/vocabularies/document-source-maps#lexical": [
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_3",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -512,19 +512,6 @@
                             "http://a.ml/vocabularies/document-source-maps#value": [
                               {
                                 "@value": "[(27,8)-(28,0)]"
-                              }
-                            ]
-                          },
-                          {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
-                            "http://a.ml/vocabularies/document-source-maps#element": [
-                              {
-                                "@value": "http://a.ml/vocabularies/core#description"
-                              }
-                            ],
-                            "http://a.ml/vocabularies/document-source-maps#value": [
-                              {
-                                "@value": "[(28,8)-(29,0)]"
                               }
                             ]
                           },
@@ -542,7 +529,7 @@
                             ]
                           },
                           {
-                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
+                            "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
                             "http://a.ml/vocabularies/document-source-maps#element": [
                               {
                                 "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version"
@@ -621,6 +608,32 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#lexical": [
                       {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_2",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#name"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(26,6)-(26,13)]"
+                          }
+                        ]
+                      },
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0",
+                        "http://a.ml/vocabularies/document-source-maps#element": [
+                          {
+                            "@value": "http://a.ml/vocabularies/core#description"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/document-source-maps#value": [
+                          {
+                            "@value": "[(28,8)-(29,0)]"
+                          }
+                        ]
+                      },
+                      {
                         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1",
                         "http://a.ml/vocabularies/document-source-maps#element": [
                           {
@@ -630,19 +643,6 @@
                         "http://a.ml/vocabularies/document-source-maps#value": [
                           {
                             "@value": "[(26,6)-(29,0)]"
-                          }
-                        ]
-                      },
-                      {
-                        "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0",
-                        "http://a.ml/vocabularies/document-source-maps#element": [
-                          {
-                            "@value": "http://a.ml/vocabularies/core#name"
-                          }
-                        ],
-                        "http://a.ml/vocabularies/document-source-maps#value": [
-                          {
-                            "@value": "[(26,6)-(26,13)]"
                           }
                         ]
                       }
@@ -9142,6 +9142,11 @@
             "@value": "environment"
           }
         ],
+        "http://a.ml/vocabularies/core#description": [
+          {
+            "@value": "Development API environment"
+          }
+        ],
         "http://a.ml/vocabularies/apiContract#required": [
           {
             "@value": true
@@ -9170,11 +9175,6 @@
             "http://www.w3.org/ns/shacl#name": [
               {
                 "@value": "environment"
-              }
-            ],
-            "http://a.ml/vocabularies/core#description": [
-              {
-                "@value": "Development API environment"
               }
             ],
             "http://www.w3.org/ns/shacl#defaultValue": [
@@ -9281,7 +9281,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -9290,19 +9290,6 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(207,6)-(208,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://a.ml/vocabularies/core#description"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(208,6)-(209,0)]"
                       }
                     ]
                   },
@@ -9320,7 +9307,7 @@
                     ]
                   },
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment"
@@ -9429,6 +9416,32 @@
             ],
             "http://a.ml/vocabularies/document-source-maps#lexical": [
               {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(206,4)-(206,15)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#description"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(208,6)-(209,0)]"
+                  }
+                ]
+              },
+              {
                 "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1",
                 "http://a.ml/vocabularies/document-source-maps#element": [
                   {
@@ -9438,19 +9451,6 @@
                 "http://a.ml/vocabularies/document-source-maps#value": [
                   {
                     "@value": "[(206,4)-(209,0)]"
-                  }
-                ]
-              },
-              {
-                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0",
-                "http://a.ml/vocabularies/document-source-maps#element": [
-                  {
-                    "@value": "http://a.ml/vocabularies/core#name"
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#value": [
-                  {
-                    "@value": "[(206,4)-(206,15)]"
                   }
                 ]
               }
@@ -9473,6 +9473,11 @@
         "http://a.ml/vocabularies/apiContract#paramName": [
           {
             "@value": "version"
+          }
+        ],
+        "http://a.ml/vocabularies/core#description": [
+          {
+            "@value": "Development API version"
           }
         ],
         "http://a.ml/vocabularies/apiContract#required": [
@@ -9503,11 +9508,6 @@
             "http://www.w3.org/ns/shacl#name": [
               {
                 "@value": "version"
-              }
-            ],
-            "http://a.ml/vocabularies/core#description": [
-              {
-                "@value": "Development API version"
               }
             ],
             "http://www.w3.org/ns/shacl#defaultValue": [
@@ -9614,7 +9614,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_3",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://www.w3.org/ns/shacl#defaultValue"
@@ -9623,19 +9623,6 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(210,6)-(211,0)]"
-                      }
-                    ]
-                  },
-                  {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://a.ml/vocabularies/core#description"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(211,6)-(212,0)]"
                       }
                     ]
                   },
@@ -9653,7 +9640,7 @@
                     ]
                   },
                   {
-                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
+                    "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version"
@@ -9762,6 +9749,32 @@
             ],
             "http://a.ml/vocabularies/document-source-maps#lexical": [
               {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(209,4)-(209,11)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#description"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(211,6)-(212,0)]"
+                  }
+                ]
+              },
+              {
                 "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1",
                 "http://a.ml/vocabularies/document-source-maps#element": [
                   {
@@ -9771,19 +9784,6 @@
                 "http://a.ml/vocabularies/document-source-maps#value": [
                   {
                     "@value": "[(209,4)-(212,0)]"
-                  }
-                ]
-              },
-              {
-                "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0",
-                "http://a.ml/vocabularies/document-source-maps#element": [
-                  {
-                    "@value": "http://a.ml/vocabularies/core#name"
-                  }
-                ],
-                "http://a.ml/vocabularies/document-source-maps#value": [
-                  {
-                    "@value": "[(209,4)-(209,11)]"
                   }
                 ]
               }

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.flattened.jsonld
@@ -277,6 +277,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "environment",
       "http://a.ml/vocabularies/apiContract#paramName": "environment",
+      "http://a.ml/vocabularies/core#description": "API environment",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -297,6 +298,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "version",
       "http://a.ml/vocabularies/apiContract#paramName": "version",
+      "http://a.ml/vocabularies/core#description": "API version",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -774,7 +776,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "environment",
-      "http://a.ml/vocabularies/core#description": "API environment",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/scalar_1"
       },
@@ -806,10 +807,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -828,7 +832,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "version",
-      "http://a.ml/vocabularies/core#description": "API version",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/scalar_1"
       },
@@ -860,10 +863,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -1540,16 +1546,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -1574,14 +1577,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(26,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(23,17)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(23,17)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(25,8)-(26,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,6)-(26,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/scalar_1",
@@ -1615,16 +1623,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -1649,14 +1654,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(29,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(26,13)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(26,13)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(28,8)-(29,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(26,6)-(29,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/scheme/oauth2",
@@ -2438,14 +2448,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,8)-(25,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(25,8)-(26,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_0",
@@ -2453,7 +2458,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,8)-(25,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/environment/scalar/environment",
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,0)-(26,0)]"
     },
@@ -2482,14 +2487,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,8)-(28,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(28,8)-(29,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_0",
@@ -2497,7 +2497,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,8)-(28,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/async-api/server/some.com/variable/parameter/path/version/scalar/version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(27,0)-(29,0)]"
     },
@@ -5145,6 +5145,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "environment",
       "http://a.ml/vocabularies/apiContract#paramName": "environment",
+      "http://a.ml/vocabularies/core#description": "Development API environment",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -5165,6 +5166,7 @@
       ],
       "http://a.ml/vocabularies/core#name": "version",
       "http://a.ml/vocabularies/apiContract#paramName": "version",
+      "http://a.ml/vocabularies/core#description": "Development API version",
       "http://a.ml/vocabularies/apiContract#required": true,
       "http://a.ml/vocabularies/apiContract#binding": "path",
       "http://a.ml/vocabularies/shapes#schema": {
@@ -5378,7 +5380,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "environment",
-      "http://a.ml/vocabularies/core#description": "Development API environment",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/scalar_1"
       },
@@ -5420,10 +5421,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -5442,7 +5446,6 @@
         }
       ],
       "http://www.w3.org/ns/shacl#name": "version",
-      "http://a.ml/vocabularies/core#description": "Development API version",
       "http://www.w3.org/ns/shacl#defaultValue": {
         "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/scalar_1"
       },
@@ -5484,10 +5487,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -5820,16 +5826,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1"
         }
       ]
     },
@@ -5864,14 +5867,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(206,4)-(209,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(206,4)-(206,15)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(206,4)-(206,15)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(208,6)-(209,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(206,4)-(209,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/scalar_1",
@@ -5905,16 +5913,13 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_3"
-        },
-        {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2"
+          "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1"
         }
       ]
     },
@@ -5949,14 +5954,19 @@
       "http://a.ml/vocabularies/document-source-maps#value": ""
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(209,4)-(212,0)]"
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(209,4)-(209,11)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(209,4)-(209,11)]"
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(211,6)-(212,0)]"
+    },
+    {
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(209,4)-(212,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/shape/market/property/property/type/scalar/type/source-map",
@@ -6272,14 +6282,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(207,6)-(208,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(208,6)-(209,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_0",
@@ -6287,7 +6292,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(207,6)-(208,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/environment/scalar/environment",
       "http://a.ml/vocabularies/document-source-maps#value": "[(207,0)-(209,0)]"
     },
@@ -6316,14 +6321,9 @@
       "http://a.ml/vocabularies/document-source-maps#value": "true"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_3",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#defaultValue",
       "http://a.ml/vocabularies/document-source-maps#value": "[(210,6)-(211,0)]"
-    },
-    {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#description",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(211,6)-(212,0)]"
     },
     {
       "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_0",
@@ -6331,7 +6331,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(210,6)-(211,0)]"
     },
     {
-      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_2",
+      "@id": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.yaml#/declares/parameter/path/version/scalar/version",
       "http://a.ml/vocabularies/document-source-maps#value": "[(210,0)-(212,0)]"
     },

--- a/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/asyncApi-2.6-all.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.6"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/channel-parameters.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/channel-parameters.expanded.jsonld
@@ -614,7 +614,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/channel-parameters.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/channel-parameters.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/components/async-components.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/components/async-components.expanded.jsonld
@@ -1295,7 +1295,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/components/async-components.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/components/async-components.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/components/external-operation-traits.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/components/external-operation-traits.expanded.jsonld
@@ -318,7 +318,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/components/external-operation-traits.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/components/external-operation-traits.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/components/message-traits.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/components/message-traits.expanded.jsonld
@@ -465,7 +465,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/components/message-traits.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/components/message-traits.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/components/operation-traits.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/components/operation-traits.expanded.jsonld
@@ -282,7 +282,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/components/operation-traits.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/components/operation-traits.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/draft-7-schemas.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/draft-7-schemas.expanded.jsonld
@@ -6393,7 +6393,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/draft-7-schemas.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/draft-7-schemas.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/draft-7/references.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/draft-7/references.expanded.jsonld
@@ -90,7 +90,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/draft-7/references.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/draft-7/references.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/empty-binding-and-annotations.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/empty-binding-and-annotations.expanded.jsonld
@@ -3124,7 +3124,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/empty-binding-and-annotations.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/empty-binding-and-annotations.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/http-message-binding.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/http-message-binding.expanded.jsonld
@@ -607,7 +607,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/http-message-binding.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/http-message-binding.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/http-operation-binding.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/http-operation-binding.expanded.jsonld
@@ -594,7 +594,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/http-operation-binding.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/http-operation-binding.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/kafka-message-binding.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/kafka-message-binding.expanded.jsonld
@@ -473,7 +473,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/kafka-message-binding.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/kafka-message-binding.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/kafka-operation-binding.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/kafka-operation-binding.expanded.jsonld
@@ -607,7 +607,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/kafka-operation-binding.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/kafka-operation-binding.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/message-obj.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/message-obj.expanded.jsonld
@@ -2149,7 +2149,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/message-obj.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/message-obj.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/mqtt-message-binding.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/mqtt-message-binding.expanded.jsonld
@@ -1125,7 +1125,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/mqtt-message-binding.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/mqtt-message-binding.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/mqtt-operation-binding.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/mqtt-operation-binding.expanded.jsonld
@@ -358,7 +358,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/mqtt-operation-binding.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/mqtt-operation-binding.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/mqtt-server-binding.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/mqtt-server-binding.expanded.jsonld
@@ -895,7 +895,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/mqtt-server-binding.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/mqtt-server-binding.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/publish-subscribe.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/publish-subscribe.expanded.jsonld
@@ -825,7 +825,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/publish-subscribe.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/publish-subscribe.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/chained-include.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/chained-include.expanded.jsonld
@@ -227,7 +227,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -454,7 +454,7 @@
                 ],
                 "apiContract:modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "doc:sourceSpec": [
@@ -484,7 +484,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/chained-include.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/chained-include.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },
@@ -402,7 +402,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -410,7 +410,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/include-root-payload.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/include-root-payload.expanded.jsonld
@@ -158,7 +158,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -248,7 +248,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/include-root-payload.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/include-root-payload.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },
@@ -257,7 +257,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-data-type-fragment-invalid.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-data-type-fragment-invalid.expanded.jsonld
@@ -152,7 +152,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -204,7 +204,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-data-type-fragment-invalid.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-data-type-fragment-invalid.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },
@@ -213,7 +213,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-data-type-fragment.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-data-type-fragment.expanded.jsonld
@@ -158,7 +158,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -248,7 +248,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-data-type-fragment.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-data-type-fragment.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },
@@ -223,7 +223,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-external-yaml.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-external-yaml.expanded.jsonld
@@ -191,7 +191,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-external-yaml.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-external-yaml.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-type-in-library.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-type-in-library.expanded.jsonld
@@ -158,7 +158,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -399,7 +399,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-type-in-library.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/raml-data-type-references/ref-type-in-library.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },
@@ -307,7 +307,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/validations/async20/rpc-server.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/rpc-server.expanded.jsonld
@@ -2718,7 +2718,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/rpc-server.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/rpc-server.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/security-schemes.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/security-schemes.expanded.jsonld
@@ -2755,7 +2755,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/security-schemes.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/security-schemes.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/async20/validations/external-reference/external-ref-message-trait.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/validations/external-reference/external-ref-message-trait.expanded.jsonld
@@ -235,7 +235,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/async20/validations/external-reference/external-ref-message-trait.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/validations/external-reference/external-ref-message-trait.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/async20/validations/external-reference/external-ref-operation-trait.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/validations/external-reference/external-ref-operation-trait.expanded.jsonld
@@ -235,7 +235,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/async20/validations/external-reference/external-ref-operation-trait.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/validations/external-reference/external-ref-operation-trait.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "ASYNC 2.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/async20/validations/solace-server.yaml
+++ b/amf-cli/shared/src/test/resources/validations/async20/validations/solace-server.yaml
@@ -1,0 +1,14 @@
+asyncapi: '2.6.0'
+info:
+  title: Orders AsyncAPI
+  version: '1.0.0'
+servers:
+  solace-server:
+    protocol: solace
+    variables:
+      port:
+        description: This is my port
+        enum:
+          - '1000'
+    url: tcps://mr-connection-yi1vivxoitd.messaging.solace.cloud:55443
+channels: {}

--- a/amf-cli/shared/src/test/resources/validations/async20/ws-channel-binding.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/ws-channel-binding.expanded.jsonld
@@ -761,7 +761,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/async20/ws-channel-binding.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/async20/ws-channel-binding.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "ASYNC 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name-oas.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name-oas.expanded.jsonld
@@ -437,7 +437,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name-oas.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name-oas.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name-with-default.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name-with-default.expanded.jsonld
@@ -431,7 +431,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name-with-default.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name-with-default.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name.expanded.jsonld
@@ -1401,7 +1401,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -1552,7 +1552,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [
@@ -1700,7 +1700,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [
@@ -1848,7 +1848,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/auto-generated-schema-name/auto-generated-schema-name.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -1822,7 +1822,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -1830,7 +1830,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -1838,7 +1838,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/validations/body-link-name/body-link-name.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/body-link-name/body-link-name.expanded.jsonld
@@ -258,7 +258,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/body-link-name/body-link-name.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/body-link-name/body-link-name.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/dup-name-example-tracking/dup-name-example-tracking.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/dup-name-example-tracking/dup-name-example-tracking.expanded.jsonld
@@ -258,7 +258,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/dup-name-example-tracking/dup-name-example-tracking.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/dup-name-example-tracking/dup-name-example-tracking.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/examples/dialect-fragment/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/examples/dialect-fragment/api.expanded.jsonld
@@ -1884,7 +1884,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/validations/examples/dialect-fragment/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/examples/dialect-fragment/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/examples/inline-named-examples/api.resolved.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/examples/inline-named-examples/api.resolved.expanded.jsonld
@@ -1224,7 +1224,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -1687,7 +1687,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [
@@ -1742,7 +1742,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [
@@ -1797,7 +1797,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/examples/inline-named-examples/api.resolved.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/examples/inline-named-examples/api.resolved.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -1655,7 +1655,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -1672,7 +1672,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -1689,7 +1689,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/validations/examples/vocabulary-fragment/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/examples/vocabulary-fragment/api.expanded.jsonld
@@ -5459,7 +5459,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/validations/examples/vocabulary-fragment/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/examples/vocabulary-fragment/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/healthcare_reduced_v1.raml.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/healthcare_reduced_v1.raml.resolved.jsonld
@@ -308,7 +308,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/validations/healthcare_reduced_v2.raml.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/healthcare_reduced_v2.raml.resolved.jsonld
@@ -290,7 +290,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/validations/inheritance-provenance/from-declaration/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/inheritance-provenance/from-declaration/api.expanded.jsonld
@@ -290,7 +290,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/inheritance-provenance/from-declaration/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/inheritance-provenance/from-declaration/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-library/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-library/api.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -194,7 +194,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-library/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-library/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -157,7 +157,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-recursive-inheritance/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-recursive-inheritance/api.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-recursive-inheritance/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-recursive-inheritance/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-regular-inheritance/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-regular-inheritance/api.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-regular-inheritance/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/inheritance-provenance/with-regular-inheritance/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/japanese/cycle/oas30api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/cycle/oas30api.expanded.jsonld
@@ -1165,7 +1165,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/japanese/cycle/oas30api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/cycle/oas30api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/japanese/cycle/oasapi.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/cycle/oasapi.expanded.jsonld
@@ -1414,7 +1414,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/japanese/cycle/oasapi.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/cycle/oasapi.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/japanese/cycle/ramlapi.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/cycle/ramlapi.expanded.jsonld
@@ -1991,7 +1991,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/japanese/cycle/ramlapi.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/cycle/ramlapi.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/japanese/resolve/oas30api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/resolve/oas30api.expanded.jsonld
@@ -861,7 +861,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/validations/japanese/resolve/oas30api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/resolve/oas30api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/japanese/resolve/oasapi.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/resolve/oasapi.expanded.jsonld
@@ -1077,7 +1077,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/validations/japanese/resolve/oasapi.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/resolve/oasapi.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/japanese/resolve/ramlapi.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/resolve/ramlapi.expanded.jsonld
@@ -1949,7 +1949,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/validations/japanese/resolve/ramlapi.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/japanese/resolve/ramlapi.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#transformed": true,
       "http://a.ml/vocabularies/document#sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/json-schema-nested-refs/result.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/json-schema-nested-refs/result.expanded.jsonld
@@ -93,7 +93,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/json-schema-nested-refs/result.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/json-schema-nested-refs/result.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/jsonld-compact-uris/no-raw-source-maps-compact-uris.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/jsonld-compact-uris/no-raw-source-maps-compact-uris.expanded.jsonld
@@ -224,7 +224,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/jsonld-compact-uris/no-raw-source-maps-compact-uris.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/jsonld-compact-uris/no-raw-source-maps-compact-uris.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/jsonld-compact-uris/parsed-result.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/jsonld-compact-uris/parsed-result.expanded.jsonld
@@ -174,7 +174,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/jsonld-compact-uris/parsed-result.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/jsonld-compact-uris/parsed-result.flattened.jsonld
@@ -20,7 +20,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/links/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/links/api.expanded.jsonld
@@ -158,7 +158,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -353,7 +353,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/links/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/links/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -334,7 +334,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/validations/nil-type.raml.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/nil-type.raml.resolved.jsonld
@@ -268,7 +268,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/validations/oas-security/api-with-security-requirements.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/oas-security/api-with-security-requirements.expanded.jsonld
@@ -1269,7 +1269,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/oas-security/api-with-security-requirements.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/oas-security/api-with-security-requirements.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/oas2/cycled/invalid-endpoint-path-still-parses.json.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/oas2/cycled/invalid-endpoint-path-still-parses.json.expanded.jsonld
@@ -192,7 +192,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/oas2/cycled/invalid-endpoint-path-still-parses.json.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/oas2/cycled/invalid-endpoint-path-still-parses.json.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 2.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-components.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-components.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-flow.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-flow.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-flows.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-flows.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-info.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-info.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-server.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-server.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-xml-object.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/oas3/spec-extensions/extension-in-xml-object.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "http://a.ml/vocabularies/document#APIContractProcessingData"
       ],
-      "http://a.ml/vocabularies/apiContract#modelVersion": "3.9.0",
+      "http://a.ml/vocabularies/apiContract#modelVersion": "3.10.0",
       "http://a.ml/vocabularies/document#sourceSpec": "OAS 3.0"
     },
     {

--- a/amf-cli/shared/src/test/resources/validations/optional-scalar-value/optional-scalar-value.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/optional-scalar-value/optional-scalar-value.expanded.jsonld
@@ -115,7 +115,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/optional-scalar-value/optional-scalar-value.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/optional-scalar-value/optional-scalar-value.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/api.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case1/api.jsonld
@@ -48,7 +48,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -454,7 +454,7 @@
                     ],
                     "apiContract:modelVersion": [
                       {
-                        "@value": "3.9.0"
+                        "@value": "3.10.0"
                       }
                     ],
                     "doc:sourceSpec": [
@@ -484,7 +484,7 @@
                 ],
                 "apiContract:modelVersion": [
                   {
-                    "@value": "3.9.0"
+                    "@value": "3.10.0"
                   }
                 ],
                 "doc:sourceSpec": [
@@ -514,7 +514,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case2/api.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/raml/any-cant-override/case2/api.jsonld
@@ -18,7 +18,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/recursion-inheritance-properties.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/recursion-inheritance-properties.expanded.jsonld
@@ -338,7 +338,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/recursion-inheritance-properties.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/recursion-inheritance-properties.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/ref-from-allof-facet/result.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/ref-from-allof-facet/result.expanded.jsonld
@@ -56,7 +56,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/ref-from-allof-facet/result.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/ref-from-allof-facet/result.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 3.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/resolved-link-annotation/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/resolved-link-annotation/api.expanded.jsonld
@@ -238,7 +238,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/resolved-link-annotation/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/resolved-link-annotation/api.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/root-mediatype-propagation/root-mediatype-propagation.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/root-mediatype-propagation/root-mediatype-propagation.expanded.jsonld
@@ -201,7 +201,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/root-mediatype-propagation/root-mediatype-propagation.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/root-mediatype-propagation/root-mediatype-propagation.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/rt-parameters.raml.resolved.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/rt-parameters.raml.resolved.jsonld
@@ -399,7 +399,7 @@
         ],
         "http://a.ml/vocabularies/apiContract#modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "http://a.ml/vocabularies/document#transformed": [

--- a/amf-cli/shared/src/test/resources/validations/simple-recursion.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/simple-recursion.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/tracked-from-resource-type/tracked-from-resource-type.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/tracked-from-resource-type/tracked-from-resource-type.expanded.jsonld
@@ -653,7 +653,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -708,7 +708,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/tracked-from-resource-type/tracked-from-resource-type.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/tracked-from-resource-type/tracked-from-resource-type.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -744,7 +744,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/validations/tracked-oas-examples/tracked-oas-examples.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/tracked-oas-examples/tracked-oas-examples.expanded.jsonld
@@ -782,7 +782,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/tracked-oas-examples/tracked-oas-examples.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/tracked-oas-examples/tracked-oas-examples.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/tracked-oas-param-body/tracked-oas-param-body.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/tracked-oas-param-body/tracked-oas-param-body.expanded.jsonld
@@ -779,7 +779,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/tracked-oas-param-body/tracked-oas-param-body.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/tracked-oas-param-body/tracked-oas-param-body.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "OAS 2.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/tracked-to-linked/tracked-to-linked.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/tracked-to-linked/tracked-to-linked.expanded.jsonld
@@ -666,7 +666,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [
@@ -861,7 +861,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [
@@ -916,7 +916,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [
@@ -971,7 +971,7 @@
             ],
             "apiContract:modelVersion": [
               {
-                "@value": "3.9.0"
+                "@value": "3.10.0"
               }
             ],
             "doc:sourceSpec": [

--- a/amf-cli/shared/src/test/resources/validations/tracked-to-linked/tracked-to-linked.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/tracked-to-linked/tracked-to-linked.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },
@@ -900,7 +900,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -917,7 +917,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     },
     {
@@ -934,7 +934,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:sourceSpec": "RAML 1.0"
     }
   ],

--- a/amf-cli/shared/src/test/resources/validations/union-type-array.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/union-type-array.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/union-type-array.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/union-type-array.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/resources/validations/union-type-containg-array/union-type-containg-array.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/union-type-containg-array/union-type-containg-array.expanded.jsonld
@@ -42,7 +42,7 @@
         ],
         "apiContract:modelVersion": [
           {
-            "@value": "3.9.0"
+            "@value": "3.10.0"
           }
         ],
         "doc:transformed": [

--- a/amf-cli/shared/src/test/resources/validations/union-type-containg-array/union-type-containg-array.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/validations/union-type-containg-array/union-type-containg-array.flattened.jsonld
@@ -5,7 +5,7 @@
       "@type": [
         "doc:APIContractProcessingData"
       ],
-      "apiContract:modelVersion": "3.9.0",
+      "apiContract:modelVersion": "3.10.0",
       "doc:transformed": true,
       "doc:sourceSpec": "RAML 1.0"
     },

--- a/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
@@ -780,4 +780,16 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
       recordFieldSchema.annotations.lexical() should not be null
     }
   }
+
+  // W-16888404
+  test("async solace server parameter should have description at parameter level") {
+    val api = s"$basePath/async20/validations/solace-server.yaml"
+    asyncClient.parse(api) flatMap { parseResult =>
+      parseResult.results.isEmpty shouldBe true
+      val solaceServer  = getServers(parseResult.baseUnit, isWebApi = false).head
+      val portParameter = solaceServer.variables.head
+      portParameter.description.nonNull shouldBe true
+      portParameter.schema.description.isNullOrEmpty shouldBe true
+    }
+  }
 }


### PR DESCRIPTION
- **update amf snapshot in js package.json**
- **W-16888404: add avro tck test with payload in external ref**
- **W-16888404: parse server variable descriptions into parameter instead of schema**
- **W-16888404: bump amf model to 3.10.0 for avro model changes**
