### PR TITLE
W-10548463: [OAS 3.1] add ref summary and description

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/AMFConfiguration.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/client/scala/AMFConfiguration.scala
@@ -18,12 +18,7 @@ import amf.apicontract.internal.spec.avro.{AvroParsePlugin, AvroRenderPlugin}
 import amf.apicontract.internal.spec.oas._
 import amf.apicontract.internal.spec.raml._
 import amf.apicontract.internal.transformation._
-import amf.apicontract.internal.transformation.compatibility.{
-  Oas20CompatibilityPipeline,
-  Oas3CompatibilityPipeline,
-  Raml08CompatibilityPipeline,
-  Raml10CompatibilityPipeline
-}
+import amf.apicontract.internal.transformation.compatibility._
 import amf.apicontract.internal.validation.model.ApiEffectiveValidations._
 import amf.apicontract.internal.validation.model.ApiValidationProfiles._
 import amf.apicontract.internal.validation.payload.APIPayloadValidationPlugin
@@ -256,10 +251,10 @@ object OASConfiguration extends APIConfigurationBuilder {
       .withValidationProfile(Oas31ValidationProfile, Oas31EffectiveValidations)
       .withTransformationPipelines(
         List(
-          Oas30TransformationPipeline(),
-          Oas3EditingPipeline(),
-          Oas3CompatibilityPipeline(),
-          Oas3CachePipeline()
+          Oas31TransformationPipeline(),
+          Oas31EditingPipeline(),
+          Oas31CompatibilityPipeline(),
+          Oas31CachePipeline()
         )
       )
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/emitters/context/AsyncSpecEmitterContext.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/async/emitters/context/AsyncSpecEmitterContext.scala
@@ -10,7 +10,6 @@ import amf.apicontract.internal.spec.common.emitter.{
 }
 import amf.apicontract.internal.spec.oas.emitter.context.{OasLikeSpecEmitterContext, OasLikeSpecEmitterFactory}
 import amf.apicontract.internal.spec.oas.emitter.domain.OasSecurityRequirementEmitter
-import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.extensions.{CustomDomainProperty, ShapeExtension}
@@ -19,14 +18,12 @@ import amf.core.internal.metamodel.Field
 import amf.core.internal.parser.domain.FieldEntry
 import amf.core.internal.plugins.render.RenderConfiguration
 import amf.core.internal.remote.{AsyncApi20, Spec}
-import amf.core.internal.render.BaseEmitters.MapEntryEmitter
 import amf.core.internal.render.SpecOrdering
 import amf.core.internal.render.emitters.{Emitter, EntryEmitter, PartEmitter}
 import amf.shapes.internal.spec.common.emitter.annotations.FacetsInstanceEmitter
 import amf.shapes.internal.spec.common.emitter.{CustomFacetsEmitter, RefEmitter, TagToReferenceEmitter}
 import amf.shapes.internal.spec.common.{JSONSchemaDraft7SchemaVersion, SchemaVersion}
 import amf.shapes.internal.spec.oas.emitter.{OasRecursiveShapeEmitter, OasTypeEmitter}
-import org.yaml.model.YDocument.PartBuilder
 
 import scala.util.matching.Regex
 
@@ -103,7 +100,4 @@ class Async20SpecEmitterContext(
   override def schemasDeclarationsPath: String  = "/definitions/"
 }
 
-object AsyncRefEmitter extends RefEmitter {
-
-  override def ref(url: String, b: PartBuilder): Unit = b.obj(MapEntryEmitter("$ref", url).emit(_))
-}
+object AsyncRefEmitter extends RefEmitter {}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/avro/emitters/context/AvroSpecEmitterContext.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/avro/emitters/context/AvroSpecEmitterContext.scala
@@ -18,13 +18,11 @@ import amf.core.internal.metamodel.Field
 import amf.core.internal.parser.domain.FieldEntry
 import amf.core.internal.plugins.render.RenderConfiguration
 import amf.core.internal.remote.{AvroSchema, Spec}
-import amf.core.internal.render.BaseEmitters.MapEntryEmitter
 import amf.core.internal.render.SpecOrdering
 import amf.core.internal.render.emitters.{Emitter, EntryEmitter}
 import amf.shapes.internal.spec.common.emitter.annotations.FacetsInstanceEmitter
 import amf.shapes.internal.spec.common.emitter.{CustomFacetsEmitter, RefEmitter, TagToReferenceEmitter}
 import amf.shapes.internal.spec.common.{SchemaVersion, AVROSchema => AVROSchemaVersion}
-import org.yaml.model.YDocument.PartBuilder
 
 import scala.util.matching.Regex
 
@@ -82,6 +80,4 @@ class AvroSpecEmitterFactory(implicit override val spec: AvroSpecEmitterContext)
   override def headerEmitter: (Parameter, SpecOrdering, Seq[BaseUnit]) => EntryEmitter = ???
 }
 
