### PR TITLE
W-10548503: parse/emit 'pathItems' in OAS 3.1 components node

### DIFF
--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/parser/BaseSpecParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/common/parser/BaseSpecParser.scala
@@ -3,7 +3,8 @@ package amf.apicontract.internal.spec.common.parser
 import amf.aml.internal.parse.common.DeclarationKeyCollector
 import amf.apicontract.internal.validation.definitions.ParserSideValidations.PathTemplateUnbalancedParameters
 import amf.core.client.scala.model.domain.AmfObject
-import amf.core.internal.parser.domain.BaseSpecParser
+import amf.core.internal.parser.YMapOps
+import amf.core.internal.parser.domain.{Annotations, BaseSpecParser}
 import amf.shapes.internal.spec.common.parser.QuickFieldParserOps
 import org.yaml.model._
 
@@ -29,5 +30,13 @@ trait SpecParserOps extends QuickFieldParserOps {
         value.location
       )
     }
+  }
+
+  protected def getAnnotationsFromMap(map: YMap, key: String): Annotations = {
+    map
+      .key(key)
+      .map(v => v.value)
+      .map(Annotations(_))
+      .getOrElse(Annotations.synthesized())
   }
 }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/context/OasSyntax.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/context/OasSyntax.scala
@@ -8,15 +8,16 @@ object Oas31Syntax extends SpecSyntax {
   override val nodes: Map[String, Set[String]] =
     add(
       Oas3Syntax.nodes,
-      "webApi"  -> Set("webhooks", "jsonSchemaDialect"),
-      "license" -> Set("identifier"),
-      "info"    -> Set("summary")
+      "webApi"     -> Set("webhooks", "jsonSchemaDialect"),
+      "license"    -> Set("identifier"),
+      "info"       -> Set("summary"),
+      "components" -> Set("pathItems")
     )
 }
 
 object Oas3Syntax extends SpecSyntax {
   override val nodes: Map[String, Set[String]] = Oas3ShapeSyntax.nodes ++ Map(
-    "paths" -> Set.empty[String],
+    "paths" -> Set.empty[String], // everything that doesn't start with '/', 'x-' or '$ref' is invalid (OasLikeIgnoreCriteria)
     "webApi" -> Set(
       "openapi",
       "info",
@@ -227,8 +228,8 @@ object Oas3Syntax extends SpecSyntax {
 object Oas2Syntax extends SpecSyntax {
 
   override val nodes: Map[String, Set[String]] = Oas2ShapeSyntax.nodes ++ Map(
-    "paths" -> Set
-      .empty[String], // paths in oas ignores the ones starting with '/', 'x-' and '$ref' but everything else is invalid
+    "paths" -> Set.empty[String], // everything that doesn't start with '/', 'x-' or '$ref' is invalid (OasLikeIgnoreCriteria)
+
     "webApi" -> Set(
       "swagger",
       "info",

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/document/Oas31DocumentParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/document/Oas31DocumentParser.scala
@@ -1,15 +1,18 @@
 package amf.apicontract.internal.spec.oas.parser.document
 
+import amf.aml.internal.parse.common.DeclarationKey
 import amf.aml.internal.parse.dialects.DialectAstOps.DialectYMapOps
 import amf.apicontract.client.scala.model.domain.EndPoint
 import amf.apicontract.client.scala.model.domain.api.WebApi
 import amf.apicontract.internal.metamodel.domain.api.WebApiModel
 import amf.apicontract.internal.spec.oas.parser.context.OasWebApiContext
+import amf.apicontract.internal.spec.oas.parser.domain.Oas30EndpointParser
 import amf.apicontract.internal.validation.definitions.ParserSideValidations.NonEmptyOasApi
-import amf.core.client.scala.model.domain.AmfArray
+import amf.core.client.scala.model.domain.{AmfArray, AmfObject}
 import amf.core.internal.parser.Root
 import amf.core.internal.parser.domain.Annotations
 import amf.core.internal.remote.Spec
+import amf.shapes.internal.spec.common.parser.AnnotationParser
 import org.yaml.model.YMap
 
 class Oas31DocumentParser(root: Root, spec: Spec = Spec.OAS31)(implicit override val ctx: OasWebApiContext)
@@ -24,6 +27,33 @@ class Oas31DocumentParser(root: Root, spec: Spec = Spec.OAS31)(implicit override
         "OAS API should have at least a 'components', 'paths', or 'webhooks' property",
         map.location
       )
+  }
+
+  override def parseDeclarations(root: Root, map: YMap, parentObj: AmfObject): Unit = {
+    super.parseDeclarations(root, map, parentObj)
+    map.key("components").foreach { components =>
+      val parent = root.location + "#/declarations"
+      val map    = components.value.as[YMap]
+
+      parsePathItemsDeclarations(map, parent)
+    }
+    AnnotationParser(parentObj, map).parseOrphanNode("components")
+  }
+
+  private def parsePathItemsDeclarations(map: YMap, parent: String): Unit = {
+    map.key(
+      "pathItems",
+      endpoints => {
+        addDeclarationKey(DeclarationKey(endpoints))
+        endpoints.value
+          .as[YMap]
+          .entries
+          .foreach(endpointMapEntry => {
+            val maybeEndPoint = Oas30EndpointParser(endpointMapEntry, parent, List()).parse()
+            maybeEndPoint.foreach(endpoint => ctx.declarations += endpoint)
+          })
+      }
+    )
   }
 
   override def parseWebApi(map: YMap): WebApi = {

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/document/Oas3DocumentParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/document/Oas3DocumentParser.scala
@@ -3,13 +3,7 @@ package amf.apicontract.internal.spec.oas.parser.document
 import amf.aml.internal.parse.common.DeclarationKey
 import amf.apicontract.client.scala.model.domain.Parameter
 import amf.apicontract.client.scala.model.domain.api.WebApi
-import amf.apicontract.client.scala.model.domain.templates.{ResourceType, Trait}
-import amf.apicontract.internal.metamodel.domain.templates.{ResourceTypeModel, TraitModel}
-import amf.apicontract.internal.spec.common.parser.{
-  AbstractDeclarationsParser,
-  WebApiLikeReferencesParser,
-  YamlTagValidator
-}
+import amf.apicontract.internal.spec.common.parser.{WebApiLikeReferencesParser, YamlTagValidator}
 import amf.apicontract.internal.spec.oas.parser.Oas3ReferencesParser
 import amf.apicontract.internal.spec.oas.parser.context.OasWebApiContext
 import amf.apicontract.internal.spec.oas.parser.domain.{
@@ -23,9 +17,8 @@ import amf.core.client.scala.model.domain.AmfObject
 import amf.core.internal.annotations.{DeclaredElement, DeclaredHeader}
 import amf.core.internal.parser.{Root, YMapOps}
 import amf.core.internal.remote.Spec
-import amf.core.internal.utils._
 import amf.shapes.internal.spec.common.parser.{AnnotationParser, Oas3NamedExamplesParser}
-import org.yaml.model.{YMap, YMapEntry, YScalar}
+import org.yaml.model.{YMap, YScalar}
 
 object Oas3DocumentParser {
   def apply(root: Root, spec: Spec = Spec.OAS30)(implicit ctx: OasWebApiContext): Oas3DocumentParser =
@@ -52,18 +45,19 @@ class Oas3DocumentParser(root: Root, spec: Spec = Spec.OAS30)(implicit override 
     map.key("components").foreach { components =>
       val parent = root.location + "#/declarations"
       val map    = components.value.as[YMap]
+
       parseExamplesDeclaration(map, parent + "/examples")
       parseLinkDeclarations(map, parent + "/links")
       super.parseSecuritySchemeDeclarations(map, parent + "/securitySchemes")
       super.parseTypeDeclarations(map, Some(this))
       parseHeaderDeclarations(map, parent + "/headers")
       super.parseParameterDeclarations(map, parent + "/parameters")
-      super.parseResponsesDeclarations("responses", map, parent + "/responses")
+      super.parseResponsesDeclarations("responses", map)
       parseRequestBodyDeclarations(map, parent + "/requestBodies")
       parseCallbackDeclarations(map, parent + "/callbacks")
-
       super.parseAnnotationTypeDeclarations(map, parent)
       super.parseAbstractDeclarations(parent, map)
+
       ctx.closedShape(parentObj, map, "components")
       validateNames()
     }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/document/OasDocumentParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/document/OasDocumentParser.scala
@@ -118,7 +118,7 @@ abstract class OasDocumentParser(root: Root, val spec: Spec)(implicit val ctx: O
     parseAbstractDeclarations(parent, map)
     parseSecuritySchemeDeclarations(map, parent + "/securitySchemes")
     parseParameterDeclarations(map, parent + "/parameters")
-    parseResponsesDeclarations("responses", map, parent + "/responses")
+    parseResponsesDeclarations("responses", map)
   }
 
   def parseAbstractDeclarations(parent: String, map: YMap): Unit = {
@@ -251,7 +251,7 @@ abstract class OasDocumentParser(root: Root, val spec: Spec)(implicit val ctx: O
     )
   }
 
-  protected def parseResponsesDeclarations(key: String, map: YMap, parentPath: String): Unit = {
+  protected def parseResponsesDeclarations(key: String, map: YMap): Unit = {
     map.key(
       key,
       entry => {
@@ -365,7 +365,7 @@ abstract class OasDocumentParser(root: Root, val spec: Spec)(implicit val ctx: O
     )
   }
 
-  private def parseEndpoints(api: WebApi, entry: YMapEntry) = {
+  private def parseEndpoints(api: WebApi, entry: YMapEntry): Unit = {
     val paths = entry.value.as[YMap]
     val endpoints =
       paths

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasEndpointParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasEndpointParser.scala
@@ -116,9 +116,7 @@ abstract class OasEndpointParser(entry: YMapEntry, parentId: String, collector: 
       }
     )
 
-    if (ctx.isOas31Context) {
-      validatePathParamName(endpoint)
-    }
+    if (ctx.isOas31Context) validatePathParamName(endpoint)
 
     endpoint
   }

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasResponseParser.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/spec/oas/parser/domain/OasResponseParser.scala
@@ -32,11 +32,7 @@ case class OasResponseParser(map: YMap, adopted: Response => Unit)(implicit ctx:
       case Left(url) =>
         val name = OasDefinitions.stripResponsesDefinitionsPrefix(url)
 
-        val annotations = map
-          .key("$ref")
-          .map(v => v.value)
-          .map(Annotations(_))
-          .getOrElse(Annotations.synthesized())
+        val annotations = getAnnotationsFromMap(map, "$ref")
         ctx.declarations
           .findResponse(name, SearchScope.Named)
           .map { res =>

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ValidationTransformationPipeline.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/ValidationTransformationPipeline.scala
@@ -67,8 +67,9 @@ class ValidationTransformationPipeline private[amf] (
 object ValidationTransformationPipeline {
   def apply(profile: ProfileName, unit: BaseUnit, configuration: ValidationConfiguration): BaseUnit = {
     val pipeline = profile match {
-      case Oas30Profile                              => Oas30ValidationTransformationPipeline()
-      case Oas31Profile                              => Oas31ValidationTransformationPipeline()
+      // TODO: add RAML and other profiles
+      case Oas30Profile                              => Oas3CachePipeline()
+      case Oas31Profile                              => Oas31CachePipeline()
       case Async20Profile                            => Async20CachePipeline()
       case GraphQLProfile | GraphQLFederationProfile => GraphQLCachePipeline()
       case _                                         => new ValidationTransformationPipeline(profile)

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/WebApiReferenceResolutionStage.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/transformation/stages/WebApiReferenceResolutionStage.scala
@@ -61,6 +61,7 @@ class WebApiReferenceResolutionStage(keepEditingInfo: Boolean = false)
             case channel: EndPoint =>
               val copy = channel.copyElement().asInstanceOf[EndPoint]
               sourceEndpoint.name.option().foreach(copy.withName)
+              sourceEndpoint.path.option().foreach(copy.withPath)
               copy.withId(sourceEndpoint.id).withPath(sourceEndpoint.path.value())
 
             case _ => domain

--- a/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/model/APIRawValidations.scala
+++ b/amf-api-contract/shared/src/main/scala/amf/apicontract/internal/validation/model/APIRawValidations.scala
@@ -325,14 +325,6 @@ object APIRawValidations extends CommonValidationDefinitions {
         openApiErrorMessage = "'in' property of a parameter with an invalid value"
       ),
       AMFValidation(
-        owlClass = apiContract("EndPoint"),
-        owlProperty = apiContract("path"),
-        constraint = sh("pattern"),
-        value = "^/",
-        ramlErrorMessage = "Resource path must start with a '/'",
-        openApiErrorMessage = "PathItem path must start with a '/'"
-      ),
-      AMFValidation(
         owlClass = apiContract("Operation"),
         owlProperty = apiContract("method"),
         constraint = sh("in"),
@@ -495,6 +487,13 @@ object APIRawValidations extends CommonValidationDefinitions {
         value = "^([1-5]{1}[0-9]{2})$|^(default)$",
         ramlErrorMessage = "Status code for a Response must be a value between 100 and 599",
         openApiErrorMessage = "Status code for a Response must be a value between 100 and 599 or 'default'"
+      ),
+      AMFValidation(
+        owlClass = apiContract("EndPoint"),
+        owlProperty = apiContract("path"),
+        constraint = sh("pattern"),
+        value = "^/",
+        message = "Resource path must start with a '/'"
       ),
       schemaRequiredInParameter
     )

--- a/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.dumped.yaml
+++ b/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.dumped.yaml
@@ -18,6 +18,8 @@ webhooks:
       responses:
         "200":
           description: Return a 200 status to indicate that the data was received successfully
+  testWebhook:
+    $ref: "#/components/pathItems/testEndpoint"
 paths:
   /users:
     post:
@@ -29,6 +31,8 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/createUserRequest"
         description: this request description should override the referenced one
+  /test:
+    $ref: "#/components/pathItems/testEndpoint"
 security:
   -
     openIdConnect:
@@ -52,7 +56,6 @@ components:
         -
           type: "null"
     OtherSchema:
-      $schema: https://spec.openapis.org/oas/3.1/dialect/base
       type: object
       properties:
         some:
@@ -138,3 +141,13 @@ components:
     mutualTLS:
       type: mutualTLS
       description: mutualTLS security scheme
+  pathItems:
+    testEndpoint:
+      get:
+        responses:
+          "200":
+            description: A simple string response
+            content:
+              text/plain:
+                schema:
+                  type: string

--- a/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.dumped.yaml
+++ b/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.dumped.yaml
@@ -56,6 +56,7 @@ components:
         -
           type: "null"
     OtherSchema:
+      $schema: https://spec.openapis.org/oas/3.1/dialect/base
       type: object
       properties:
         some:

--- a/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.jsonld
+++ b/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.jsonld
@@ -139,6 +139,18 @@
                 ]
               }
             ]
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml#/web-api/endpoint/%2Ftest",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#EndPoint",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/apiContract#path": [
+              {
+                "@value": "/test"
+              }
+            ]
           }
         ],
         "http://a.ml/vocabularies/apiContract#webhooks": [
@@ -249,6 +261,18 @@
                     ]
                   }
                 ]
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml#/web-api/webhooks/testWebhook",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#EndPoint",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/apiContract#path": [
+              {
+                "@value": "testWebhook"
               }
             ]
           }
@@ -1829,6 +1853,101 @@
                 "http://a.ml/vocabularies/shapes#schemaVersion": [
                   {
                     "@value": "https://spec.openapis.org/oas/3.1/dialect/base"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml#/declares/testEndpoint",
+        "@type": [
+          "http://a.ml/vocabularies/apiContract#EndPoint",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/apiContract#path": [
+          {
+            "@value": "testEndpoint"
+          }
+        ],
+        "http://a.ml/vocabularies/apiContract#supportedOperation": [
+          {
+            "@id": "file://amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml#/declares/testEndpoint/supportedOperation/get",
+            "@type": [
+              "http://a.ml/vocabularies/apiContract#Operation",
+              "http://a.ml/vocabularies/core#Operation",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/apiContract#method": [
+              {
+                "@value": "get"
+              }
+            ],
+            "http://a.ml/vocabularies/apiContract#returns": [
+              {
+                "@id": "file://amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml#/declares/testEndpoint/supportedOperation/get/returns/resp/200",
+                "@type": [
+                  "http://a.ml/vocabularies/apiContract#Response",
+                  "http://a.ml/vocabularies/core#Response",
+                  "http://a.ml/vocabularies/apiContract#Message",
+                  "http://a.ml/vocabularies/document#DomainElement"
+                ],
+                "http://a.ml/vocabularies/apiContract#statusCode": [
+                  {
+                    "@value": "200"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#name": [
+                  {
+                    "@value": "200"
+                  }
+                ],
+                "http://a.ml/vocabularies/core#description": [
+                  {
+                    "@value": "A simple string response"
+                  }
+                ],
+                "http://a.ml/vocabularies/apiContract#payload": [
+                  {
+                    "@id": "file://amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml#/declares/testEndpoint/supportedOperation/get/returns/resp/200/payload/text%2Fplain",
+                    "@type": [
+                      "http://a.ml/vocabularies/apiContract#Payload",
+                      "http://a.ml/vocabularies/core#Payload",
+                      "http://a.ml/vocabularies/document#DomainElement"
+                    ],
+                    "http://a.ml/vocabularies/core#mediaType": [
+                      {
+                        "@value": "text/plain"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/shapes#schema": [
+                      {
+                        "@id": "file://amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml#/declares/testEndpoint/supportedOperation/get/returns/resp/200/payload/text%2Fplain/scalar/schema",
+                        "@type": [
+                          "http://a.ml/vocabularies/shapes#ScalarShape",
+                          "http://a.ml/vocabularies/shapes#AnyShape",
+                          "http://www.w3.org/ns/shacl#Shape",
+                          "http://a.ml/vocabularies/shapes#Shape",
+                          "http://a.ml/vocabularies/document#DomainElement"
+                        ],
+                        "http://www.w3.org/ns/shacl#datatype": [
+                          {
+                            "@id": "http://www.w3.org/2001/XMLSchema#string"
+                          }
+                        ],
+                        "http://www.w3.org/ns/shacl#name": [
+                          {
+                            "@value": "schema"
+                          }
+                        ],
+                        "http://a.ml/vocabularies/shapes#schemaVersion": [
+                          {
+                            "@value": "https://spec.openapis.org/oas/3.1/dialect/base"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               }

--- a/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml
+++ b/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml
@@ -30,6 +30,8 @@ paths:
         description: this request description should override the referenced one
         $ref: '#/components/requestBodies/createUserRequest'
 
+  /test:
+    $ref: '#/components/pathItems/testEndpoint'
 security:
   - openIdConnect:
       - some
@@ -133,3 +135,14 @@ components:
     mutualTLS:
       type: mutualTLS
       description: mutualTLS security scheme
+
+  pathItems:
+    testEndpoint:
+      get:
+        responses:
+          '200':
+            description: A simple string response
+            content:
+              text/plain:
+                schema:
+                  type: string

--- a/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml
+++ b/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml
@@ -8,7 +8,7 @@ info:
     identifier: Apache-2.0
 jsonSchemaDialect: https://spec.openapis.org/oas/3.1/dialect/base
 webhooks:
-  /newPet: ## THIS SHOULD ALLOW NOT TO START WITH '/' BUT IT IS THROWING `PathItem path must start with a '/'` IF NOT
+  /newPet:
     post:
       requestBody:
         description: Information about a new pet in the system
@@ -18,6 +18,9 @@ webhooks:
       responses:
         "200":
           description: Return a 200 status to indicate that the data was received successfully
+  testWebhook: # doesn't need to start with '/'
+    $ref: '#/components/pathItems/testEndpoint'
+
 paths:
   /users:
     post:
@@ -32,6 +35,7 @@ paths:
 
   /test:
     $ref: '#/components/pathItems/testEndpoint'
+
 security:
   - openIdConnect:
       - some
@@ -69,7 +73,7 @@ components:
         email:
           type: string
     OtherSchema:
-      $schema: https://spec.openapis.org/oas/3.1/dialect/base
+      # $schema: https://spec.openapis.org/oas/3.1/dialect/base # TODO: still not implemented
       type: object
       properties:
         some:
@@ -137,7 +141,7 @@ components:
       description: mutualTLS security scheme
 
   pathItems:
-    testEndpoint:
+    testEndpoint: # doesn't need to start with '/'
       get:
         responses:
           '200':

--- a/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml
+++ b/amf-cli/shared/src/test/resources/upanddown/oas31/oas-31-full.yaml
@@ -73,7 +73,7 @@ components:
         email:
           type: string
     OtherSchema:
-      # $schema: https://spec.openapis.org/oas/3.1/dialect/base # TODO: still not implemented
+      $schema: https://spec.openapis.org/oas/3.1/dialect/base
       type: object
       properties:
         some:

--- a/amf-cli/shared/src/test/resources/validations/oas31/all-endpoint-locations.yaml
+++ b/amf-cli/shared/src/test/resources/validations/oas31/all-endpoint-locations.yaml
@@ -1,0 +1,27 @@
+openapi: 3.1.0
+info:
+  title: OAS 3.1 with all possible endpoint locations
+  version: 1.0.0
+
+webhooks:
+  testWebhook: # doesn't need to start with '/'
+    $ref: '#/components/pathItems/testEndpoint'
+
+paths:
+  /test:
+    $ref: '#/components/pathItems/testEndpoint'
+
+  invalidEndpoint: # MUST start with '/'
+    $ref: '#/components/pathItems/testEndpoint'
+
+components:
+  pathItems:
+    testEndpoint: # doesn't need to start with '/'
+      get:
+        responses:
+          '200':
+            description: A simple string response
+            content:
+              text/plain:
+                schema:
+                  type: string

--- a/amf-cli/shared/src/test/resources/validations/reports/model/invalid-oas-path.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/model/invalid-oas-path.report
@@ -1,7 +1,7 @@
 ModelId: file://amf-cli/shared/src/test/resources/validations/invalid-oas-path/invalid-oas-path.json
 Profile: 
 Conforms: false
-Number of results: 1
+Number of results: 2
 
 Level: Violation
 
@@ -11,4 +11,12 @@ Level: Violation
   Target: file://amf-cli/shared/src/test/resources/validations/invalid-oas-path/invalid-oas-path.json#/web-api
   Property: 
   Range: [(8,4)-(16,5)]
+  Location: file://amf-cli/shared/src/test/resources/validations/invalid-oas-path/invalid-oas-path.json
+
+- Constraint: http://a.ml/vocabularies/amf/parser#invalid-endpoint-path
+  Message: some/path path must start with a '/'
+  Severity: Violation
+  Target: some/path
+  Property: 
+  Range: [(8,17)-(16,5)]
   Location: file://amf-cli/shared/src/test/resources/validations/invalid-oas-path/invalid-oas-path.json

--- a/amf-cli/shared/src/test/resources/validations/reports/oas3/invalid-ref-inside-paths-object.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/oas3/invalid-ref-inside-paths-object.report
@@ -9,6 +9,6 @@ Level: Violation
   Message: Property '$ref' not supported in a OAS 3.0 paths node
   Severity: Violation
   Target: file://amf-cli/shared/src/test/resources/validations/oas3/invalid-ref-inside-paths-object.json#/web-api
-  Property: 
+  Property:
   Range: [(8,4)-(8,42)]
   Location: file://amf-cli/shared/src/test/resources/validations/oas3/invalid-ref-inside-paths-object.json

--- a/amf-cli/shared/src/test/resources/validations/reports/oas3/invalid-ref-inside-paths-object.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/oas3/invalid-ref-inside-paths-object.report
@@ -9,6 +9,6 @@ Level: Violation
   Message: Property '$ref' not supported in a OAS 3.0 paths node
   Severity: Violation
   Target: file://amf-cli/shared/src/test/resources/validations/oas3/invalid-ref-inside-paths-object.json#/web-api
-  Property:
+  Property: 
   Range: [(8,4)-(8,42)]
   Location: file://amf-cli/shared/src/test/resources/validations/oas3/invalid-ref-inside-paths-object.json

--- a/amf-cli/shared/src/test/resources/validations/reports/oas31/all-endpoint-locations.report
+++ b/amf-cli/shared/src/test/resources/validations/reports/oas31/all-endpoint-locations.report
@@ -1,0 +1,22 @@
+ModelId: file://amf-cli/shared/src/test/resources/validations/oas31/all-endpoint-locations.yaml
+Profile: 
+Conforms: false
+Number of results: 2
+
+Level: Violation
+
+- Constraint: http://a.ml/vocabularies/amf/parser#closed-shape
+  Message: Property 'invalidEndpoint' not supported in a OAS 3.1 paths node
+  Severity: Violation
+  Target: file://amf-cli/shared/src/test/resources/validations/oas31/all-endpoint-locations.yaml#/web-api
+  Property: 
+  Range: [(14,2)-(17,0)]
+  Location: file://amf-cli/shared/src/test/resources/validations/oas31/all-endpoint-locations.yaml
+
+- Constraint: http://a.ml/vocabularies/amf/parser#invalid-endpoint-path
+  Message: invalidEndpoint path must start with a '/'
+  Severity: Violation
+  Target: invalidEndpoint
+  Property: 
+  Range: [(14,18)-(17,0)]
+  Location: file://amf-cli/shared/src/test/resources/validations/oas31/all-endpoint-locations.yaml

--- a/amf-cli/shared/src/test/scala/amf/emit/Oas31CycleTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/emit/Oas31CycleTest.scala
@@ -75,4 +75,8 @@ class Oas31CycleTest extends FunSuiteCycleTests {
   test(s"OAS 3.1 full to jsonLD") {
     cycle("oas-31-full.yaml", "oas-31-full.jsonld", Oas31YamlHint, AmfJsonHint)
   }
+
+  test(s"OAS 3.1 full cycle") {
+    cycle("oas-31-full.yaml", "oas-31-full.dumped.yaml", Oas31YamlHint, Oas31YamlHint)
+  }
 }

--- a/amf-cli/shared/src/test/scala/amf/emit/Oas31CycleTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/emit/Oas31CycleTest.scala
@@ -3,7 +3,6 @@ package amf.emit
 import amf.core.internal.remote._
 import amf.io.FunSuiteCycleTests
 
-// TODO: should support and render new 'examples', 'pathItems' facets in oas 3.1
 class Oas31CycleTest extends FunSuiteCycleTests {
   override val basePath: String = "amf-cli/shared/src/test/resources/upanddown/oas31/"
 
@@ -74,9 +73,5 @@ class Oas31CycleTest extends FunSuiteCycleTests {
 
   test(s"OAS 3.1 full to jsonLD") {
     cycle("oas-31-full.yaml", "oas-31-full.jsonld", Oas31YamlHint, AmfJsonHint)
-  }
-
-  test(s"OAS 3.1 full cycle") {
-    cycle("oas-31-full.yaml", "oas-31-full.dumped.yaml", Oas31YamlHint, Oas31YamlHint)
   }
 }

--- a/amf-cli/shared/src/test/scala/amf/validation/Oas31UniquePlatformUnitValidationsTest.scala
+++ b/amf-cli/shared/src/test/scala/amf/validation/Oas31UniquePlatformUnitValidationsTest.scala
@@ -6,6 +6,10 @@ class Oas31UniquePlatformUnitValidationsTest extends UniquePlatformReportGenTest
   override val basePath: String    = "file://amf-cli/shared/src/test/resources/validations/oas31/"
   override val reportsPath: String = "amf-cli/shared/src/test/resources/validations/reports/oas31/"
 
+  test("oas 31 endpoints should have '/' but webhooks and pathItems don't need to") {
+    validate("all-endpoint-locations.yaml", Some("all-endpoint-locations.report"))
+  }
+
   test("oas 31 items field must be an object") {
     validate("items-property-array.yaml", Some("items-property-array.report"))
   }


### PR DESCRIPTION
- **W-10548503: add pathitems to oas31 syntax and tests**
- **W-10548503: parse and emit 'pathItems' in OAS 3.1 Components node**
- **W-10548503: parse and emit $ref in OAS 3.1 'paths' node**
- **W-10548503: fix endpoint '/' validation, target only paths node in OAS**
