### PR TITLE
W-17168388. Fix for nested refs in OAS external fragments.

### DIFF
--- a/amf-cli/shared/src/test/resources/resolution/oas-internal-json-schema-link/api.expanded.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-internal-json-schema-link/api.expanded.jsonld
@@ -92,156 +92,10 @@
                           {
                             "@id": "#10",
                             "@type": [
-                              "shacl:NodeShape",
                               "raml-shapes:AnyShape",
                               "shacl:Shape",
                               "raml-shapes:Shape",
                               "doc:DomainElement"
-                            ],
-                            "shacl:closed": [
-                              {
-                                "@value": false
-                              }
-                            ],
-                            "shacl:property": [
-                              {
-                                "@id": "#11",
-                                "@type": [
-                                  "shacl:PropertyShape",
-                                  "shacl:Shape",
-                                  "raml-shapes:Shape",
-                                  "doc:DomainElement"
-                                ],
-                                "shacl:path": [
-                                  {
-                                    "@id": "http://a.ml/vocabularies/data#status"
-                                  }
-                                ],
-                                "raml-shapes:range": [
-                                  {
-                                    "@id": "#12",
-                                    "@type": [
-                                      "raml-shapes:ScalarShape",
-                                      "raml-shapes:AnyShape",
-                                      "shacl:Shape",
-                                      "raml-shapes:Shape",
-                                      "doc:DomainElement"
-                                    ],
-                                    "shacl:datatype": [
-                                      {
-                                        "@id": "http://www.w3.org/2001/XMLSchema#string"
-                                      }
-                                    ],
-                                    "shacl:pattern": [
-                                      {
-                                        "@value": "^[1-5][0-9][0-9]$"
-                                      }
-                                    ],
-                                    "shacl:name": [
-                                      {
-                                        "@value": "status"
-                                      }
-                                    ],
-                                    "core:description": [
-                                      {
-                                        "@value": "HTTP Response code"
-                                      }
-                                    ],
-                                    "apiContract:examples": [
-                                      {
-                                        "@id": "#13",
-                                        "@type": [
-                                          "apiContract:Example",
-                                          "doc:DomainElement"
-                                        ],
-                                        "doc:strict": [
-                                          {
-                                            "@value": true
-                                          }
-                                        ],
-                                        "doc:structuredValue": [
-                                          {
-                                            "@id": "#14",
-                                            "@type": [
-                                              "data:Scalar",
-                                              "data:Node",
-                                              "doc:DomainElement"
-                                            ],
-                                            "data:value": [
-                                              {
-                                                "@value": "400"
-                                              }
-                                            ],
-                                            "shacl:datatype": [
-                                              {
-                                                "@id": "http://www.w3.org/2001/XMLSchema#string"
-                                              }
-                                            ],
-                                            "core:name": [
-                                              {
-                                                "@value": "scalar_1"
-                                              }
-                                            ],
-                                            "smaps": {
-                                              "synthesized-field": {
-                                                "core:name": "true",
-                                                "shacl:datatype": "true"
-                                              },
-                                              "lexical": {
-                                                "#14": "[(9,17)-(9,22)]"
-                                              }
-                                            }
-                                          }
-                                        ],
-                                        "doc:raw": [
-                                          {
-                                            "@value": "400"
-                                          }
-                                        ],
-                                        "smaps": {
-                                          "synthesized-field": {
-                                            "doc:raw": "true",
-                                            "doc:strict": "true"
-                                          },
-                                          "lexical": {
-                                            "#13": "[(9,17)-(9,22)]"
-                                          }
-                                        }
-                                      }
-                                    ],
-                                    "smaps": {
-                                      "lexical": {
-                                        "apiContract:examples": "[(9,8)-(11,0)]",
-                                        "shacl:pattern": "[(8,8)-(9,0)]",
-                                        "#12": "[(5,6)-(11,0)]",
-                                        "shacl:datatype": "[(7,8)-(8,0)]",
-                                        "core:description": "[(6,8)-(7,0)]"
-                                      },
-                                      "type-property-lexical-info": {
-                                        "#12": "[(7,8)-(7,12)]"
-                                      }
-                                    }
-                                  }
-                                ],
-                                "shacl:minCount": [
-                                  {
-                                    "@value": 0
-                                  }
-                                ],
-                                "shacl:name": [
-                                  {
-                                    "@value": "status"
-                                  }
-                                ],
-                                "smaps": {
-                                  "synthesized-field": {
-                                    "shacl:minCount": "true"
-                                  },
-                                  "lexical": {
-                                    "#11": "[(5,6)-(11,0)]"
-                                  }
-                                }
-                              }
                             ],
                             "shacl:name": [
                               {
@@ -253,22 +107,289 @@
                                 "@value": "The response schema"
                               }
                             ],
+                            "shacl:and": [
+                              {
+                                "@id": "#11",
+                                "@type": [
+                                  "shacl:NodeShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:closed": [
+                                  {
+                                    "@value": false
+                                  }
+                                ],
+                                "shacl:property": [
+                                  {
+                                    "@id": "#12",
+                                    "@type": [
+                                      "shacl:PropertyShape",
+                                      "shacl:Shape",
+                                      "raml-shapes:Shape",
+                                      "doc:DomainElement"
+                                    ],
+                                    "shacl:path": [
+                                      {
+                                        "@id": "http://a.ml/vocabularies/data#message"
+                                      }
+                                    ],
+                                    "raml-shapes:range": [
+                                      {
+                                        "@id": "#13",
+                                        "@type": [
+                                          "raml-shapes:ScalarShape",
+                                          "raml-shapes:AnyShape",
+                                          "shacl:Shape",
+                                          "raml-shapes:Shape",
+                                          "doc:DomainElement"
+                                        ],
+                                        "shacl:datatype": [
+                                          {
+                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                          }
+                                        ],
+                                        "shacl:name": [
+                                          {
+                                            "@value": "message"
+                                          }
+                                        ],
+                                        "core:description": [
+                                          {
+                                            "@value": "HTTP message"
+                                          }
+                                        ],
+                                        "smaps": {
+                                          "lexical": {
+                                            "core:description": "[(6,8)-(7,0)]",
+                                            "#13": "[(5,6)-(9,0)]",
+                                            "shacl:datatype": "[(7,8)-(9,0)]"
+                                          },
+                                          "type-property-lexical-info": {
+                                            "#13": "[(7,8)-(7,12)]"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "shacl:minCount": [
+                                      {
+                                        "@value": 0
+                                      }
+                                    ],
+                                    "shacl:name": [
+                                      {
+                                        "@value": "message"
+                                      }
+                                    ],
+                                    "smaps": {
+                                      "synthesized-field": {
+                                        "shacl:minCount": "true"
+                                      },
+                                      "lexical": {
+                                        "#12": "[(5,6)-(9,0)]"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "shacl:name": [
+                                  {
+                                    "@value": "NestedResponseSchema"
+                                  }
+                                ],
+                                "core:description": [
+                                  {
+                                    "@value": "A nested response schema"
+                                  }
+                                ],
+                                "smaps": {
+                                  "synthesized-field": {
+                                    "shacl:closed": "true"
+                                  },
+                                  "lexical": {
+                                    "core:description": "[(3,4)-(4,0)]",
+                                    "#11": "[(2,2)-(9,0)]"
+                                  }
+                                }
+                              },
+                              {
+                                "@id": "#14",
+                                "@type": [
+                                  "shacl:NodeShape",
+                                  "raml-shapes:AnyShape",
+                                  "shacl:Shape",
+                                  "raml-shapes:Shape",
+                                  "doc:DomainElement"
+                                ],
+                                "shacl:closed": [
+                                  {
+                                    "@value": false
+                                  }
+                                ],
+                                "shacl:property": [
+                                  {
+                                    "@id": "#15",
+                                    "@type": [
+                                      "shacl:PropertyShape",
+                                      "shacl:Shape",
+                                      "raml-shapes:Shape",
+                                      "doc:DomainElement"
+                                    ],
+                                    "shacl:path": [
+                                      {
+                                        "@id": "http://a.ml/vocabularies/data#status"
+                                      }
+                                    ],
+                                    "raml-shapes:range": [
+                                      {
+                                        "@id": "#16",
+                                        "@type": [
+                                          "raml-shapes:ScalarShape",
+                                          "raml-shapes:AnyShape",
+                                          "shacl:Shape",
+                                          "raml-shapes:Shape",
+                                          "doc:DomainElement"
+                                        ],
+                                        "shacl:datatype": [
+                                          {
+                                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                          }
+                                        ],
+                                        "shacl:pattern": [
+                                          {
+                                            "@value": "^[1-5][0-9][0-9]$"
+                                          }
+                                        ],
+                                        "shacl:name": [
+                                          {
+                                            "@value": "status"
+                                          }
+                                        ],
+                                        "core:description": [
+                                          {
+                                            "@value": "HTTP Response code"
+                                          }
+                                        ],
+                                        "apiContract:examples": [
+                                          {
+                                            "@id": "#17",
+                                            "@type": [
+                                              "apiContract:Example",
+                                              "doc:DomainElement"
+                                            ],
+                                            "doc:strict": [
+                                              {
+                                                "@value": true
+                                              }
+                                            ],
+                                            "doc:structuredValue": [
+                                              {
+                                                "@id": "#18",
+                                                "@type": [
+                                                  "data:Scalar",
+                                                  "data:Node",
+                                                  "doc:DomainElement"
+                                                ],
+                                                "data:value": [
+                                                  {
+                                                    "@value": "400"
+                                                  }
+                                                ],
+                                                "shacl:datatype": [
+                                                  {
+                                                    "@id": "http://www.w3.org/2001/XMLSchema#string"
+                                                  }
+                                                ],
+                                                "core:name": [
+                                                  {
+                                                    "@value": "scalar_1"
+                                                  }
+                                                ],
+                                                "smaps": {
+                                                  "synthesized-field": {
+                                                    "core:name": "true",
+                                                    "shacl:datatype": "true"
+                                                  },
+                                                  "lexical": {
+                                                    "#18": "[(18,21)-(18,26)]"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "doc:raw": [
+                                              {
+                                                "@value": "400"
+                                              }
+                                            ],
+                                            "smaps": {
+                                              "synthesized-field": {
+                                                "doc:raw": "true",
+                                                "doc:strict": "true"
+                                              },
+                                              "lexical": {
+                                                "#17": "[(18,21)-(18,26)]"
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "smaps": {
+                                          "lexical": {
+                                            "apiContract:examples": "[(18,12)-(20,0)]",
+                                            "shacl:pattern": "[(17,12)-(18,0)]",
+                                            "#16": "[(14,10)-(20,0)]",
+                                            "shacl:datatype": "[(16,12)-(17,0)]",
+                                            "core:description": "[(15,12)-(16,0)]"
+                                          },
+                                          "type-property-lexical-info": {
+                                            "#16": "[(16,12)-(16,16)]"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "shacl:minCount": [
+                                      {
+                                        "@value": 0
+                                      }
+                                    ],
+                                    "shacl:name": [
+                                      {
+                                        "@value": "status"
+                                      }
+                                    ],
+                                    "smaps": {
+                                      "synthesized-field": {
+                                        "shacl:minCount": "true"
+                                      },
+                                      "lexical": {
+                                        "#15": "[(14,10)-(20,0)]"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "shacl:name": [
+                                  {
+                                    "@value": "item1"
+                                  }
+                                ],
+                                "smaps": {
+                                  "synthesized-field": {
+                                    "shacl:closed": "true"
+                                  },
+                                  "lexical": {
+                                    "#14": "[(13,8)-(20,0)]"
+                                  }
+                                }
+                              }
+                            ],
                             "smaps": {
-                              "synthesized-field": {
-                                "shacl:closed": "true"
+                              "lexical": {
+                                "shacl:and": "[(11,4)-(20,0)]",
+                                "#10": "[(9,2)-(20,0)]",
+                                "core:description": "[(10,4)-(11,0)]"
                               },
                               "auto-generated-name": {
                                 "#10": ""
-                              },
-                              "resolved-link-target": {
-                                "#10": "amf://id#15"
-                              },
-                              "resolved-link": {
-                                "#10": "amf://id#10"
-                              },
-                              "lexical": {
-                                "core:description": "[(3,4)-(4,0)]",
-                                "#10": "[(2,2)-(11,0)]"
                               }
                             }
                           }
@@ -278,15 +399,15 @@
                             "#9": "true"
                           },
                           "lexical": {
-                            "raml-shapes:schema": "[(14,4)-(15,42)]",
-                            "#9": "[(2,2)-(11,0)]"
+                            "raml-shapes:schema": "[(23,4)-(27,28)]",
+                            "#9": "[(9,2)-(20,0)]"
                           }
                         }
                       }
                     ],
                     "smaps": {
                       "lexical": {
-                        "core:description": "[(13,4)-(14,0)]",
+                        "core:description": "[(22,4)-(23,0)]",
                         "#8": "[(10,8)-(11,54)]",
                         "core:name": "[(10,8)-(10,13)]"
                       }
@@ -364,7 +485,7 @@
             ],
             "doc:raw": [
               {
-                "@value": "definitions:\n  ResponseSchema:\n    description: The response schema\n    properties:\n      status:\n        description: 'HTTP Response code'\n        type: string\n        pattern: '^[1-5][0-9][0-9]$'\n        example: '400'\n\nresponses:\n  403Response:\n    description: a description\n    schema:\n      $ref: '#/definitions/ResponseSchema'"
+                "@value": "definitions:\n  NestedResponseSchema:\n    description: A nested response schema\n    properties:\n      message:\n        description: 'HTTP message'\n        type: string\n\n  ResponseSchema:\n    description: The response schema\n    allOf:\n      - \"$ref\": \"#/definitions/NestedResponseSchema\"\n      - properties:\n          status:\n            description: 'HTTP Response code'\n            type: string\n            pattern: '^[1-5][0-9][0-9]$'\n            example: '400'\n\nresponses:\n  403Response:\n    description: a description\n    schema:\n      $ref: '#/definitions/ResponseSchema'\n      example:\n        status: '400'\n        message: 'A message'"
               }
             ],
             "core:mediaType": [
@@ -374,7 +495,7 @@
             ],
             "smaps": {
               "lexical": {
-                "#3": "[(1,0)-(15,42)]"
+                "#3": "[(1,0)-(27,28)]"
               }
             }
           }

--- a/amf-cli/shared/src/test/resources/resolution/oas-internal-json-schema-link/api.flattened.jsonld
+++ b/amf-cli/shared/src/test/resources/resolution/oas-internal-json-schema-link/api.flattened.jsonld
@@ -91,7 +91,7 @@
       ],
       "smaps": {
         "lexical": {
-          "core:description": "[(13,4)-(14,0)]",
+          "core:description": "[(22,4)-(23,0)]",
           "#8": "[(10,8)-(11,54)]",
           "core:name": "[(10,8)-(10,13)]"
         }
@@ -112,13 +112,42 @@
           "#9": "true"
         },
         "lexical": {
-          "raml-shapes:schema": "[(14,4)-(15,42)]",
-          "#9": "[(2,2)-(11,0)]"
+          "raml-shapes:schema": "[(23,4)-(27,28)]",
+          "#9": "[(9,2)-(20,0)]"
         }
       }
     },
     {
       "@id": "#10",
+      "@type": [
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:name": "default",
+      "core:description": "The response schema",
+      "shacl:and": [
+        {
+          "@id": "#11"
+        },
+        {
+          "@id": "#14"
+        }
+      ],
+      "smaps": {
+        "lexical": {
+          "shacl:and": "[(11,4)-(20,0)]",
+          "#10": "[(9,2)-(20,0)]",
+          "core:description": "[(10,4)-(11,0)]"
+        },
+        "auto-generated-name": {
+          "#10": ""
+        }
+      }
+    },
+    {
+      "@id": "#11",
       "@type": [
         "shacl:NodeShape",
         "raml-shapes:AnyShape",
@@ -129,32 +158,75 @@
       "shacl:closed": false,
       "shacl:property": [
         {
-          "@id": "#11"
+          "@id": "#12"
         }
       ],
-      "shacl:name": "default",
-      "core:description": "The response schema",
+      "shacl:name": "NestedResponseSchema",
+      "core:description": "A nested response schema",
       "smaps": {
         "synthesized-field": {
           "shacl:closed": "true"
         },
-        "auto-generated-name": {
-          "#10": ""
-        },
-        "resolved-link-target": {
-          "#10": "amf://id#15"
-        },
-        "resolved-link": {
-          "#10": "amf://id#10"
-        },
         "lexical": {
           "core:description": "[(3,4)-(4,0)]",
-          "#10": "[(2,2)-(11,0)]"
+          "#11": "[(2,2)-(9,0)]"
         }
       }
     },
     {
-      "@id": "#11",
+      "@id": "#14",
+      "@type": [
+        "shacl:NodeShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:closed": false,
+      "shacl:property": [
+        {
+          "@id": "#15"
+        }
+      ],
+      "shacl:name": "item1",
+      "smaps": {
+        "synthesized-field": {
+          "shacl:closed": "true"
+        },
+        "lexical": {
+          "#14": "[(13,8)-(20,0)]"
+        }
+      }
+    },
+    {
+      "@id": "#12",
+      "@type": [
+        "shacl:PropertyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#message"
+        }
+      ],
+      "raml-shapes:range": {
+        "@id": "#13"
+      },
+      "shacl:minCount": 0,
+      "shacl:name": "message",
+      "smaps": {
+        "synthesized-field": {
+          "shacl:minCount": "true"
+        },
+        "lexical": {
+          "#12": "[(5,6)-(9,0)]"
+        }
+      }
+    },
+    {
+      "@id": "#15",
       "@type": [
         "shacl:PropertyShape",
         "shacl:Shape",
@@ -167,7 +239,7 @@
         }
       ],
       "raml-shapes:range": {
-        "@id": "#12"
+        "@id": "#16"
       },
       "shacl:minCount": 0,
       "shacl:name": "status",
@@ -176,12 +248,39 @@
           "shacl:minCount": "true"
         },
         "lexical": {
-          "#11": "[(5,6)-(11,0)]"
+          "#15": "[(14,10)-(20,0)]"
         }
       }
     },
     {
-      "@id": "#12",
+      "@id": "#13",
+      "@type": [
+        "raml-shapes:ScalarShape",
+        "raml-shapes:AnyShape",
+        "shacl:Shape",
+        "raml-shapes:Shape",
+        "doc:DomainElement"
+      ],
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "shacl:name": "message",
+      "core:description": "HTTP message",
+      "smaps": {
+        "lexical": {
+          "core:description": "[(6,8)-(7,0)]",
+          "#13": "[(5,6)-(9,0)]",
+          "shacl:datatype": "[(7,8)-(9,0)]"
+        },
+        "type-property-lexical-info": {
+          "#13": "[(7,8)-(7,12)]"
+        }
+      }
+    },
+    {
+      "@id": "#16",
       "@type": [
         "raml-shapes:ScalarShape",
         "raml-shapes:AnyShape",
@@ -199,31 +298,31 @@
       "core:description": "HTTP Response code",
       "apiContract:examples": [
         {
-          "@id": "#13"
+          "@id": "#17"
         }
       ],
       "smaps": {
         "lexical": {
-          "apiContract:examples": "[(9,8)-(11,0)]",
-          "shacl:pattern": "[(8,8)-(9,0)]",
-          "#12": "[(5,6)-(11,0)]",
-          "shacl:datatype": "[(7,8)-(8,0)]",
-          "core:description": "[(6,8)-(7,0)]"
+          "apiContract:examples": "[(18,12)-(20,0)]",
+          "shacl:pattern": "[(17,12)-(18,0)]",
+          "#16": "[(14,10)-(20,0)]",
+          "shacl:datatype": "[(16,12)-(17,0)]",
+          "core:description": "[(15,12)-(16,0)]"
         },
         "type-property-lexical-info": {
-          "#12": "[(7,8)-(7,12)]"
+          "#16": "[(16,12)-(16,16)]"
         }
       }
     },
     {
-      "@id": "#13",
+      "@id": "#17",
       "@type": [
         "apiContract:Example",
         "doc:DomainElement"
       ],
       "doc:strict": true,
       "doc:structuredValue": {
-        "@id": "#14"
+        "@id": "#18"
       },
       "doc:raw": "400",
       "smaps": {
@@ -232,12 +331,12 @@
           "doc:strict": "true"
         },
         "lexical": {
-          "#13": "[(9,17)-(9,22)]"
+          "#17": "[(18,21)-(18,26)]"
         }
       }
     },
     {
-      "@id": "#14",
+      "@id": "#18",
       "@type": [
         "data:Scalar",
         "data:Node",
@@ -256,7 +355,7 @@
           "shacl:datatype": "true"
         },
         "lexical": {
-          "#14": "[(9,17)-(9,22)]"
+          "#18": "[(18,21)-(18,26)]"
         }
       }
     },
@@ -302,11 +401,11 @@
         "doc:ExternalDomainElement",
         "doc:DomainElement"
       ],
-      "doc:raw": "definitions:\n  ResponseSchema:\n    description: The response schema\n    properties:\n      status:\n        description: 'HTTP Response code'\n        type: string\n        pattern: '^[1-5][0-9][0-9]$'\n        example: '400'\n\nresponses:\n  403Response:\n    description: a description\n    schema:\n      $ref: '#/definitions/ResponseSchema'",
+      "doc:raw": "definitions:\n  NestedResponseSchema:\n    description: A nested response schema\n    properties:\n      message:\n        description: 'HTTP message'\n        type: string\n\n  ResponseSchema:\n    description: The response schema\n    allOf:\n      - \"$ref\": \"#/definitions/NestedResponseSchema\"\n      - properties:\n          status:\n            description: 'HTTP Response code'\n            type: string\n            pattern: '^[1-5][0-9][0-9]$'\n            example: '400'\n\nresponses:\n  403Response:\n    description: a description\n    schema:\n      $ref: '#/definitions/ResponseSchema'\n      example:\n        status: '400'\n        message: 'A message'",
       "core:mediaType": "application/yaml",
       "smaps": {
         "lexical": {
-          "#3": "[(1,0)-(15,42)]"
+          "#3": "[(1,0)-(27,28)]"
         }
       }
     },

--- a/amf-cli/shared/src/test/resources/resolution/oas-internal-json-schema-link/external.yaml
+++ b/amf-cli/shared/src/test/resources/resolution/oas-internal-json-schema-link/external.yaml
@@ -1,15 +1,27 @@
 definitions:
+  NestedResponseSchema:
+    description: A nested response schema
+    properties:
+      message:
+        description: 'HTTP message'
+        type: string
+
   ResponseSchema:
     description: The response schema
-    properties:
-      status:
-        description: 'HTTP Response code'
-        type: string
-        pattern: '^[1-5][0-9][0-9]$'
-        example: '400'
+    allOf:
+      - "$ref": "#/definitions/NestedResponseSchema"
+      - properties:
+          status:
+            description: 'HTTP Response code'
+            type: string
+            pattern: '^[1-5][0-9][0-9]$'
+            example: '400'
 
 responses:
   403Response:
     description: a description
     schema:
       $ref: '#/definitions/ResponseSchema'
+      example:
+        status: '400'
+        message: 'A message'

--- a/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/oas/parser/OasRefParser.scala
+++ b/amf-shapes/shared/src/main/scala/amf/shapes/internal/spec/oas/parser/OasRefParser.scala
@@ -119,18 +119,22 @@ class OasRefParser(
           .map { shape =>
             ctx.futureDeclarations.resolveRef(declarationNameOrResolvedRef, shape)
             ctx.registerJsonSchema(rawOrResolvedRef, shape)
-            if (ctx.linkTypes || rawOrResolvedRef.equals("#")) {
-              val link = shape
-                .link(AmfScalar(declarationNameOrResolvedRef), Annotations(ast), Annotations.synthesized())
-                .asInstanceOf[AnyShape]
-              val (nextName, annotations) = entryLike.key match {
-                case Some(keyNode) =>
-                  val key = keyNode.asScalar.map(_.text).getOrElse(name)
-                  (key, Annotations(keyNode))
-                case None => (name, Annotations())
-              }
-              link.withName(nextName, annotations)
-            } else shape
+// If we create a link here it won't be correctly solved in resolution stage because this declarations only
+// live in this context
+//
+//            if (ctx.linkTypes || rawOrResolvedRef.equals("#")) {
+//              val link = shape
+//                .link(AmfScalar(declarationNameOrResolvedRef), Annotations(ast), Annotations.synthesized())
+//                .asInstanceOf[AnyShape]
+//              val (nextName, annotations) = entryLike.key match {
+//                case Some(keyNode) =>
+//                  val key = keyNode.asScalar.map(_.text).getOrElse(name)
+//                  (key, Annotations(keyNode))
+//                case None => (name, Annotations())
+//              }
+//              link.withName(nextName, annotations)
+//            } else
+            shape
           } orElse { Some(tmpShape) }
 
       case None => Some(tmpShape)


### PR DESCRIPTION
- Task: W-17168388.
- Description: Multiple levels of refs where not corretly resolved in OAS when using external fragments. Linkage was removed for this cases to prevent errors in resolution and validation, this types are not declarations in the main file context, so there is no reason to treat them as links.