-object AvroRefEmitter extends RefEmitter {
-  override def ref(url: String, b: PartBuilder): Unit = b.obj(MapEntryEmitter("$ref", url).emit(_))
-}
+object AvroRefEmitter extends RefEmitter {}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/emitter/AgnosticShapeEmitterContextAdapter.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/emitter/AgnosticShapeEmitterContextAdapter.scala
@@ -50,7 +50,7 @@ class AgnosticShapeEmitterContextAdapter(private val specCtx: SpecEmitterContext
 
   override def spec: Spec = specCtx.spec
 
-  override def ref(b: YDocument.PartBuilder, url: String): Unit = specCtx.ref(b, url)
+  override def ref(b: YDocument.PartBuilder, url: String, l: Linkable): Unit = specCtx.ref(b, url, l)
 
   override def schemaVersion: SchemaVersion = specCtx match {
     case oasCtx: OasLikeSpecEmitterContext => oasCtx.schemaVersion

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/emitter/ParameterEmitters.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/emitter/ParameterEmitters.scala
@@ -15,8 +15,6 @@ import amf.apicontract.internal.spec.raml
 import amf.apicontract.internal.spec.raml.emitter.RamlShapeEmitterContextAdapter
 import amf.apicontract.internal.spec.raml.emitter.context.{RamlSpecEmitterContext, XRaml10SpecEmitterContext}
 import amf.apicontract.internal.spec.spec.OasDefinitions
-import amf.core.client.scala.model.BoolField
-import org.mulesoft.common.client.lexical.Position
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.extensions.PropertyShape
 import amf.core.client.scala.model.domain.{AmfScalar, Shape}
@@ -38,6 +36,7 @@ import amf.shapes.internal.spec.common.emitter.{CommentEmitter, OasResponseExamp
 import amf.shapes.internal.spec.contexts.emitter.raml.RamlScalarEmitter
 import amf.shapes.internal.spec.oas.emitter.{OasSchemaEmitter, OasTypeEmitter}
 import amf.shapes.internal.spec.raml.emitter.{Raml08TypePartEmitter, Raml10TypeEmitter}
+import org.mulesoft.common.client.lexical.Position
 import org.yaml.model.YDocument.{EntryBuilder, PartBuilder}
 import org.yaml.model.YType.Bool
 import org.yaml.model.{YNode, YType}
@@ -368,10 +367,7 @@ case class ParameterEmitter(parameter: Parameter, ordering: SpecOrdering, refere
         if (asHeader) OasDefinitions.appendOas3ComponentsPrefix(parameter.linkLabel.value(), "headers")
         else OasDefinitions.appendParameterDefinitionsPrefix(parameter.linkLabel.value())
     }
-    spec.ref(
-      b,
-      label
-    )
+    spec.ref(b, label, parameter)
   }
 
   override def emit(b: PartBuilder): Unit =
@@ -550,7 +546,8 @@ case class PayloadAsParameterEmitter(payload: Payload, ordering: SpecOrdering, r
   override def emit(b: PartBuilder): Unit =
     handleInlinedRefOr(b, payload) {
       if (payload.isLink) {
-        spec.ref(b, OasDefinitions.appendParameterDefinitionsPrefix(payload.linkLabel.value()))
+        val url = OasDefinitions.appendParameterDefinitionsPrefix(payload.linkLabel.value())
+        spec.ref(b, url, payload)
       } else {
         payload.schema match {
           case file: FileShape => fileShape(file, b)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/emitter/SpecEmitterContext.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/emitter/SpecEmitterContext.scala
@@ -13,9 +13,10 @@ import amf.core.internal.remote.Spec
 import amf.core.internal.render.BaseEmitters.ArrayEmitter
 import amf.core.internal.render.SpecOrdering
 import amf.core.internal.render.emitters.{EntryEmitter, PartEmitter}
+import amf.shapes.client.scala.model.domain.AnyShape
 import amf.shapes.internal.spec.common.SchemaVersion
-import amf.shapes.internal.spec.common.emitter.{CustomFacetsEmitter, RefEmitter, TagToReferenceEmitter}
 import amf.shapes.internal.spec.common.emitter.annotations.{AnnotationEmitter, FacetsInstanceEmitter}
+import amf.shapes.internal.spec.common.emitter.{CustomFacetsEmitter, RefEmitter, TagToReferenceEmitter}
 import amf.shapes.internal.spec.contexts.DeclarationEmissionDecorator
 import org.yaml.model.YDocument.PartBuilder
 import org.yaml.model.YType
@@ -28,7 +29,7 @@ abstract class SpecEmitterContext(
 
   val options: RenderOptions = renderConfig.renderOptions
 
-  def ref(b: PartBuilder, url: String): Unit = refEmitter.ref(url, b)
+  def ref(b: PartBuilder, url: String, l: Linkable = AnyShape()): Unit = refEmitter.ref(url, b, l)
 
   def schemaVersion: SchemaVersion
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/parser/ParameterParsers.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/parser/ParameterParsers.scala
@@ -501,7 +501,7 @@ case class Oas2ParameterParser(
       entry => {
         val req: Boolean = entry.value.as[Boolean]
         payload.annotations += RequiredParamPayload(req, entry.range)
-        payload.set(PayloadModel.Required, AmfScalar(req, Annotations(entry.value)), Annotations(entry) )
+        payload.set(PayloadModel.Required, AmfScalar(req, Annotations(entry.value)), Annotations(entry))
       }
     )
     map.key("description", PayloadModel.Description in payload)
@@ -579,7 +579,7 @@ case class Oas2ParameterParser(
     ctx.declarations.findParameter(refUrl, SearchScope.All) match {
       case Some(param) =>
         val parameterName        = refUrl.split("/").last
-        val parameter: Parameter = param.link(AmfScalar(refUrl), Annotations(map), Annotations.synthesized())
+        val parameter: Parameter = ctx.link(param, map, AmfScalar(refUrl), Annotations(map), Annotations.synthesized())
         // TODO: Could also delete link name
         parameter.withName(parameterName)
         OasParameter(parameter, Some(ref))
@@ -587,7 +587,9 @@ case class Oas2ParameterParser(
         ctx.declarations.findPayload(refUrl, SearchScope.All) match {
           case Some(payload) =>
             OasParameter(
-              payload.link(AmfScalar(refUrl), Annotations(map), Annotations.synthesized()).asInstanceOf[Payload],
+              ctx
+                .link(payload, map, AmfScalar(refUrl), Annotations(map), Annotations.synthesized())
+                .asInstanceOf[Payload],
               Some(ref)
             )
           case None =>
@@ -799,8 +801,6 @@ case class OasParametersParser(values: Seq[YNode], parentId: String)(implicit ct
               AmfScalar(1, Annotations() += LexicalInformation(a.range) += ExplicitField())
             )
         }
-
-
 
         Option(payload.schema).foreach(property.withRange)
       }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/PathDescriptionNormalizationStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/PathDescriptionNormalizationStage.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.spec.common.transformation.stage
 import amf.apicontract.client.scala.model.domain.api.Api
 import amf.apicontract.client.scala.model.domain.{EndPoint, Operation}
 import amf.apicontract.internal.metamodel.domain.{EndPointModel, OperationModel}
-import amf.core.client.common.validation.{Async20Profile, Oas30Profile, ProfileName}
+import amf.core.client.common.validation.{Async20Profile, Oas30Profile, Oas31Profile, ProfileName}
 import amf.core.client.scala.AMFGraphConfiguration
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
@@ -26,8 +26,8 @@ class PathDescriptionNormalizationStage(profile: ProfileName, val keepEditingInf
   ): BaseUnit = {
     profile match {
       // TODO should run for Amf too
-      case Oas30Profile | Async20Profile => normalizeDescriptions(model)
-      case _                             => model
+      case Oas30Profile | Oas31Profile | Async20Profile => normalizeDescriptions(model)
+      case _                                            => model
     }
   }
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/PayloadAndParameterResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/PayloadAndParameterResolutionStage.scala
@@ -13,7 +13,7 @@ import amf.shapes.internal.domain.metamodel.common.ExamplesField
 import amf.shapes.internal.domain.resolution.ExampleTracking
 
 /** Propagate examples defined in parameters and payloads onto their corresponding shape so they are validated in the
-  * examples validation phase Only necessary for OAS 3.0 spec
+  * examples validation phase (Only necessary for OAS 3.0/3.1 spec)
   */
 class PayloadAndParameterResolutionStage(profile: ProfileName) extends TransformationStep() {
 
@@ -27,12 +27,12 @@ class PayloadAndParameterResolutionStage(profile: ProfileName) extends Transform
     if (appliesTo(profile)) resolveExamples(model)
     else model
 
-  protected def appliesTo(profile: ProfileName) = profile match {
-    case Oas30Profile | AmfProfile => true
-    case _                         => false
+  protected def appliesTo(profile: ProfileName): Boolean = profile match {
+    case Oas30Profile | Oas31Profile | AmfProfile => true
+    case _                                        => false
   }
 
-  def resolveExamples(model: BaseUnit): BaseUnit = {
+  private def resolveExamples(model: BaseUnit): BaseUnit = {
     model match {
       case doc: Document if doc.encodes.isInstanceOf[Api] =>
         val webApiContainers   = searchPayloadAndParams(doc.encodes.asInstanceOf[Api])
@@ -50,7 +50,7 @@ class PayloadAndParameterResolutionStage(profile: ProfileName) extends Transform
       case res: Response    => res.payloads
     }.flatten
 
-  def searchPayloadAndParams(baseApi: Api): Seq[SchemaContainerWithId] = {
+  private def searchPayloadAndParams(baseApi: Api): Seq[SchemaContainerWithId] = {
     baseApi.endPoints.flatMap { endpoint =>
       val paramSchemas    = endpoint.parameters.flatMap(_.payloads)
       val endpointSchemas = traverseEndpoint(endpoint)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/RequestParamsLinkStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/RequestParamsLinkStage.scala
@@ -9,6 +9,7 @@ import amf.core.client.scala.transform.TransformationStep
 import amf.core.internal.transform.stages.elements.resolution.ReferenceResolution
 import amf.core.internal.transform.stages.selectors.{LinkSelector, Selector}
 
+/** Resolve links in request parameters (OAS 3.0, 3.1) */
 object RequestParamsLinkStage extends TransformationStep {
   override def transform(
       model: BaseUnit,

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/RequestParamsLinkStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/RequestParamsLinkStage.scala
@@ -1,6 +1,7 @@
 package amf.apicontract.internal.spec.common.transformation.stage
 
 import amf.apicontract.client.scala.model.domain.Request
+import amf.apicontract.internal.transformation.ReferenceDocumentationResolver.updateSummaryAndDescription
 import amf.core.client.scala.AMFGraphConfiguration
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
@@ -37,6 +38,7 @@ private class RequestParamsLinkStage(val errorHandler: AMFErrorHandler) {
   }
 
   private def customDomainElementTransformation(resolved: DomainElement, link: Linkable): DomainElement = {
+    updateSummaryAndDescription(resolved, link)
     (resolved, link) match {
       case (resolvedReq: Request, link: Request) =>
         val copied = Request(resolvedReq.fields.copy(), resolvedReq.annotations.copy())

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/ServersNormalizationStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/transformation/stage/ServersNormalizationStage.scala
@@ -4,13 +4,13 @@ import amf.apicontract.client.scala.model.domain.api.{Api, AsyncApi, WebApi}
 import amf.apicontract.client.scala.model.domain.{EndPoint, Operation, Server, ServerContainer}
 import amf.apicontract.internal.metamodel.domain.api.{AsyncApiModel, WebApiModel}
 import amf.apicontract.internal.metamodel.domain.{EndPointModel, OperationModel}
-import amf.core.client.common.validation.{Oas30Profile, ProfileName}
+import amf.core.client.common.validation.{Oas30Profile, Oas31Profile, ProfileName}
 import amf.core.client.scala.AMFGraphConfiguration
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.transform.TransformationStep
 
-/** Place server models in the right locations according to OAS 3.0 and our own criterium for AMF
+/** Place server models in the right locations according to OAS 3.0 and our own criteria for AMF
   *
   * @param profile
   *   target profile
@@ -25,8 +25,8 @@ class ServersNormalizationStage(profile: ProfileName, val keepEditingInfo: Boole
   ): BaseUnit = {
     profile match {
       // TODO should run for Amf too
-      case Oas30Profile => normalizeServers(model)
-      case _            => model
+      case Oas30Profile | Oas31Profile => normalizeServers(model)
+      case _                           => model
     }
   }
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/emitter/document/OasDocumentEmitter.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/emitter/document/OasDocumentEmitter.scala
@@ -21,7 +21,6 @@ import amf.apicontract.internal.spec.oas.emitter.context.{
 import amf.apicontract.internal.spec.oas.emitter.domain._
 import amf.apicontract.internal.spec.raml.emitter.domain.ExtendsEmitter
 import amf.apicontract.internal.spec.spec.OasDefinitions
-import org.mulesoft.common.client.lexical.Position
 import amf.core.client.scala.model.document.{BaseUnit, Document}
 import amf.core.client.scala.model.domain.AmfScalar
 import amf.core.client.scala.model.domain.extensions.DomainExtension
@@ -40,8 +39,10 @@ import amf.shapes.internal.spec.common.emitter.ExternalReferenceUrlEmitter.handl
 import amf.shapes.internal.spec.common.emitter.ShapeEmitterContext
 import amf.shapes.internal.spec.common.emitter.annotations.AnnotationsEmitter
 import amf.shapes.internal.spec.oas.emitter.{OasOrphanAnnotationsEmitter, OasSpecEmitter}
+import org.mulesoft.common.client.lexical.Position
 import org.yaml.model.YDocument
 import org.yaml.model.YDocument.{EntryBuilder, PartBuilder}
+
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
@@ -317,7 +318,7 @@ case class Oas3RequestBodyEmitter(request: Request, ordering: SpecOrdering, refe
   override def emit(b: EntryBuilder): Unit = {
     if (request.isLink) {
       val refUrl = OasDefinitions.appendOas3ComponentsPrefix(request.linkLabel.value(), "requestBodies")
-      b.entry("requestBody", _.obj(_.entry("$ref", refUrl)))
+      b.entry("requestBody", specCtx.ref(_, refUrl, request))
     } else {
       val partEmitter: Oas3RequestBodyPartEmitter = Oas3RequestBodyPartEmitter(request, ordering, references)
       if (partEmitter.emitters.nonEmpty)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/emitter/domain/OasResponseEmitter.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/emitter/domain/OasResponseEmitter.scala
@@ -6,6 +6,7 @@ import amf.apicontract.internal.metamodel.domain.{PayloadModel, RequestModel, Re
 import amf.apicontract.internal.spec.common.emitter.RamlParametersEmitter
 import amf.apicontract.internal.spec.oas.emitter.context.{
   Oas2SpecEmitterFactory,
+  Oas31SpecEmitterFactory,
   Oas3SpecEmitterFactory,
   OasLikeShapeEmitterContextAdapter,
   OasSpecEmitterContext
@@ -15,7 +16,6 @@ import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.model.domain.AmfScalar
 import amf.core.internal.annotations.SynthesizedField
 import amf.core.internal.parser.domain.{Annotations, FieldEntry, Fields, Value}
-import amf.core.internal.remote.Mimes
 import amf.core.internal.remote.Mimes._
 import amf.core.internal.render.BaseEmitters._
 import amf.core.internal.render.SpecOrdering
@@ -81,7 +81,7 @@ case class OasResponsePartEmitter(response: Response, ordering: SpecOrdering, re
             .map(f => result += RamlParametersEmitter("headers", f, ordering, references)(spec))
 
           // OAS 3.0.0
-          if (spec.factory.isInstanceOf[Oas3SpecEmitterFactory]) {
+          if (spec.factory.isInstanceOf[Oas3SpecEmitterFactory] || spec.factory.isInstanceOf[Oas31SpecEmitterFactory]) {
             response.fields.fields().find(_.field == ResponseModel.Payloads) foreach { f: FieldEntry =>
               val payloads: Seq[Payload] = f.arrayValues
               val annotations            = f.value.annotations

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/emitter/domain/OasTagToReferenceEmitter.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/emitter/domain/OasTagToReferenceEmitter.scala
@@ -29,7 +29,7 @@ case class OasTagToReferenceEmitter(link: DomainElement)(implicit val specContex
 
   override protected def getRefUrlFor(element: DomainElement, default: String = referenceLabel)(implicit
       spec: ShapeEmitterContext
-  ) = element match {
+  ): String = element match {
     case p: Parameter if p.annotations.contains(classOf[DeclaredServerVariable]) =>
       appendOas3ComponentsPrefix(referenceLabel, "serverVariables")
     case _: Parameter                        => appendParameterDefinitionsPrefix(referenceLabel)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/context/Oas3WebApiContext.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/context/Oas3WebApiContext.scala
@@ -6,7 +6,6 @@ import amf.core.client.scala.parse.document.{ParsedReference, ParserContext}
 import amf.shapes.internal.spec.common.parser.SpecSyntax
 import amf.shapes.internal.spec.common.{OAS30SchemaVersion, SchemaPosition, SchemaVersion}
 import amf.shapes.internal.spec.oas.parser
-import amf.shapes.internal.spec.oas.parser.Oas3Settings
 
 class Oas3WebApiContext(
     loc: String,

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/Oas30RequestParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/Oas30RequestParser.scala
@@ -62,7 +62,10 @@ case class Oas30RequestParser(map: YMap, parentId: String, definitionEntry: YMap
     val name = OasDefinitions.stripOas3ComponentsPrefix(fullRef, "requestBodies")
     ctx.declarations
       .findRequestBody(name, SearchScope.Named)
-      .map(req => adopt(req.link(AmfScalar(name), Annotations(map), Annotations.synthesized())))
+      .map { req =>
+        val link = ctx.link(req, map, AmfScalar(name), Annotations(map), Annotations.synthesized())
+        adopt(link)
+      }
       .getOrElse {
         ctx.navigateToRemoteYNode(fullRef) match {
           case Some(navigation) =>

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasEndpointParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasEndpointParser.scala
@@ -31,7 +31,7 @@ abstract class OasEndpointParser(entry: YMapEntry, parentId: String, collector: 
 
     var parameters = Parameters()
     val entries    = ListBuffer[YMapEntry]()
-    // This are the rest of the parameters, this must be simple to be supported by OAS.
+    // These are the rest of the parameters, this must be simple to be supported by OAS.
     map
       .key("parameters")
       .foreach { entry =>

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasHeaderParametersParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasHeaderParametersParser.scala
@@ -4,18 +4,18 @@ import amf.apicontract.client.scala.model.domain.{Parameter, Payload}
 import amf.apicontract.internal.metamodel.domain.{ParameterModel, PayloadModel, ResponseModel}
 import amf.apicontract.internal.spec.common.WebApiDeclarations.ErrorParameter
 import amf.apicontract.internal.spec.common.parser.{Oas3ParameterParser, SpecParserOps}
-import amf.apicontract.internal.spec.oas.parser.context.{Oas3Syntax, OasWebApiContext}
+import amf.apicontract.internal.spec.oas.parser.context.OasWebApiContext
 import amf.apicontract.internal.spec.spec.OasDefinitions
 import amf.core.client.scala.model.domain.{AmfArray, AmfScalar, Shape}
 import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.{Annotations, ScalarNode, SearchScope}
 import amf.core.internal.remote.Spec
 import amf.core.internal.validation.CoreValidations
+import amf.shapes.client.scala.model.domain.Example
 import amf.shapes.internal.annotations.ExternalReferenceUrl
 import amf.shapes.internal.domain.resolution.ExampleTracking.tracking
-import amf.shapes.client.scala.model.domain.Example
-import amf.shapes.internal.spec.common.{OAS20SchemaVersion, SchemaPosition}
 import amf.shapes.internal.spec.common.parser.{AnnotationParser, OasExamplesParser, YMapEntryLike}
+import amf.shapes.internal.spec.common.{OAS20SchemaVersion, SchemaPosition}
 import amf.shapes.internal.spec.oas.parser.OasTypeParser
 import org.yaml.model.{YMap, YMapEntry, YScalar}
 
@@ -54,9 +54,10 @@ case class OasHeaderParameterParser(map: YMap, adopt: Parameter => Unit)(implici
           ctx.declarations
             .findHeader(label, SearchScope.Named)
             .map(header => {
-              val ref: Option[YScalar]  = map.key("$ref").flatMap(v => v.value.asOption[YScalar])
-              val annotations           = ref.map(Annotations(_)).getOrElse(Annotations.synthesized())
-              val linkHeader: Parameter = header.link(AmfScalar(label), annotations, Annotations.synthesized())
+              val ref: Option[YScalar] = map.key("$ref").flatMap(v => v.value.asOption[YScalar])
+              val annotations          = ref.map(Annotations(_)).getOrElse(Annotations.synthesized())
+              val linkHeader: Parameter =
+                ctx.link(header, map, AmfScalar(label), annotations, Annotations.synthesized())
               adopt(linkHeader)
               linkHeader
             })

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasLinkParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasLinkParser.scala
@@ -3,7 +3,7 @@ package amf.apicontract.internal.spec.oas.parser.domain
 import amf.apicontract.client.scala.model.domain.TemplatedLink
 import amf.apicontract.internal.metamodel.domain.TemplatedLinkModel
 import amf.apicontract.internal.spec.common.WebApiDeclarations.ErrorLink
-import amf.apicontract.internal.spec.common.parser.{SpecParserOps}
+import amf.apicontract.internal.spec.common.parser.SpecParserOps
 import amf.apicontract.internal.spec.oas.parser.context.OasWebApiContext
 import amf.apicontract.internal.spec.spec.OasDefinitions
 import amf.apicontract.internal.validation.definitions.ParserSideValidations.ExclusiveLinkTargetError
@@ -11,8 +11,8 @@ import amf.core.client.scala.model.domain.{AmfArray, AmfScalar}
 import amf.core.internal.parser.YMapOps
 import amf.core.internal.parser.domain.{Annotations, ScalarNode, SearchScope}
 import amf.core.internal.validation.CoreValidations
-import amf.shapes.internal.annotations.ExternalReferenceUrl
 import amf.shapes.client.scala.model.domain.IriTemplateMapping
+import amf.shapes.internal.annotations.ExternalReferenceUrl
 import amf.shapes.internal.domain.metamodel.IriTemplateMappingModel
 import amf.shapes.internal.spec.common.parser.{AnnotationParser, YMapEntryLike}
 import org.yaml.model.{YMap, YMapEntry, YScalar}
@@ -38,9 +38,11 @@ case class OasLinkParser(parentId: String, definitionEntry: YMapEntry)(implicit 
           .getOrElse(Annotations.synthesized())
         ctx.declarations
           .findTemplatedLink(label, SearchScope.Named)
-          .map(templatedLink =>
-            nameAndAdopt(templatedLink.link(AmfScalar(label), annotations, Annotations.synthesized()))
-          )
+          .map(templatedLink => {
+            val linkedElement =
+              ctx.link(templatedLink, map, AmfScalar(label), annotations, Annotations.synthesized())
+            nameAndAdopt(linkedElement)
+          })
           .getOrElse(remote(fullRef, map))
 
       case Right(_) => buildAndPopulate(map)
@@ -54,7 +56,6 @@ case class OasLinkParser(parentId: String, definitionEntry: YMapEntry)(implicit 
       case None =>
         ctx.eh.violation(CoreValidations.UnresolvedReference, "", s"Cannot find link reference $fullRef", map.location)
         nameAndAdopt(new ErrorLink(fullRef, map).link(fullRef))
-
     }
   }
 

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasOperationParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasOperationParser.scala
@@ -5,7 +5,7 @@ import amf.apicontract.client.scala.model.domain.{Operation, Response}
 import amf.apicontract.internal.metamodel.domain.api.WebApiModel
 import amf.apicontract.internal.metamodel.domain.{OperationModel, ResponseModel}
 import amf.apicontract.internal.spec.common.parser.OasLikeSecurityRequirementParser
-import amf.apicontract.internal.spec.oas.parser.context.{Oas3WebApiContext, OasWebApiContext}
+import amf.apicontract.internal.spec.oas.parser.context.{Oas31WebApiContext, Oas3WebApiContext, OasWebApiContext}
 import amf.apicontract.internal.spec.raml.parser.domain.ParametrizedDeclarationParser
 import amf.apicontract.internal.validation.definitions.ParserSideValidations.InvalidStatusCode
 import amf.core.client.scala.model.domain.AmfArray
@@ -51,9 +51,9 @@ abstract class OasOperationParser(entry: YMapEntry, adopt: Operation => Operatio
       }
     )
 
-    map.key("security".asOasExtension, entry => { parseSecurity(operation, entry) })
+    map.key("security".asOasExtension, entry => parseSecurity(operation, entry))
 
-    map.key("security", entry => { parseSecurity(operation, entry) })
+    map.key("security", entry => parseSecurity(operation, entry))
 
     map.key(
       "responses",
@@ -73,8 +73,11 @@ abstract class OasOperationParser(entry: YMapEntry, adopt: Operation => Operatio
                   .setWithoutId(ResponseModel.StatusCode, node.text(), Annotations.inferred())
                 if (!r.annotations.contains(classOf[SourceAST]))
                   r.annotations ++= Annotations(entry)
-                // Validation for OAS 3
-                if (ctx.isInstanceOf[Oas3WebApiContext] && entry.key.tagType != YType.Str)
+                // Validation for OAS 3.0 & 3.1
+                if (
+                  (ctx.isInstanceOf[Oas3WebApiContext] || ctx
+                    .isInstanceOf[Oas31WebApiContext]) && entry.key.tagType != YType.Str
+                )
                   ctx.eh.violation(
                     InvalidStatusCode,
                     r,

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasResponseParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasResponseParser.scala
@@ -40,7 +40,7 @@ case class OasResponseParser(map: YMap, adopted: Response => Unit)(implicit ctx:
         ctx.declarations
           .findResponse(name, SearchScope.Named)
           .map { res =>
-            val resLink: Response = res.link(AmfScalar(name), annotations, Annotations.synthesized())
+            val resLink: Response = ctx.link(res, map, AmfScalar(name), annotations, Annotations.synthesized())
             adopted(resLink)
             resLink
           }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas30TransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas30TransformationPipeline.scala
@@ -10,14 +10,14 @@ import amf.core.client.common.transform._
 import amf.core.client.common.validation.{Oas30Profile, ProfileName}
 import amf.core.client.scala.transform.TransformationStep
 
-class Oas30TransformationPipeline private (override val name: String) extends AmfTransformationPipeline(name) {
+class Oas30TransformationPipeline private[amf] (override val name: String) extends AmfTransformationPipeline(name) {
   override def profileName: ProfileName = Oas30Profile
   override def references               = new WebApiReferenceResolutionStage()
 
   override protected def parameterNormalizationStage: ParametersNormalizationStage =
     new OpenApiParametersNormalizationStage()
 
-  override def steps: Seq[TransformationStep] = Seq(RequestParamsLinkStage) ++ super.steps
+  override def steps: Seq[TransformationStep] = RequestParamsLinkStage +: super.steps
 }
 
 object Oas30TransformationPipeline {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas30ValidationTransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas30ValidationTransformationPipeline.scala
@@ -1,16 +1,16 @@
 package amf.apicontract.internal.transformation
 
 import amf.apicontract.internal.spec.common.transformation.stage.RequestParamsLinkStage
-import amf.core.client.common.validation.Oas30Profile
+import amf.core.client.common.validation.{Oas30Profile, ProfileName}
 import amf.core.client.scala.transform.TransformationStep
 
-class Oas30ValidationTransformationPipeline private (override val name: String)
-    extends ValidationTransformationPipeline(Oas30Profile, name) {
+class Oas30ValidationTransformationPipeline private[amf] (override val name: String, val profile: ProfileName)
+    extends ValidationTransformationPipeline(profile, name) {
 
   override def steps: Seq[TransformationStep] = RequestParamsLinkStage +: super.steps
 }
 
 object Oas30ValidationTransformationPipeline {
   val name: String = "Oas30ValidationTransformationPipeline"
-  def apply()      = new Oas30ValidationTransformationPipeline(name)
+  def apply()      = new Oas30ValidationTransformationPipeline(name, Oas30Profile)
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas31EditingPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas31EditingPipeline.scala
@@ -1,0 +1,24 @@
+package amf.apicontract.internal.transformation
+
+import amf.core.client.common.transform._
+import amf.core.client.common.validation.{Oas31Profile, ProfileName}
+import amf.core.client.scala.transform.TransformationStep
+
+class Oas31EditingPipeline private[amf] (urlShortening: Boolean, override val name: String)
+    extends Oas3EditingPipeline(urlShortening, name) {
+  override def profileName: ProfileName = Oas31Profile
+
+  override def steps: Seq[TransformationStep] = super.steps
+}
+
+object Oas31EditingPipeline {
+  val name: String = PipelineId.Editing
+  def apply()      = new Oas31EditingPipeline(true, name = name)
+
+  private[amf] def cachePipeline() = new Oas31EditingPipeline(false, Oas31CachePipeline.name)
+}
+
+object Oas31CachePipeline {
+  val name: String                  = PipelineId.Cache
+  def apply(): Oas31EditingPipeline = Oas31EditingPipeline.cachePipeline()
+}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas31TransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas31TransformationPipeline.scala
@@ -1,0 +1,16 @@
+package amf.apicontract.internal.transformation
+
+import amf.core.client.common.transform._
+import amf.core.client.common.validation.{Oas31Profile, ProfileName}
+import amf.core.client.scala.transform.TransformationStep
+
+class Oas31TransformationPipeline private[amf] (override val name: String) extends Oas30TransformationPipeline(name) {
+  override def profileName: ProfileName = Oas31Profile
+
+  override def steps: Seq[TransformationStep] = super.steps
+}
+
+object Oas31TransformationPipeline {
+  def apply()      = new Oas31TransformationPipeline(name)
+  val name: String = PipelineId.Default
+}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas31ValidationTransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas31ValidationTransformationPipeline.scala
@@ -1,0 +1,15 @@
+package amf.apicontract.internal.transformation
+
+import amf.core.client.common.validation.{Oas31Profile, ProfileName}
+import amf.core.client.scala.transform.TransformationStep
+
+class Oas31ValidationTransformationPipeline(override val name: String, val profileName: ProfileName)
+    extends Oas30ValidationTransformationPipeline(name, profileName) {
+
+  override def steps: Seq[TransformationStep] = super.steps
+}
+
+object Oas31ValidationTransformationPipeline {
+  val name: String = "Oas31ValidationTransformationPipeline"
+  def apply()      = new Oas31ValidationTransformationPipeline(name, Oas31Profile)
+}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas3EditingPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/Oas3EditingPipeline.scala
@@ -10,17 +10,14 @@ import amf.core.client.common.transform._
 import amf.core.client.common.validation.{Oas30Profile, ProfileName}
 import amf.core.client.scala.transform.TransformationStep
 
-class Oas3EditingPipeline private (urlShortening: Boolean, override val name: String)
+class Oas3EditingPipeline private[amf] (urlShortening: Boolean, override val name: String)
     extends AmfEditingPipeline(urlShortening, name) {
   override def profileName: ProfileName = Oas30Profile
   override def references               = new WebApiReferenceResolutionStage(true)
 
   override def parameterNormalizationStage: ParametersNormalizationStage = new OpenApiParametersNormalizationStage()
 
-  override def steps: Seq[TransformationStep] =
-    Seq(
-      RequestParamsLinkStage
-    ) ++ super.steps
+  override def steps: Seq[TransformationStep] = RequestParamsLinkStage +: super.steps
 }
 
 object Oas3EditingPipeline {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ReferenceDocumentationResolver.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ReferenceDocumentationResolver.scala
@@ -1,0 +1,34 @@
+package amf.apicontract.internal.transformation
+
+import amf.apicontract.client.scala.model.domain.{Operation, Parameter, Request, Response, TemplatedLink}
+import amf.apicontract.client.scala.model.domain.security.SecurityScheme
+import amf.core.client.scala.model.domain.{DomainElement, Linkable}
+import amf.core.internal.metamodel.domain.LinkableElementModel
+import amf.shapes.client.scala.model.domain.Example
+
+object ReferenceDocumentationResolver {
+  def updateSummaryAndDescription(domain: DomainElement, source: Linkable): Unit = {
+    def updateSummary(updateFn: String => Unit): Unit =
+      Option(source.refSummary.value()).filter(_.nonEmpty).foreach(updateFn)
+
+    def updateDescription(updateFn: String => Unit): Unit =
+      Option(source.refDescription.value()).filter(_.nonEmpty).foreach(updateFn)
+
+    domain match {
+      case operation: Operation =>
+        updateSummary(operation.withSummary)
+        updateDescription(operation.withDescription)
+      case example: Example =>
+        updateSummary(example.withSummary)
+        updateDescription(example.withDescription)
+      case response: Response             => updateDescription(response.withDescription)
+      case param: Parameter               => updateDescription(param.withDescription)
+      case request: Request               => updateDescription(request.withDescription)
+      case securityScheme: SecurityScheme => updateDescription(securityScheme.withDescription)
+      case templatedLink: TemplatedLink   => updateDescription(templatedLink.withDescription)
+      case _                              => // ignore
+    }
+    source.fields.removeField(LinkableElementModel.RefSummary)
+    source.fields.removeField(LinkableElementModel.RefDescription)
+  }
+}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ValidationTransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ValidationTransformationPipeline.scala
@@ -20,6 +20,7 @@ import amf.core.client.common.validation.{
   GraphQLProfile,
   Oas20Profile,
   Oas30Profile,
+  Oas31Profile,
   ProfileName,
   Raml08Profile,
   Raml10Profile
@@ -55,9 +56,10 @@ class ValidationTransformationPipeline private[amf] (
 
   private def parameterNormalizationStageFor(profile: ProfileName): ParametersNormalizationStage = {
     profile match {
-      case Raml10Profile                                                => new Raml10ParametersNormalizationStage
-      case Oas30Profile | Oas20Profile | Raml08Profile | Async20Profile => new OpenApiParametersNormalizationStage
-      case _                                                            => new AmfParametersNormalizationStage
+      case Raml10Profile => new Raml10ParametersNormalizationStage
+      case Oas30Profile | Oas31Profile | Oas20Profile | Raml08Profile | Async20Profile =>
+        new OpenApiParametersNormalizationStage
+      case _ => new AmfParametersNormalizationStage
     }
   }
 }
@@ -66,6 +68,7 @@ object ValidationTransformationPipeline {
   def apply(profile: ProfileName, unit: BaseUnit, configuration: ValidationConfiguration): BaseUnit = {
     val pipeline = profile match {
       case Oas30Profile                              => Oas30ValidationTransformationPipeline()
+      case Oas31Profile                              => Oas31ValidationTransformationPipeline()
       case Async20Profile                            => Async20CachePipeline()
       case GraphQLProfile | GraphQLFederationProfile => GraphQLCachePipeline()
       case _                                         => new ValidationTransformationPipeline(profile)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas31CompatibilityPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas31CompatibilityPipeline.scala
@@ -1,0 +1,17 @@
+package amf.apicontract.internal.transformation.compatibility
+
+import amf.apicontract.internal.transformation.Oas31TransformationPipeline
+import amf.core.client.common.transform._
+import amf.core.client.scala.transform.TransformationStep
+
+class Oas31CompatibilityPipeline private[amf] (override val name: String) extends Oas3CompatibilityPipeline(name) {
+
+  override val baseSteps: Seq[TransformationStep] = filterOutSemanticStage(Oas31TransformationPipeline().steps)
+
+  override def steps: Seq[TransformationStep] = baseSteps ++ super.steps
+}
+
+object Oas31CompatibilityPipeline {
+  def apply(): Oas31CompatibilityPipeline = new Oas31CompatibilityPipeline(name)
+  val name: String                        = PipelineId.Compatibility
+}

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas31CompatibilityPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas31CompatibilityPipeline.scala
@@ -8,7 +8,7 @@ class Oas31CompatibilityPipeline private[amf] (override val name: String) extend
 
   override val baseSteps: Seq[TransformationStep] = filterOutSemanticStage(Oas31TransformationPipeline().steps)
 
-  override def steps: Seq[TransformationStep] = baseSteps ++ super.steps
+  override def steps: Seq[TransformationStep] = super.steps
 }
 
 object Oas31CompatibilityPipeline {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas3CompatibilityPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/compatibility/Oas3CompatibilityPipeline.scala
@@ -7,11 +7,11 @@ import amf.apicontract.internal.transformation.compatibility.oas3._
 import amf.core.client.common.transform._
 import amf.core.client.scala.transform.{TransformationPipeline, TransformationStep}
 
-class Oas3CompatibilityPipeline private (override val name: String)
+class Oas3CompatibilityPipeline private[amf] (override val name: String)
     extends TransformationPipeline()
     with SemanticFlattenFilter {
 
-  private val baseSteps: Seq[TransformationStep] = filterOutSemanticStage(Oas30TransformationPipeline().steps)
+  val baseSteps: Seq[TransformationStep] = filterOutSemanticStage(Oas30TransformationPipeline().steps)
 
   override def steps: Seq[TransformationStep] =
     baseSteps ++ Seq(

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/WebApiReferenceResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/WebApiReferenceResolutionStage.scala
@@ -1,17 +1,19 @@
 package amf.apicontract.internal.transformation.stages
 
-import amf.apicontract.client.scala.model.domain.{EndPoint, Message, Parameter, Request, Response, Server}
+import amf.apicontract.client.scala.model.domain._
 import amf.apicontract.internal.metamodel.domain.MessageModel
+import amf.apicontract.internal.transformation.ReferenceDocumentationResolver.updateSummaryAndDescription
 import amf.core.client.scala.model.domain.{DomainElement, Linkable}
 import amf.core.internal.annotations.DeclaredServerVariable
-import amf.core.internal.transform.stages.ReferenceResolutionStage
 import amf.core.internal.parser.domain.{Annotations, Fields}
+import amf.core.internal.transform.stages.ReferenceResolutionStage
 
 class WebApiReferenceResolutionStage(keepEditingInfo: Boolean = false)
     extends ReferenceResolutionStage(keepEditingInfo) {
 
   override protected def customDomainElementTransformation: (DomainElement, Linkable) => DomainElement =
     (domain: DomainElement, source: Linkable) => {
+      updateSummaryAndDescription(domain, source)
       source match {
         case sourceResp: Response =>
           domain match {
@@ -46,7 +48,8 @@ class WebApiReferenceResolutionStage(keepEditingInfo: Boolean = false)
               copy.withId(sourceServer.id).withName(sourceServer.name.value())
             case _ => domain
           }
-        case sourceServerVariable: Parameter if sourceServerVariable.annotations.contains(classOf[DeclaredServerVariable]) =>
+        case sourceServerVariable: Parameter
+            if sourceServerVariable.annotations.contains(classOf[DeclaredServerVariable]) =>
           domain match {
             case serverVariable: Parameter =>
               val copy = serverVariable.copyElement().asInstanceOf[Parameter]

--- a/amf-cli/js/typings/amf-client-js.d.ts
+++ b/amf-cli/js/typings/amf-client-js.d.ts
@@ -5257,6 +5257,8 @@ declare module "amf-client-js" {
   export interface Linkable {
     isLink: boolean;
     linkLabel: StrField;
+    refSummary: StrField;
+    refDescription: StrField;
     linkTarget: undefined | DomainElement;
 
     link<T>(): T;

--- a/amf-cli/js/typings/amf-client-js.d.ts
+++ b/amf-cli/js/typings/amf-client-js.d.ts
@@ -3335,6 +3335,7 @@ declare module "amf-client-js" {
   }
   export class Example implements DomainElement, Linkable {
     customDomainProperties: Array<DomainExtension>;
+    summary: StrField;
     description: StrField;
     displayName: StrField;
     extendsNode: Array<DomainElement>;
@@ -3364,6 +3365,8 @@ declare module "amf-client-js" {
     linkCopy(): Example;
 
     withCustomDomainProperties(extensions: Array<DomainExtension>): this;
+
+    withSummary(summary: string): this;
 
     withDescription(description: string): this;
 

--- a/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-ref-fields.dumped.yaml
+++ b/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-ref-fields.dumped.yaml
@@ -1,0 +1,101 @@
+openapi: 3.1.0
+info:
+  title: API with Inline Summary and Description for $ref
+  description: Demonstrates how to include summary and description alongside $ref.
+  version: 1.0.0
+paths:
+  /users:
+    post:
+      operationId: getUsers
+      parameters:
+        -
+          $ref: "#/components/parameters/userId"
+          description: this parameter description should override the referenced one
+      responses:
+        "200":
+          $ref: "#/components/responses/usersListResponse"
+          description: this response description should override the referenced one
+      requestBody:
+        $ref: "#/components/requestBodies/createUserRequest"
+        description: this request description should override the referenced one
+      security:
+        -
+          apiKeyAuth: []
+components:
+  parameters:
+    userId:
+      description: this parameter description should be overridden
+      name: userId
+      in: query
+      required: true
+      schema:
+        type: string
+  responses:
+    usersListResponse:
+      description: this response description should be overridden
+      headers:
+        aHeader:
+          $ref: "#/components/headers/xRateLimit"
+          description: this header description should override the referenced one
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/User"
+          examples:
+            usersExample:
+              $ref: "#/components/examples/usersList"
+              summary: this example summary should override the referenced one
+              description: this example description should override the referenced one
+      links:
+        aLink:
+          $ref: "#/components/links/userProfile"
+          description: this link description should override the referenced one
+  requestBodies:
+    createUserRequest:
+      description: this request description should be overridden
+      content:
+        application/json:
+          schema:
+            type: string
+  examples:
+    usersList:
+      summary: this example summary should be overridden
+      description: this example description should be overridden
+      value:
+        -
+          id: "1"
+          name: Alice
+          email: alice@example.com
+        -
+          id: "2"
+          name: Bob
+          email: bob@example.com
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+  securitySchemes:
+    apiKeyAuth:
+      description: this security scheme description should be overridden
+      type: apiKey
+      in: header
+      name: X-API-Key
+  x-amf-securitySchemes:
+    refToApiKeyAuth: {}
+  headers:
+    xRateLimit:
+      schema:
+        type: integer
+      description: this header description should be overridden
+  links:
+    userProfile:
+      description: this link description should be overridden
+      operationId: getUserById

--- a/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-ref-fields.yaml
+++ b/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-ref-fields.yaml
@@ -1,0 +1,129 @@
+openapi: 3.1.0
+
+info:
+  title: API with Inline Summary and Description for $ref
+  description: Demonstrates how to include summary and description alongside $ref.
+  version: 1.0.0
+
+paths:
+  /users:
+    post:
+      operationId: getUsers
+      parameters:
+        - description: this parameter description should override the referenced one
+          $ref: '#/components/parameters/userId'
+      responses:
+        '200':
+          description: this response description should override the referenced one
+          $ref: '#/components/responses/usersListResponse'
+      requestBody:
+        description: this request description should override the referenced one
+        $ref: '#/components/requestBodies/createUserRequest'
+      security:
+        - apiKeyAuth: []
+
+#  /users2: # TODO: uncomment when doing W-10548503
+#    $ref: '#/components/pathItems/getUsers'
+#    summary: this summary should override the referenced one
+#    description: this description should override the referenced one
+
+components:
+#  pathItems: # TODO: uncomment when doing W-10548503
+#    getUsers:
+#      summary: this pathItem summary should be overridden
+#      description: this pathItem description should be overridden
+#      get:
+#        operationId: getUsers
+#        parameters:
+#          - description: this parameter description should override the referenced one
+#            $ref: '#/components/parameters/userId'
+#        responses:
+#          '200':
+#            description: this response description should override the referenced one
+#            $ref: '#/components/responses/usersListResponse'
+#        security:
+#          - apiKeyAuth: [ ]
+
+  parameters:
+    userId:
+      description: this parameter description should be overridden
+      name: userId
+      in: query
+      required: true
+      schema:
+        type: string
+
+  responses:
+    usersListResponse:
+      description: this response description should be overridden
+      links:
+        aLink:
+          description: this link description should override the referenced one
+          $ref: '#/components/links/userProfile'
+      headers:
+        aHeader:
+          description: this header description should override the referenced one
+          $ref: '#/components/headers/xRateLimit'
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+          examples:
+            usersExample:
+              summary: this example summary should override the referenced one
+              description: this example description should override the referenced one
+              $ref: '#/components/examples/usersList'
+
+  requestBodies:
+    createUserRequest:
+      description: this request description should be overridden
+      content:
+        application/json:
+          schema:
+            type: string
+
+  examples:
+    usersList:
+      summary: this example summary should be overridden
+      description: this example description should be overridden
+      value:
+        - id: "1"
+          name: Alice
+          email: alice@example.com
+        - id: "2"
+          name: Bob
+          email: bob@example.com
+
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+
+  securitySchemes:
+    apiKeyAuth:
+      description: this security scheme description should be overridden
+      type: apiKey
+      in: header
+      name: X-API-Key
+    refToApiKeyAuth: # TODO: not supported yet
+      description: this security scheme description should override the referenced one
+      $ref: '#/components/securitySchemes/apiKeyAuth'
+
+  headers:
+    xRateLimit:
+      schema:
+        type: integer
+      description: this header description should be overridden
+
+  links:
+    userProfile: # TemplatedLink
+      description: this link description should be overridden
+      operationId: getUserById

--- a/amf-cli/shared/src/test/scala/amf/emit/Oas31CycleTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/emit/Oas31CycleTest.scala
@@ -3,7 +3,7 @@ package amf.emit
 import amf.core.internal.remote._
 import amf.io.FunSuiteCycleTests
 
-// TODO: it's not rendering new 'examples' facet
+// TODO: should support and render new 'examples', 'pathItems' facets in oas 3.1
 class Oas31CycleTest extends FunSuiteCycleTests {
   override val basePath: String = "amf-cli/shared/src/test/resources/upanddown/oas31/"
 
@@ -11,7 +11,7 @@ class Oas31CycleTest extends FunSuiteCycleTests {
 
   val cyclesOas31Json: Seq[FixtureData] = Seq(
     FixtureData(
-      "OAS 3.1 PetStore API in JSON",
+      "OAS 3.1 webhooks field in JSON",
       "oas-petstore-31.json",
       "oas-petstore-31.dumped.json"
     )
@@ -25,7 +25,7 @@ class Oas31CycleTest extends FunSuiteCycleTests {
 
   val cyclesOas31Yaml: Seq[FixtureData] = Seq(
     FixtureData(
-      "OAS 3.1 PetStore API in YAML",
+      "OAS 3.1 webhooks field in YAML",
       "oas-petstore-31.yaml",
       "oas-petstore-31.dumped.yaml"
     ),
@@ -33,6 +33,11 @@ class Oas31CycleTest extends FunSuiteCycleTests {
       "OAS 3.1 annotation in discriminator field",
       "oas-31-discriminator-ann.yaml",
       "oas-31-discriminator-ann.dumped.yaml"
+    ),
+    FixtureData(
+      "OAS 3.1 $ref object summary and description",
+      "oas-31-ref-fields.yaml",
+      "oas-31-ref-fields.dumped.yaml"
     )
   )
 

--- a/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
@@ -771,4 +771,42 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
       portParameter.schema.description.isNullOrEmpty shouldBe true
     }
   }
+
+  // W-10548463
+  test("OAS 3.1 summary and description facet") {
+    val api = s"file://amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-ref-fields.yaml"
+    modelAssertion(api, pipelineId = PipelineId.Editing) { bu =>
+      val request            = getFirstRequest(bu)
+      val requestDescription = request.description.value()
+
+      val parameter            = request.queryParameters.head
+      val parameterDescription = parameter.description.value()
+
+      val response            = getFirstResponse(bu)
+      val responseDescription = response.description.value()
+
+      val responseLink            = response.links.head
+      val responseLinkDescription = responseLink.description.value()
+
+      val responseHeader            = response.headers.head
+      val responseHeaderDescription = responseHeader.description.value()
+
+      val responseSchema                   = response.payloads.head.schema
+      val responseSchemaExample            = responseSchema.asInstanceOf[AnyShape].examples.head
+      val responseSchemaExampleDescription = responseSchemaExample.description.value()
+      val responseSchemaExampleSummary     = responseSchemaExample.summary.value()
+
+      val allAreBeingOverridden = Seq(
+        requestDescription,
+        parameterDescription,
+        responseDescription,
+        responseLinkDescription,
+        responseHeaderDescription,
+        responseSchemaExampleSummary,
+        responseSchemaExampleDescription
+      ).forall(_.contains("should override the referenced one"))
+
+      allAreBeingOverridden shouldBe true
+    }
+  }
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/AMFModelAssertionTest.scala
@@ -41,6 +41,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   val raml08Client: AMFBaseUnitClient        = raml08Config.baseUnitClient()
   val oasConfig: AMFConfiguration            = OASConfiguration.OAS30().withRenderOptions(ro)
   val oasClient: AMFBaseUnitClient           = oasConfig.baseUnitClient()
+  val oas31Config: AMFConfiguration          = OASConfiguration.OAS31().withRenderOptions(ro)
+  val oas31Client: AMFBaseUnitClient         = oas31Config.baseUnitClient()
   val oasComponentsConfig: AMFConfiguration  = OASConfiguration.OAS30Component().withRenderOptions(ro)
   val oasComponentsClient: AMFBaseUnitClient = oasComponentsConfig.baseUnitClient()
   val asyncConfig: AMFConfiguration          = AsyncAPIConfiguration.Async20().withRenderOptions(ro)
@@ -542,10 +544,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-13595824
   test("transforming raml with 3+ unions should flatten union members") {
     val api = "file://amf-cli/shared/src/test/resources/upanddown/raml10/unions/triple-unions.raml"
-    ramlClient.parse(api) flatMap { parseResult =>
-      val parseBU      = parseResult.baseUnit
-      val transformBU  = ramlClient.transform(parseBU, pipeline = PipelineId.Editing).baseUnit
-      val declarations = getDeclarations(transformBU)
+    modelAssertion(api, pipelineId = PipelineId.Editing) { bu =>
+      val declarations = getDeclarations(bu)
 
       val unionInArray      = declarations(1).asInstanceOf[ArrayShape]
       val unionInArrayUnion = unionInArray.items.asInstanceOf[UnionShape]
@@ -569,9 +569,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-13595824
   test("transforming raml with nested UnionShapes should NOT flatten union members") {
     val api = "file://amf-cli/shared/src/test/resources/union/inner-union.raml"
-    ramlClient.parse(api) flatMap { parseResult =>
-      val transformBU  = ramlClient.transform(parseResult.baseUnit, pipeline = PipelineId.Editing).baseUnit
-      val declarations = getDeclarations(transformBU)
+    modelAssertion(api, pipelineId = PipelineId.Editing) { bu =>
+      val declarations = getDeclarations(bu)
 
       // in parsing they are an union that inherits an union with anyOf of a ScalarShape and an UnionShape with link-target to the next Union (SomeType, OtherType)
       val unionType = declarations.head.asInstanceOf[UnionShape]
@@ -590,9 +589,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-13595824
   test("transforming raml with 3+ unions should NOT duplicate IDs when flattening members") {
     val api = s"$basePath/raml/triple-union.raml"
-    ramlClient.parse(api) flatMap { parseResult =>
-      val transformBU          = ramlClient.transform(parseResult.baseUnit, pipeline = PipelineId.Editing).baseUnit
-      val declarations         = getDeclarations(transformBU)
+    modelAssertion(api, pipelineId = PipelineId.Editing) { bu =>
+      val declarations         = getDeclarations(bu)
       val unionInArrayProperty = declarations.last.asInstanceOf[NodeShape]
       val complexArrayProperty = unionInArrayProperty.properties.head
       val complexArrayRange    = complexArrayProperty.range
@@ -618,15 +616,13 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-12689955
   test("async2.0 should not emit server channels if not specified") {
     val api = s"$basePath/async20/validations/channel-servers-async20.yaml"
-    asyncClient.parse(api) flatMap { parseResult =>
-      val transformResult = asyncClient.transform(parseResult.baseUnit)
-      val transformBU     = transformResult.baseUnit
-      val endpoint        = getFirstEndpoint(transformBU, isWebApi = false)
+    modelAssertion(api) { bu =>
+      val endpoint        = getFirstEndpoint(bu, isWebApi = false)
       val endpointServers = endpoint.servers
       // channel should have all servers linked
       endpointServers.size shouldBe 3
 
-      val render          = asyncClient.render(transformBU)
+      val render          = asyncClient.render(bu)
       val serversInRender = render.linesIterator.filter(_.contains("servers:")).toArray
       // but only the declared root servers should be present in the rendered API
       serversInRender.length shouldBe 1
@@ -636,10 +632,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-12689962
   test("async2.4+ explicit operation security facet") {
     val api = s"$basePath/async20/validations/operation-security-explicit.yaml"
-    asyncClient.parse(api) flatMap { parseResult =>
-      val transformResult = asyncClient.transform(parseResult.baseUnit)
-      val transformBU     = transformResult.baseUnit
-      val endpoint        = getFirstEndpoint(transformBU, isWebApi = false)
+    modelAssertion(api) { bu =>
+      val endpoint = getFirstEndpoint(bu, isWebApi = false)
 
       val serverSecurity    = endpoint.servers.head.security.head.schemes.head
       val operationSecurity = endpoint.operations.head.security.head.schemes.head
@@ -655,10 +649,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-12689962
   test("async2.4+ resolve implicit operation security facet") {
     val api = s"$basePath/async20/validations/operation-security-implicit.yaml"
-    asyncClient.parse(api) flatMap { parseResult =>
-      val transformResult = asyncClient.transform(parseResult.baseUnit)
-      val transformBU     = transformResult.baseUnit
-      val endpoint        = getFirstEndpoint(transformBU, isWebApi = false)
+    modelAssertion(api) { bu =>
+      val endpoint = getFirstEndpoint(bu, isWebApi = false)
 
       val serverSecurity    = endpoint.servers.head.security.head.schemes.head
       val operationSecurity = endpoint.operations.head.security.head.schemes.head
@@ -684,11 +676,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-15633176
   test("parse AVRO Schema in an Async API") {
     val api = s"$basePath/avro/valid-avro-schema.yaml"
-    asyncClient.parse(api) flatMap { parseResult =>
-      val transformResult = asyncClient.transform(parseResult.baseUnit)
-      val transformBU     = transformResult.baseUnit
-
-      val schema = getFirstRequestPayload(transformBU, isWebApi = false).schema
+    modelAssertion(api) { bu =>
+      val schema = getFirstRequestPayload(bu, isWebApi = false).schema
       schema.annotations.contains(classOf[AVROSchemaType]) shouldBe true
     }
   }
@@ -696,11 +685,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-16540082
   test("test all primitive avro types XSD mappings") {
     val api = s"$basePath/avro/all-primitive-types.yaml"
-    asyncClient.parse(api) flatMap { parseResult =>
-      val transformResult = asyncClient.transform(parseResult.baseUnit)
-      val transformBU     = transformResult.baseUnit
-
-      val schema = getFirstRequestPayload(transformBU, isWebApi = false).schema
+    modelAssertion(api) { bu =>
+      val schema = getFirstRequestPayload(bu, isWebApi = false).schema
       asyncConfig.elementClient().buildJsonSchema(schema.asInstanceOf[NodeShape])
       schema.annotations.contains(classOf[AVROSchemaType]) shouldBe true
     }
@@ -709,8 +695,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-16609870
   test("async avro message payloads should be virtual by default unless explicitly declared") {
     val api = s"$basePath/async20/virtual-payload-async.yaml"
-    asyncClient.parse(api) flatMap { parseResult =>
-      val response      = getFirstResponse(parseResult.baseUnit, isWebApi = false)
+    modelAssertion(api) { bu =>
+      val response      = getFirstResponse(bu, isWebApi = false)
       val payload       = response.payloads.head
       val payloadSchema = payload.schema
       payloadSchema should not be null
@@ -731,11 +717,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-16701643
   test("async avro payload validation") {
     val api = s"$basePath/async20/validations/async-avro-payload-validation/invalid-payload-example.yaml"
-    asyncClient.parse(api) flatMap { parseResult =>
-      val transformResult = asyncClient.transform(parseResult.baseUnit)
-      parseResult.results.isEmpty shouldBe true
-      transformResult.results.isEmpty shouldBe true
-      val avroPayload = getFirstResponsePayload(transformResult.baseUnit, isWebApi = false)
+    modelAssertion(api) { bu =>
+      val avroPayload = getFirstResponsePayload(bu, isWebApi = false)
       val avroShape   = avroPayload.schema
       val payloadValidator = asyncConfig
         .elementClient()
@@ -752,11 +735,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-16701643
   test("async avro payload validation with avro payload in external file") {
     val api = s"$basePath/async20/validations/async-avro-payload-validation/invalid-payload-example-refs.yaml"
-    asyncClient.parse(api) flatMap { parseResult =>
-      val transformResult = asyncClient.transform(parseResult.baseUnit)
-      parseResult.results.isEmpty shouldBe true
-      transformResult.results.isEmpty shouldBe true
-      val avroPayload = getFirstResponsePayload(transformResult.baseUnit, isWebApi = false)
+    modelAssertion(api) { bu =>
+      val avroPayload = getFirstResponsePayload(bu, isWebApi = false)
       val avroShape   = avroPayload.schema
       val payloadValidator = asyncConfig
         .elementClient()
@@ -784,9 +764,8 @@ class AMFModelAssertionTest extends AsyncFunSuite with Matchers {
   // W-16888404
   test("async solace server parameter should have description at parameter level") {
     val api = s"$basePath/async20/validations/solace-server.yaml"
-    asyncClient.parse(api) flatMap { parseResult =>
-      parseResult.results.isEmpty shouldBe true
-      val solaceServer  = getServers(parseResult.baseUnit, isWebApi = false).head
+    modelAssertion(api) { bu =>
+      val solaceServer  = getServers(bu, isWebApi = false).head
       val portParameter = solaceServer.variables.head
       portParameter.description.nonNull shouldBe true
       portParameter.schema.description.isNullOrEmpty shouldBe true

--- a/amf-cli/shared/src/test/scala/amf/validation/OasExamplesValidationTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/OasExamplesValidationTest.scala
@@ -1,7 +1,5 @@
 package amf.validation
 
-import amf.core.internal.remote.{Hint, Oas20JsonHint, Oas30JsonHint}
-
 class OasExamplesValidationTest extends MultiPlatformReportGenTest {
 
   override val basePath: String    = "file://amf-cli/shared/src/test/resources/validations/"

--- a/amf-cli/shared/src/test/scala/amf/validation/OasJsonModelUniquePlatformReportTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/OasJsonModelUniquePlatformReportTest.scala
@@ -1,8 +1,5 @@
 package amf.validation
 
-import amf.core.client.common.validation.Oas30Profile
-import amf.core.internal.remote.{Hint, Oas20JsonHint, Oas30JsonHint}
-
 class OasJsonModelUniquePlatformReportTest extends UniquePlatformReportGenTest {
 
   override val basePath    = "file://amf-cli/shared/src/test/resources/validations/"

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/Example.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/platform/model/domain/Example.scala
@@ -1,13 +1,11 @@
 package amf.shapes.client.platform.model.domain
 
-import amf.core.client.platform.AMFGraphConfiguration
 import amf.core.client.platform.model.domain.{DataNode, DomainElement, Linkable, NamedDomainElement}
 import amf.core.client.platform.model.{BoolField, StrField}
 import amf.shapes.client.scala.model.domain.{Example => InternalExample}
-import amf.shapes.internal.convert.ShapeClientConverters.ClientOption
+import amf.shapes.internal.convert.ShapeClientConverters.{ClientOption, _}
 
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
-import amf.shapes.internal.convert.ShapeClientConverters._
 
 /** Example model class
   */
@@ -22,6 +20,7 @@ case class Example(override private[amf] val _internal: InternalExample)
 
   def name: StrField                 = _internal.name
   def displayName: StrField          = _internal.displayName
+  def summary: StrField              = _internal.summary
   def description: StrField          = _internal.description
   def value: StrField                = _internal.raw
   def structuredValue: DataNode      = _internal.structuredValue
@@ -36,6 +35,11 @@ case class Example(override private[amf] val _internal: InternalExample)
 
   def withDisplayName(displayName: String): this.type = {
     _internal.withDisplayName(displayName)
+    this
+  }
+
+  def withSummary(summary: String): this.type = {
+    _internal.withSummary(summary)
     this
   }
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/Example.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/client/scala/model/domain/Example.scala
@@ -18,12 +18,14 @@ class Example private[amf] (override val fields: Fields, override val annotation
     with Key {
 
   def displayName: StrField     = fields.field(DisplayName)
+  def summary: StrField         = fields.field(Summary)
   def description: StrField     = fields.field(Description)
   def structuredValue: DataNode = fields.field(StructuredValue)
   def strict: BoolField         = fields.field(Strict)
   def mediaType: StrField       = fields.field(MediaType)
 
   def withDisplayName(displayName: String): this.type = set(DisplayName, displayName)
+  def withSummary(summary: String): this.type         = set(Summary, summary)
   def withDescription(description: String): this.type = set(Description, description)
   def withValue(value: String): this.type             = set(ExternalSourceElementModel.Raw, value)
   def withStructuredValue(value: DataNode): this.type = set(StructuredValue, value)

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/emitter/ExampleEmitters.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/emitter/ExampleEmitters.scala
@@ -6,7 +6,7 @@ import amf.core.internal.datanode.DataNodeEmitter
 import amf.core.internal.metamodel.Field
 import amf.core.internal.metamodel.domain.common.NameFieldSchema
 import amf.core.internal.parser.domain.{FieldEntry, Fields}
-import amf.core.internal.render.BaseEmitters.{EntryPartEmitter, NullEmitter, pos, traverse}
+import amf.core.internal.render.BaseEmitters._
 import amf.core.internal.render.SpecOrdering
 import amf.core.internal.render.emitters.{Emitter, EntryEmitter, PartEmitter}
 import amf.core.internal.utils.{IdCounter, _}
@@ -68,7 +68,7 @@ case class Oas3ExampleValuesPartEmitter(example: Example, ordering: SpecOrdering
     handleInlinedRefOr(p, example) {
       if (example.isLink) {
         val refUrl = OasShapeDefinitions.appendOas3ComponentsPrefix(example.linkLabel.value(), "examples")
-        p.obj(_.entry("$ref", refUrl))
+        spec.ref(p, refUrl, example)
       } else {
         p.obj(traverse(ordering.sorted(emitters), _))
       }

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/emitter/ExternalReferenceUrlEmitter.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/emitter/ExternalReferenceUrlEmitter.scala
@@ -1,6 +1,6 @@
 package amf.shapes.internal.spec.common.emitter
 
-import amf.core.client.scala.model.domain.DomainElement
+import amf.core.client.scala.model.domain.{DomainElement, Linkable}
 import amf.core.internal.render.BaseEmitters.pos
 import amf.core.internal.render.emitters.PartEmitter
 import amf.shapes.internal.annotations.ExternalReferenceUrl
@@ -30,7 +30,12 @@ case class RamlExternalReferenceUrlEmitter(element: DomainElement)(fallback: => 
 case class OasExternalReferenceUrlEmitter(element: DomainElement)(fallback: => Unit = Unit)(implicit
     val spec: ShapeEmitterContext
 ) extends ExternalReferenceUrlEmitter(element, fallback) {
-  override def emitRef(b: PartBuilder, url: String): Unit = spec.ref(b, url)
+  override def emitRef(b: PartBuilder, url: String): Unit = {
+    element match {
+      case l: Linkable => spec.ref(b, url, l)
+      case _           => spec.ref(b, url)
+    }
+  }
 }
 
 object ExternalReferenceUrlEmitter {

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/emitter/ShapeEmitterContext.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/emitter/ShapeEmitterContext.scala
@@ -3,8 +3,8 @@ package amf.shapes.internal.spec.common.emitter
 import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
+import amf.core.client.scala.model.domain._
 import amf.core.client.scala.model.domain.extensions.{DomainExtension, ShapeExtension}
-import amf.core.client.scala.model.domain.{CustomizableElement, DomainElement, Linkable, RecursiveShape, Shape}
 import amf.core.internal.metamodel.Field
 import amf.core.internal.parser.domain.FieldEntry
 import amf.core.internal.plugins.render.RenderConfiguration
@@ -23,7 +23,7 @@ import amf.shapes.internal.spec.common.{JSONSchemaDraft201909SchemaVersion, JSON
 import amf.shapes.internal.spec.contexts.DeclarationEmissionDecorator
 import amf.shapes.internal.spec.contexts.emitter.oas.{CompactableEmissionContext, OasCompactEmitterFactory}
 import amf.shapes.internal.spec.oas.emitter.compact.CompactOasRecursiveShapeEmitter
-import amf.shapes.internal.spec.raml.emitter.{Raml10TypePartEmitter, RamlTypePartEmitter}
+import amf.shapes.internal.spec.raml.emitter.RamlTypePartEmitter
 import org.yaml.model.{YDocument, YNode}
 
 import scala.util.matching.Regex
@@ -116,7 +116,7 @@ class JsonSchemaShapeEmitterContext(
 
   override def spec: Spec = Spec.JSONSCHEMA
 
-  override def ref(b: YDocument.PartBuilder, url: String): Unit = OasRefEmitter.ref(url, b)
+  override def ref(b: YDocument.PartBuilder, url: String, l: Linkable): Unit = OasRefEmitter.ref(url, b, l)
 
   override protected implicit val shapeCtx: OasLikeShapeEmitterContext = this
 
@@ -172,7 +172,7 @@ trait ShapeEmitterContext extends SpecAwareEmitterContext with DeclarationEmissi
 
   def spec: Spec
 
-  def ref(b: YDocument.PartBuilder, url: String): Unit
+  def ref(b: YDocument.PartBuilder, url: String, l: Linkable = AnyShape()): Unit
 
   def schemaVersion: SchemaVersion
 

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ShapeParserContext.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/common/parser/ShapeParserContext.scala
@@ -4,7 +4,7 @@ import amf.aml.internal.semantic.{SemanticExtensionsFacade, SemanticExtensionsFa
 import amf.core.client.scala.config.ParsingOptions
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.{BaseUnit, Fragment}
-import amf.core.client.scala.model.domain.{AmfObject, Shape}
+import amf.core.client.scala.model.domain.{AmfObject, AmfScalar, Linkable, Shape}
 import amf.core.client.scala.parse.document.{
   EmptyFutureDeclarations,
   ErrorHandlingContext,
@@ -12,7 +12,7 @@ import amf.core.client.scala.parse.document.{
   ParserContext
 }
 import amf.core.internal.parser.Root
-import amf.core.internal.parser.domain.{Declarations, SearchScope}
+import amf.core.internal.parser.domain.{Annotations, Declarations, SearchScope}
 import amf.core.internal.plugins.syntax.SyamlAMFErrorHandler
 import amf.core.internal.remote.{Oas30, Oas31, Spec}
 import amf.core.internal.utils.{AliasCounter, QName}
@@ -22,14 +22,7 @@ import amf.shapes.internal.spec.contexts.JsonSchemaRefGuide
 import amf.shapes.internal.spec.jsonschema.parser
 import amf.shapes.internal.spec.jsonschema.parser.JsonSchemaSettings
 import amf.shapes.internal.spec.jsonschema.ref.{AstIndex, AstIndexBuilder, JsonSchemaInference}
-import amf.shapes.internal.spec.oas.parser.{
-  Oas2Settings,
-  Oas2ShapeSyntax,
-  Oas31Settings,
-  Oas31ShapeSyntax,
-  Oas3Settings,
-  Oas3ShapeSyntax
-}
+import amf.shapes.internal.spec.oas.parser._
 import amf.shapes.internal.spec.raml.parser.RamlWebApiContextType.{DEFAULT, RamlWebApiContextType}
 import amf.shapes.internal.spec.raml.parser.{Raml08Settings, Raml08ShapeSyntax, Raml10Settings, Raml10ShapeSyntax}
 import org.mulesoft.common.client.lexical.SourceLocation
@@ -266,6 +259,20 @@ class ShapeParserContext(
 
   def copyForBase(unit: BaseUnit): ShapeParserContext = {
     makeCopyWithJsonPointerContext().moveToReference(unit.location().get)
+  }
+
+  private[amf] def link[T <: Linkable](
+      linkable: T,
+      map: YMap,
+      label: AmfScalar,
+      annotations: Annotations = Annotations(),
+      fieldAnn: Annotations = Annotations()
+  ): T = {
+    if (settings.isOas31Context) {
+      linkable.link(map, label, annotations, fieldAnn)
+    } else {
+      linkable.link(label, annotations, fieldAnn)
+    }
   }
 
   protected def normalizedJsonPointer(url: String): String = if (url.endsWith("/")) url.dropRight(1) else url

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/oas/parser/OasLink.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/oas/parser/OasLink.scala
@@ -5,7 +5,7 @@ import amf.core.internal.plugins.syntax.SyamlAMFErrorHandler
 import org.yaml.model.{YMap, YNode, YScalar}
 
 object OasLink {
-  def getLinkValue(node: YNode)(implicit eh: SyamlAMFErrorHandler) = {
+  def getLinkValue(node: YNode)(implicit eh: SyamlAMFErrorHandler): Either[String, YNode] = {
     node.to[YMap] match {
       case Right(map) =>
         val ref: Option[String] = map.key("$ref").flatMap(v => v.value.asOption[YScalar]).map(_.text)


### PR DESCRIPTION
- **(chore): refactor AMFModelAssertionTest to use modelAssertion method**
- **(chore): add summary getter/setter to Example class**
- **W-10548463: refactor OAS3 transformation pipelines/steps to make them inheritable**
- **W-10548463: add oas 3.1 transformation pipelines to OAS31 configuration**
- **W-10548463: add ref summary and description resolution step**
- **(chore): remove code smells**
- **W-10548463: add ref summary and description emission**
